### PR TITLE
chore: update package-lock.json peer dependency flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -649,6 +650,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1872,6 +1874,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -2347,6 +2350,7 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2357,6 +2361,7 @@
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2874,6 +2879,7 @@
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",


### PR DESCRIPTION
## Changes

This PR updates the `package-lock.json` file with improved peer dependency metadata.

### What Changed

When running `npm install`, npm updated the lockfile to properly mark 6 packages as peer dependencies:
- `@opentelemetry/api` (peer of OpenTelemetry packages)
- `ajv` (peer of `ajv-formats`)
- `mobx` (peer of `mobx-react`)
- `react` (peer of `mobx-react`, `react-tabs`, `redoc`)
- `react-dom` (peer of various React components)
- `styled-components` (peer of `redoc`)

### Why

The `"peer": true` flag in lockfile v3 provides better metadata about which packages are peer dependencies versus direct dependencies. This is a standard npm behavior when updating lockfiles.

### Impact

- ✅ No new dependencies added
- ✅ No version changes
- ✅ Only metadata improvements in lockfile
- ✅ Fully backward compatible

This is a routine lockfile maintenance update.