### PR TITLE
ci: add 'large-pr-approved' label bypass for PR size check

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -18,7 +18,19 @@ jobs:
           fetch-depth: 0
 
       - name: Check PR size
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Check if PR has 'large-pr-approved' label
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+
+          if echo "$LABELS" | grep -q "large-pr-approved"; then
+            echo "✅ PR has 'large-pr-approved' label - skipping size check"
+            echo "Reason: Legitimate large PR (e.g., boilerplate templates, auto-generated code)"
+            exit 0
+          fi
+
           # Fetch base branch
           git fetch origin ${{ github.base_ref }}
 
@@ -39,6 +51,7 @@ jobs:
           if [ "$CHANGED" -gt 600 ]; then
             echo "::error::PR too large ($CHANGED > 600 lines). Please split into smaller changes."
             echo "Tip: Auto-generated files (package-lock.json, composer.lock, etc.) and license texts are excluded from this count."
+            echo "For legitimate large PRs (e.g., boilerplate templates), request the 'large-pr-approved' label from a maintainer."
             exit 1
           fi
 


### PR DESCRIPTION
## Changes

Add escape hatch for legitimate large PRs that cannot be meaningfully split.

### What Changed

**PR Size Workflow Enhancement:**
- Check for `large-pr-approved` label before enforcing size limit
- If label present: skip size check with clear reasoning in logs
- If label absent: enforce 600 line limit as before

### Why This Change?

**Current Problem:**
PR #6 (GitHub templates) has 710 lines of boilerplate content that:
- Cannot be meaningfully split (templates are atomic units)
- Are copied from approved `.github` org templates
- Would create more complexity if artificially split

**Solution:**
Add a controlled bypass mechanism via label that:
- ✅ Maintains quality standards as default
- ✅ Allows exceptions for legitimate cases
- ✅ Requires maintainer approval (write access needed for labels)
- ✅ Logs reason for bypass clearly

### Use Cases for `large-pr-approved` Label

**Legitimate scenarios:**
1. **Boilerplate templates** - GitHub issue/PR templates (like PR #6)
2. **Auto-generated code** - Must be committed as one unit
3. **Large refactorings** - Cannot be safely split
4. **Initial setup** - Multiple config files in new repository

**NOT for:**
- Regular feature development (split into smaller PRs)
- Multiple unrelated changes (violates "One PR = One Topic")
- Avoiding code review (size limit exists for good reason)

### Quality Safeguards

- ✅ Only users with **write access** can add labels
- ✅ Clear log message explains why check was skipped
- ✅ All other quality checks still run (REUSE, Prettier, Lint, CLA)
- ✅ Default behavior unchanged (600 line limit enforced)

### Technical Details

**Before:**
```yaml
- name: Check PR size
  run: |
    # Calculate changed lines
    # Fail if > 600
```

**After:**
```yaml
- name: Check PR size
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    # 1. Check for 'large-pr-approved' label
    if has_label; then skip_check; fi
    
    # 2. Calculate changed lines
    # 3. Fail if > 600
```

### Testing

**Small PR (this one):**
- 13 lines changed ✅
- No label needed
- Size check passes normally

**Large PR (#6):**
- 710 lines (templates)
- Will add `large-pr-approved` label after this merges
- Size check will pass with clear log

### Impact

- ✅ No breaking changes
- ✅ Backward compatible (existing PRs unaffected)
- ✅ Self-documenting (error message mentions label option)

### Next Steps

After merge:
1. This workflow becomes active for all PRs
2. Add `large-pr-approved` label to PR #6
3. PR #6 size check will pass
4. PR #6 can merge (all other checks already green)

## Type of Change

- [x] 🔧 Configuration/Infrastructure change

## Related Issues

Refs #6 - GitHub templates PR blocked by size check

## Checklist

- [x] Preflight checks pass locally (13 lines, well under limit)
- [x] REUSE compliance maintained
- [x] Prettier formatted
- [x] No breaking changes
- [x] Backward compatible
- [x] Self-documenting (clear error messages)
- [x] Quality safeguards in place (maintainer-only label access)

## References

- PR #6: https://github.com/SecPal/contracts/pull/6
- Quality First principle: Maintain standards, allow controlled exceptions