### PR TITLE
refactor: use reusable PR size workflow from .github repo

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2025 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
-name: PR Size Check
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
## Summary

Refactors the PR size check workflow to use the new reusable workflow from `.github` repository instead of inline implementation.

## Changes

- ✅ Replaced 60 lines of inline bash script with 4 lines of workflow call
- ✅ Maintains exact same behavior:
  - 600 line limit
  - `large-pr-approved` label bypass
  - Exclusion of lock files and license texts
- ✅ Follows DRY principle - single source of truth in `.github` repo
- ✅ Future changes to PR size logic happen centrally

## Dependencies

~~⚠️ DRAFT - DO NOT MERGE YET~~

✅ **READY FOR REVIEW**

~~This PR depends on **SecPal/.github#50** being merged first~~
- ✅ SecPal/.github#50 merged (commit a812969)
- ✅ Reusable workflow available at `SecPal/.github/.github/workflows/reusable-pr-size.yml@main`

## Before/After

**Before (60 lines):**
```yaml
jobs:
  pr-size:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout...
      - name: Check PR size
        run: |
          # 50+ lines of bash script...
```

**After (4 lines):**
```yaml
jobs:
  pr-size:
    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
    with:
      max-lines: 600
```

## Testing

- [x] ~~Wait for PR #50 in `.github` to be merged~~ ✅ Merged
- [x] Mark this PR as ready for review
- [ ] Verify CI passes with reusable workflow
- [ ] Test `large-pr-approved` label bypass still works

## Related

- SecPal/.github#50 - Reusable workflow implementation ✅ MERGED
- SecPal/.github#51 - Security fix for label sync script