### PR TITLE
docs: replace symlinks with file copies for GitHub.com compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,49 @@
-../.github/.editorconfig
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# PHP files
+[*.php]
+indent_style = space
+indent_size = 4
+
+# JavaScript/TypeScript
+[*.{js,ts,jsx,tsx}]
+indent_style = space
+indent_size = 2
+
+# Makefiles
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,40 @@
-../.github/.gitattributes
+# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted to native line endings on checkout
+*.php text
+*.js text
+*.ts text
+*.json text
+*.yml text
+*.yaml text
+*.md text
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+
+# Exclude files from export
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore
+.editorconfig export-ignore
+.prettierrc.json export-ignore
+.prettierignore export-ignore
+.markdownlint.json export-ignore
+.yamllint.yml export-ignore
+tests/ export-ignore
+docs/ export-ignore
+CHANGELOG.md export-ignore

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,39 @@
-../.github/CODEOWNERS
+# SPDX-FileCopyrightText: 2025 SecPal
+
+# SPDX-License-Identifier: CC0-1.0
+
+# Code Owners - Single Maintainer Setup
+
+#
+
+# This file defines code ownership for automatic review requests.
+
+# As this is currently a single-maintainer project, all areas are owned
+
+# by the project maintainer. This can be expanded as the team grows.
+
+#
+
+# For more information: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owner - will be requested for review on all PRs
+
+- @SecPal/maintainers
+
+# Documentation
+
+\*.md @SecPal/maintainers
+/docs/ @SecPal/maintainers
+
+# GitHub configurations
+
+/.github/ @SecPal/maintainers
+
+# Security-sensitive files
+
+SECURITY.md @SecPal/maintainers
+/LICENSES/ @SecPal/maintainers
+
+# CI/CD Workflows
+
+/.github/workflows/ @SecPal/maintainers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,126 @@
-../.github/CODE_OF_CONDUCT.md
+<!--
+SPDX-FileCopyrightText: 2025 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that are welcoming, inclusive, and that
+contribute to a healthy and safe community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and
+will take appropriate and fair corrective action in response to any behavior that
+they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<info@secpal.app>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interaction in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,446 @@
-../.github/CONTRIBUTING.md
+<!--
+SPDX-FileCopyrightText: 2025 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Contributing to SecPal
+
+We welcome contributions to SecPal! Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+
+## Development Setup
+
+### Prerequisites
+
+Ensure you have the following tools installed:
+
+- **Git** with GPG signing configured
+- **Node.js** (v22.x) and npm/pnpm/yarn
+- **PHP** 8.4 and Composer (for backend projects)
+- **Pre-commit** hooks tool (optional but recommended)
+
+### Local Setup
+
+**Recommended Workspace Structure:**
+
+Create a dedicated directory for all SecPal repositories. This mirrors the GitHub organization structure:
+
+```bash
+<your-workspace>/SecPal/
+├── .github/          # Organization-wide settings and documentation
+├── api/              # Laravel backend (planned)
+├── frontend/         # React/TypeScript frontend
+└── contracts/        # OpenAPI 3.1 specifications
+```
+
+**Examples:**
+
+- Linux/macOS: `~/projects/SecPal/` or `~/code/SecPal/`
+- Windows: `C:\Dev\SecPal\` or `%USERPROFILE%\projects\SecPal\`
+
+**Choose your workspace location and follow these steps:**
+
+1. **Clone the repository:**
+
+   ```bash
+   # Create workspace directory (choose your preferred location)
+   mkdir -p ~/projects/SecPal  # or C:\Dev\SecPal on Windows
+   cd ~/projects/SecPal
+
+   # Clone repository
+   git clone https://github.com/SecPal/<repository>.git
+   cd <repository>
+   ```
+
+2. **Set up Git hooks (automatic):**
+
+   Git hooks are automatically configured via `.githooks/` directory:
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+3. **Install pre-commit (optional, for additional checks):**
+
+   ```bash
+   # Install pre-commit
+   pip install pre-commit
+   # or: brew install pre-commit
+
+   # Install hooks
+   pre-commit install
+   ```
+
+### Local Development Workflow
+
+Before pushing your changes, run the preflight script to ensure everything passes:
+
+```bash
+./scripts/preflight.sh
+```
+
+This script runs automatically before every `git push` via the pre-push hook.
+
+**What the preflight script checks:**
+
+- Code formatting (Prettier)
+- Markdown linting
+- Workflow linting (actionlint)
+- REUSE compliance
+- PHP linting and tests (if applicable)
+- Node.js linting and tests (if applicable)
+- OpenAPI validation (if applicable)
+- PR size (< 600 lines recommended)
+
+## How to Contribute
+
+1. **Fork the repository** and create a new branch from `main`.
+2. **Create a feature branch** using our naming convention (see below).
+3. **Write your code** and add tests where applicable.
+4. **Ensure all tests pass** locally by running `./scripts/preflight.sh`.
+5. **Sign your commits** with GPG (see below).
+6. **Push your branch** and open a pull request against `main`.
+
+All pull requests will be reviewed by a maintainer and by GitHub Copilot.
+
+## Pull Request Rules
+
+### One PR = One Topic (NO MIXING)
+
+**CRITICAL: Every PR must address exactly ONE logical topic.**
+
+✅ **Allowed:**
+
+- One feature (implementation + tests + docs for that feature)
+- One bug fix (fix + regression test for that bug)
+- One refactor (refactor + updated tests for that code)
+- One documentation update (docs for one topic)
+
+❌ **Strictly Prohibited:**
+
+- Feature + Refactor
+- Fix + Documentation (unrelated)
+- Lint + Logic changes
+- Multiple unrelated features
+- Any "while I'm here" additions
+
+**Example violations:**
+
+- ❌ "Add user auth + refactor database + fix README typos" → Split into 3 PRs
+- ❌ "Fix payment bug + add logging to user service" → Split into 2 PRs
+
+**Why this rule exists:**
+
+- Better review quality (focused review)
+- Safer reverts (one topic = one revert)
+- Clearer git history
+- Faster merging
+
+**If tempted to add "just one more thing":** Stop, create a separate branch and PR.
+
+### PR Size Limit
+
+Keep PRs **≤ 600 changed lines** for maintainability. If larger, split into sequential PRs:
+
+1. Infrastructure/types/interfaces
+2. Core implementation
+3. Tests and documentation
+
+**Exceptions:**
+
+Large PRs (> 600 lines) are acceptable for:
+
+- **Dependency updates** (e.g., `package-lock.json`, `Cargo.lock`)
+- **Generated code** (e.g., OpenAPI clients, database migrations)
+- **Boilerplate/templates** that cannot be reasonably split
+
+In these cases, add the `large-pr-approved` label to bypass the size check. See [Organization Label Standards](https://github.com/SecPal/.github/blob/main/docs/labels.md) for details.
+
+## Branch Naming Convention
+
+Use the following prefixes for your branch names:
+
+- `feat/` - New features (e.g., `feat/add-user-profile`)
+- `fix/` - Bug fixes (e.g., `fix/login-redirect`)
+- `chore/` - Maintenance tasks (e.g., `chore/update-dependencies`)
+- `docs/` - Documentation changes (e.g., `docs/update-readme`)
+- `refactor/` - Code refactoring (e.g., `refactor/simplify-auth`)
+- `test/` - Test additions or fixes (e.g., `test/add-e2e-tests`)
+- `spike/` - Exploration/prototyping (see [Spike Branch Policy](#spike-branch-policy))
+
+### Spike Branch Policy
+
+**Spike branches** are for exploration, prototyping, and learning - **NOT for production code**.
+
+**Purpose:**
+
+- Evaluate new libraries or technologies
+- Prototype UI/UX concepts
+- Performance testing and benchmarking
+- Learning unfamiliar APIs
+
+**Rules:**
+
+1. ✅ **TDD is optional** - Tests are not required in spike branches
+2. ❌ **Cannot merge to `main`** - Spike branches are isolated
+3. ⏰ **Time-limited** - Recommended lifecycle: 7 days max
+4. 🔄 **Extract knowledge** - Create `feature/*` branch with tests for production
+5. 🧹 **Clean up** - Delete spike branch after knowledge extraction
+
+**Workflow:**
+
+```bash
+# 1. Create spike branch for exploration
+git checkout -b spike/auth-library-evaluation
+
+# 2. Experiment freely (no TDD required)
+# ... code, test, evaluate ...
+
+# 3. Document findings (in PR description or issue comment)
+
+# 4. If you opened a PR for the spike branch:
+#    - Add a summary of findings to the PR description or linked issue
+#    - Close the PR before deleting the branch
+
+# 5. Create feature branch WITH tests for production
+git checkout main
+git checkout -b feature/implement-auth-library
+# ... implement with TDD ...
+
+# 6. Delete spike branch (after closing any open PRs)
+git branch -D spike/auth-library-evaluation
+git push origin --delete spike/auth-library-evaluation
+```
+
+> **Note:** If you opened a PR for your spike branch, always close it and document your findings in the PR description or a related issue before deleting the branch. This keeps the repository clean and ensures knowledge is preserved.
+
+**Examples:**
+
+- `spike/nextauth-vs-passport-comparison`
+- `spike/tailwind-component-layout`
+- `spike/redis-caching-performance`
+- `spike/websocket-real-time-updates`
+
+**What spike branches are NOT:**
+
+- ❌ A way to avoid writing tests for production code
+- ❌ Long-lived feature development branches
+- ❌ Code that will be directly merged to main
+
+**CI Behavior:**
+
+- ✅ Formatting checks **STILL RUN** (Prettier, linting)
+- ✅ REUSE compliance **STILL REQUIRED**
+- ⏭️ **Test suites are SKIPPED** (no TDD enforcement)
+
+---
+
+## Commit Message Convention
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) for clear and structured commit messages:
+
+```text
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types:**
+
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `chore:` - Maintenance/tooling
+- `docs:` - Documentation changes
+- `style:` - Code style changes (formatting, no logic change)
+- `refactor:` - Code refactoring
+- `test:` - Adding or updating tests
+- `perf:` - Performance improvements
+- `ci:` - CI/CD changes
+
+**Example:**
+
+```bash
+git commit -S -m "feat(auth): add two-factor authentication
+
+Implements 2FA using TOTP tokens. Users can enable 2FA in their
+profile settings.
+
+Closes #123"
+```
+
+## Signing Commits
+
+All commits must be signed with GPG. To set up commit signing:
+
+```bash
+# Generate a GPG key (if you don't have one)
+gpg --gen-key
+
+# List your GPG keys
+gpg --list-secret-keys --keyid-format LONG
+
+# Configure Git to use your key
+git config --global user.signingkey <YOUR_KEY_ID>
+git config --global commit.gpgSign true
+
+# Add your GPG key to GitHub
+gpg --armor --export <YOUR_KEY_ID>
+# Copy the entire output (including the BEGIN and END PGP PUBLIC KEY BLOCK lines)
+# and paste it into GitHub under Settings → SSH and GPG keys → New GPG key.
+```
+
+## Pull Request Guidelines
+
+- **Keep PRs small:** Aim for < 600 lines of changes. Large PRs are harder to review.
+- **Write clear descriptions:** Use the PR template and fill out all relevant sections.
+- **Link related issues:** Reference issues with `Closes #123` or `Fixes #456`.
+- **Ensure CI passes:** All checks must pass before merging.
+- **Request reviews:** Tag relevant maintainers or wait for automatic review.
+- **Address feedback:** Respond to review comments promptly.
+
+## Code Style
+
+- **Formatting:** We use Prettier for all code formatting. Run `npx prettier --write .` before committing.
+- **Linting:** ESLint (JavaScript/TypeScript) and PHPStan (PHP) are enforced.
+- **Testing:** All new features should include tests.
+
+## REUSE Compliance
+
+All files must include SPDX license headers. **SecPal uses different licenses depending on file type:**
+
+### License Selection Guide
+
+| File Type            | License             | Use For                                         |
+| -------------------- | ------------------- | ----------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components   |
+| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
+| **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
+| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
+
+### SPDX Header Examples
+
+**For application code (AGPL-3.0-or-later):**
+
+```php
+<?php
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+```
+
+```javascript
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+```
+
+```typescript
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+```
+
+**For configuration files (CC0-1.0):**
+
+```yaml
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
+```
+
+<!-- REUSE-IgnoreStart -->
+
+```json
+{
+  "_comment": "SPDX-FileCopyrightText: 2025 SecPal Contributors",
+  "_license": "SPDX-License-Identifier: CC0-1.0"
+}
+```
+
+<!-- REUSE-IgnoreEnd -->
+
+**For helper scripts (MIT):**
+
+```bash
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-License-Identifier: MIT
+```
+
+**For documentation (CC0-1.0):**
+
+```markdown
+<!--
+SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+```
+
+### Verification
+
+Run `reuse lint` before committing to verify compliance:
+
+```bash
+# Check all files for REUSE compliance
+reuse lint
+
+# Add headers to new files automatically
+reuse annotate --license AGPL-3.0-or-later --copyright "SecPal Contributors" path/to/file.php
+```
+
+### Bulk Licensing with REUSE.toml
+
+For files that cannot contain comments (images, binaries, etc.) or to license entire directories, use `REUSE.toml` instead of the deprecated `.reuse/dep5`:
+
+**Create `REUSE.toml` in root or subdirectories:**
+
+<!-- REUSE-IgnoreStart -->
+
+```toml
+version = 1
+
+# Example: License all images in assets directory
+[[annotations]]
+path = "assets/images/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2025 SecPal Contributors"
+SPDX-License-Identifier = "CC0-1.0"
+
+# Example: Override licensing for vendor/third-party code
+[[annotations]]
+path = ["vendor/**", "node_modules/**"]
+precedence = "override"
+SPDX-FileCopyrightText = "Various third-party contributors"
+SPDX-License-Identifier = "SEE-LICENSE-IN-PACKAGE"
+```
+
+<!-- REUSE-IgnoreEnd -->
+
+**Precedence options:**
+
+- `closest` (default): Use file's own headers if present, fallback to REUSE.toml
+- `aggregate`: Combine both file headers AND REUSE.toml information
+- `override`: REUSE.toml takes precedence, ignore file headers
+
+**Alternative for individual files:** Create adjacent `.license` files (e.g., `logo.png.license`) containing SPDX headers.
+
+**How to choose the correct copyright attribution:**
+
+- Use **"SecPal Contributors"** for all code files, including source code, test files, scripts, and any file where individual contributors make changes (e.g., `.js`, `.ts`, `.php`, `.py`, `.sh`, test files in any language).
+- Use **"SecPal"** for organizational documentation (e.g., `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`), workflow files (e.g., `.github/workflows/*.yml`), and configuration files in the root directory (e.g., `.eslintrc.yml`, `.prettierrc`, `package.json`, `composer.json`, etc.).
+- If a configuration file is specific to a code module or contains logic contributed by individuals, use **"SecPal Contributors"**.
+- For ambiguous cases, prefer **"SecPal Contributors"** if the file is likely to be edited by multiple people over time.
+- Use the **current year** in the copyright date (e.g., 2025 for files created in 2025).
+
+Run `reuse lint` to check compliance.
+
+## Getting Help
+
+If you have questions or need help:
+
+- Open a [Discussion](https://github.com/orgs/SecPal/discussions)
+- Join our community channels (if available)
+- Check existing issues and documentation
+
+## License
+
+By contributing to SecPal, you agree that your contributions will be licensed under the [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) license.
+
+Thank you for contributing to SecPal! 🎉

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,217 @@
-../.github/SECURITY.md
+<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Security Policy
+
+## Supported Versions
+
+We follow [Semantic Versioning](https://semver.org/) (SEMVER). Security updates are provided for the following versions:
+
+| Version | Supported | Notes                                                     |
+| ------- | --------- | --------------------------------------------------------- |
+| 0.x.x   | ✅        | Development phase - all versions receive security updates |
+| < 0.0.1 | ❌        | Not yet released                                          |
+
+**Note:** Once we reach 1.0.0 (stable release), we will support:
+
+- The latest major version (e.g., 2.x.x)
+- The previous major version for 6 months after new major release
+- Critical security patches may be backported to older versions on a case-by-case basis
+
+## Reporting a Vulnerability
+
+**🔒 DO NOT open public issues for security vulnerabilities!**
+
+We take security seriously. If you discover a security vulnerability, please report it responsibly:
+
+### 1. GitHub Security Advisories (Preferred)
+
+1. Go to the repository's **Security** tab
+2. Click **"Report a vulnerability"**
+3. Fill out the advisory form with:
+   - Vulnerability description
+   - Affected versions
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if known)
+
+**Benefits:**
+
+- Private communication channel
+- Coordinated disclosure timeline
+- CVE assignment (if applicable)
+- Credit in security advisory
+
+### 2. Email Contact
+
+If you cannot use GitHub Security Advisories, contact us at:
+
+**🔐 <security@secpal.app>** (PGP key available on request)
+
+**Please include:**
+
+- Brief description of the vulnerability
+- Steps to reproduce
+- Affected components/versions
+- Your contact information (for follow-up)
+
+## Response Timeline
+
+We are committed to responding quickly to security reports:
+
+| Severity | Initial Response | Fix Target | Disclosure |
+| -------- | ---------------- | ---------- | ---------- |
+| Critical | 24 hours         | 7 days     | After fix  |
+| High     | 48 hours         | 14 days    | After fix  |
+| Medium   | 72 hours         | 30 days    | After fix  |
+| Low      | 7 days           | 60 days    | After fix  |
+
+**Severity Definitions:**
+
+- **Critical:** Remote code execution, authentication bypass, SQL injection
+- **High:** Privilege escalation, unauthorized data access, XSS with sensitive data exposure
+- **Medium:** Information disclosure, CSRF, moderate data leaks
+- **Low:** Minor information leaks, low-impact bugs
+
+## Security Update Process
+
+When a vulnerability is confirmed:
+
+1. **Acknowledgment:** We confirm receipt and severity assessment
+2. **Investigation:** We reproduce and analyze the vulnerability
+3. **Fix Development:** We develop and test a patch
+4. **Coordinated Disclosure:**
+   - Security advisory created (private)
+   - Fix released as patch version (e.g., 0.3.1 → 0.3.2)
+   - Security advisory published (public)
+   - CVE assigned (if applicable)
+5. **Communication:**
+   - GitHub Security Advisory
+   - Release notes
+   - Dependabot alerts (for downstream users)
+
+## Security Best Practices for Contributors
+
+When contributing to SecPal, follow these security guidelines:
+
+### Code Review Checklist
+
+- [ ] No hardcoded secrets (API keys, passwords, tokens)
+- [ ] Input validation on all user inputs
+- [ ] SQL queries use parameterized statements (no string concatenation)
+- [ ] Authentication/Authorization checks in place
+- [ ] Sensitive data encrypted at rest and in transit
+- [ ] Error messages don't leak sensitive information
+- [ ] Dependencies scanned for known vulnerabilities
+- [ ] HTTPS/TLS enforced for all network communication
+
+### Pre-Commit Security Checks
+
+All PRs automatically run:
+
+- **Secret Scanning:** GitHub Secret Scanning with push protection
+- **Dependency Scanning:** Dependabot security updates
+- **SAST:** CodeQL (JavaScript/TypeScript only)
+- **PHP Security:** PHPStan (level: max), Laravel Pint
+- **Linting:** ESLint security rules
+
+### Secure Development Guidelines
+
+1. **Never commit secrets:**
+   - Use environment variables (`.env`)
+   - Utilize secret management services
+   - Enable push protection (automatically enabled)
+
+2. **Keep dependencies updated:**
+   - Dependabot creates PRs daily (04:00 CET)
+   - Security updates have priority
+   - Review and merge promptly
+
+3. **Follow OWASP Top 10:**
+   - [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+   - Regular security training encouraged
+
+4. **Validate all inputs:**
+   - Server-side validation (never trust client)
+   - Sanitize outputs to prevent XSS
+   - Use framework's built-in protection (Laravel, React)
+
+5. **Least Privilege Principle:**
+   - Minimal permissions for services
+   - Role-based access control (RBAC)
+   - Regular permission audits
+
+## Security Features
+
+SecPal repositories have the following security features enabled:
+
+| Feature                         | Status | Description                            |
+| ------------------------------- | ------ | -------------------------------------- |
+| **Secret Scanning**             | ✅     | Detects leaked credentials             |
+| **Push Protection**             | ✅     | Blocks commits with secrets            |
+| **Dependabot Security Updates** | ✅     | Automated security patches             |
+| **Dependabot Version Updates**  | ✅     | Daily dependency updates (04:00 CET)   |
+| **CodeQL Analysis**             | ✅     | SAST for JavaScript/TypeScript         |
+| **Branch Protection**           | ✅     | Enforced status checks, signed commits |
+| **Security Advisories**         | ✅     | Private vulnerability reporting        |
+| **Two-Factor Authentication**   | ✅     | Required for all maintainers           |
+
+## Known Security Limitations
+
+### CodeQL Language Support
+
+**⚠️ PHP is NOT supported by GitHub CodeQL.**
+
+We compensate with:
+
+- **PHPStan** (level: max) - Static analysis
+- **Laravel Pint** - Code style enforcement
+- **Manual security reviews** for PHP code
+- **Consider:** Psalm, Semgrep for additional PHP security scanning
+
+### API Rate Limiting
+
+- Currently: No rate limiting implemented
+- **Planned:** Rate limiting for public APIs (v0.5.0)
+- **Mitigation:** Monitor for unusual traffic patterns
+
+### CORS Configuration
+
+- Currently: Permissive CORS for development
+- **Planned:** Strict CORS policy for production (v0.3.0)
+
+## Security Roadmap
+
+Planned security enhancements:
+
+- [ ] **v0.3.0:** Production-ready CORS configuration
+- [ ] **v0.5.0:** API rate limiting
+- [ ] **v0.7.0:** Comprehensive audit logging
+- [ ] **v0.9.0:** Penetration testing
+- [ ] **v1.0.0:** Security certification (OWASP ASVS Level 2)
+
+## Hall of Fame
+
+We appreciate responsible disclosure! Security researchers who report valid vulnerabilities will be credited here (with permission):
+
+<!-- This section will be updated as vulnerabilities are reported and fixed -->
+
+_No vulnerabilities reported yet._
+
+---
+
+## Additional Resources
+
+- [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+- [CWE Top 25](https://cwe.mitre.org/top25/)
+- [GitHub Security Best Practices](https://docs.github.com/en/code-security)
+- [Laravel Security Documentation](https://laravel.com/docs/security)
+- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/)
+
+## Contact
+
+- **Security Issues:** Use GitHub Security Advisories or <security@secpal.app>
+- **General Questions:** Open a Discussion in the repository
+- **Non-Security Bugs:** Open an Issue using our bug report template
+
+**Last Updated:** 2025-10-25


### PR DESCRIPTION
## Summary

Replaces governance file symlinks with actual file copies for better GitHub.com compatibility.

## Changes

### Symlink-to-File Conversion
- ✅ Convert 6 governance files from symlinks to actual copies:
  - `.editorconfig`
  - `.gitattributes`
  - `CODEOWNERS`
  - `CODE_OF_CONDUCT.md`
  - `CONTRIBUTING.md`
  - `SECURITY.md`

### Documentation Updates
- ✅ Update workspace structure in CONTRIBUTING.md

## Rationale

**Problem:** Symlinks don't render properly on GitHub.com web interface - they only display as text paths instead of showing the actual file content.

**Solution:** Use file copies from `.github` repository. While this violates pure DRY principle, it's a pragmatic trade-off for better user experience on GitHub.com where most contributors view documentation.

## Technical Details

- **Type changes:** `120000` (symlink) → `100644` (regular file)
- **Line count:** 917 lines (large due to file content being added instead of symlink references)
- **Label:** `large-pr-approved` - This is a one-time infrastructure change converting symlinks to files

## Checklist

- [x] Symlinks converted to real files
- [x] Workspace structure updated
- [x] REUSE compliance maintained
- [x] OpenAPI validation passed
- [x] Linting passed
- [x] Large PR approved (boilerplate/templates that cannot be split)

## Related PRs

- SecPal/.github#56 - Parent PR documenting the strategy change
- SecPal/frontend#21 - Same changes for frontend repository ✅ MERGED

## Note on PR Size

This PR is larger than usual (917 lines) due to symlink-to-file conversion. The actual content changes are minimal - we're just replacing symlink references with actual file content. This is a one-time infrastructure change and has been labeled `large-pr-approved`.