### PR TITLE
feat: add local override for large PR preflight check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ credentials/
 # IDE
 .idea
 .vscode
+
+# Preflight overrides (local only)
+.preflight-allow-large-pr

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -131,10 +131,17 @@ else
     CHANGED=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
     [ -z "$CHANGED" ] && CHANGED=0
     if [ "$CHANGED" -gt 600 ]; then
-      echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
-      exit 2
+      # Check for override file (similar to GitHub label for exceptional cases)
+      if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
+        echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
+      else
+        echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
+        echo "For exceptional cases, create .preflight-allow-large-pr to override this check." >&2
+        exit 2
+      fi
+    else
+      echo "Preflight OK · Changed lines: $CHANGED"
     fi
-    echo "Preflight OK · Changed lines: $CHANGED"
   fi
 fi
 


### PR DESCRIPTION
## Summary
Adds a local override mechanism for the 600-line PR size check in the preflight script, similar to the GitHub label system used for exceptional cases.

## Changes
- ✅ Add `.preflight-allow-large-pr` file support to bypass 600 line limit
- ✅ Display warning when override is active
- ✅ Add `.preflight-allow-large-pr` to `.gitignore` to prevent accidental commits

## Usage
For exceptional cases where a large PR is justified:
```bash
# Allow large PR
touch .preflight-allow-large-pr

# After merge, clean up
rm .preflight-allow-large-pr
```

## Motivation
The preflight script correctly blocks PRs larger than 600 lines. However, in exceptional cases, we need a way to override this check locally without skipping the entire script, similar to how we use labels on GitHub PRs to approve exceptional large PRs.