### PR TITLE
feat: switch to GitHub App authentication

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,4 +28,6 @@ jobs:
   project-automation:
     name: Project automation
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
-    secrets: inherit
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## 🤖 GitHub App Migration

Migrates project board automation from **Fine-grained PAT** to **GitHub App authentication**.

### Why?

Fine-grained Personal Access Tokens have limitations in cross-repository API calls, causing `Bad credentials` errors despite correct configuration. GitHub App provides:

✅ **Reliability**: No cross-repo token issues  
✅ **Security**: Auto-rotating tokens, granular permissions  
✅ **Identity**: Actions appear as "SecPal[bot]"  
✅ **Maintainability**: Single app installation vs. per-repo PATs  

### Changes

- Updated `.github/workflows/project-automation.yml` to use `APP_ID` and `APP_PRIVATE_KEY` secrets
- References core workflow at `@main` (now includes token generation)
- Secrets already configured at organization level

### Testing

- ✅ Successfully verified in `api` repo (Issue #34)
- ✅ Issue added to project board with correct status
- ✅ Bot identity confirmed ("SecPal[bot]")

### Related

- Closes after successful merge
- Part of rollout to all repos (api ✅, frontend 🔄, contracts 🔄, .github ⏳)