### PR TITLE
chore: regenerate package-lock.json and fix prettier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     hooks:
       - id: prettier
         types_or: [markdown, yaml, json]
+        exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -650,6 +651,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1873,6 +1875,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -2348,6 +2351,7 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2358,6 +2362,7 @@
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2875,6 +2880,7 @@
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",


### PR DESCRIPTION
## Summary

Regenerates `package-lock.json` after merging dependabot PR #47 and fixes a pre-commit hook issue with prettier.

## Changes

### package-lock.json
- Add `peer: true` flags to peer dependencies
- Update lockfile metadata to npm v11+ format
- No functional changes, only lockfile format updates

### .pre-commit-config.yaml
- Add explicit `exclude` pattern for lock files to prettier hook
- Prevents "no files matching patterns found" error when only lock files are changed
- Lock files are already excluded via `.prettierignore`, but pre-commit needs explicit exclude

## Context

After merging dependabot updates, running `npm install` regenerates the lockfile with updated metadata (peer flags). The prettier pre-commit hook was failing with exit code 1 when no formatted files were found, which blocked commits containing only lock file changes.

## Testing

- [x] Pre-commit hooks pass locally
- [x] `npm install` completes without errors
- [x] `npm audit` shows 0 vulnerabilities
- [x] REUSE compliance maintained

## Related

- Follows up on #47 (dependabot: bump @redocly/cli)