### PR TITLE
fix: exclude lockfiles from prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     hooks:
       - id: prettier
         types_or: [markdown, yaml, json]
+        exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2


### PR DESCRIPTION
## Summary

Fixes pre-commit hook error when committing only lockfile changes.

## Problem

The prettier pre-commit hook fails with "No files matching patterns found" (exit code 1) when:
- Only `package-lock.json` or `composer.lock` are changed
- These files are already in `.prettierignore` (by design)
- But pre-commit doesn't know to skip them

## Solution

Add explicit `exclude` pattern to prettier hook:
```yaml
exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
```

## Context

- Lockfiles are intentionally excluded from prettier formatting via `.prettierignore`
- Pre-commit needs the exclusion repeated in the hook configuration
- This aligns with DRY principle by documenting the pattern centrally

## Testing

- [x] Pre-commit hooks pass with only lockfile changes
- [x] Pre-commit hooks pass with regular file changes
- [x] REUSE compliance maintained

## Related

- Coordinated fix across all 4 SecPal repositories
- See: SecPal/.github#154, SecPal/api#44, SecPal/frontend#49