### PR TITLE
chore: regenerate package-lock.json after dependabot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -650,6 +651,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1873,6 +1875,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -2348,6 +2351,7 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2358,6 +2362,7 @@
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2875,6 +2880,7 @@
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",


### PR DESCRIPTION
## Summary

Regenerates `package-lock.json` after merging dependabot PR #47.

## Changes

- Add `peer: true` flags to peer dependencies
- Update lockfile metadata to npm v11+ format
- No functional changes, only lockfile format updates

## Context

After merging dependabot updates, running `npm install` regenerates the lockfile with updated metadata (peer flags). This is a maintenance task to keep the lockfile current with npm v11+ format.

## Testing

- [x] `npm install` completes without errors
- [x] `npm audit` shows 0 vulnerabilities
- [x] Pre-commit hooks pass (prettier correctly skips lockfiles)
- [x] REUSE compliance maintained

## Related

- Follows up on #47 (dependabot: bump @redocly/cli)
- Requires #33 (prettier hook fix) to be merged first ✅