### PR TITLE
chore: add markdownlint config + fix line-length

### DIFF
--- a/.github/.markdownlint.json
+++ b/.github/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false
+  }
+}

--- a/.github/.markdownlint.json.license
+++ b/.github/.markdownlint.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -311,7 +311,10 @@ async function getUser(id: number): Promise<User> {
 
 ## Learned Lessons (Copilot-Proof Standard)
 
-**Note:** These lessons extend the organization-wide learned lessons. See [.github repository instructions](https://github.com/SecPal/.github/blob/main/.github/copilot-instructions.md#learned-lessons-copilot-proof-standard) for complete list.
+**Note:** These lessons extend the organization-wide learned lessons.
+See [.github repository instructions][org-lessons] for complete list.
+
+[org-lessons]: https://github.com/SecPal/.github/blob/main/.github/copilot-instructions.md#learned-lessons-copilot-proof-standard
 
 ### Contracts-Specific Lessons
 
@@ -364,7 +367,8 @@ components:
    - Standard headers (X-Request-ID, Rate-Limit-\*)
    - Server configurations (all environments)
 
-**VALIDATION:** Run `yq eval 'keys' docs/openapi.yaml` - MUST show: openapi, info, servers, security, components, paths. Missing ANY = incomplete.
+**VALIDATION:** Run `yq eval 'keys' docs/openapi.yaml` - MUST show: openapi, info, servers, security, components, paths.
+Missing ANY = incomplete.
 
 #### 2. Schema Reuse Over Inline (MANDATORY)
 
@@ -409,7 +413,8 @@ paths:
                   id: { type: integer }
 ```
 
-**VALIDATION:** Run `grep -n "type: object" docs/openapi.yaml` - MUST ONLY appear under `components/schemas/`. Zero matches in `paths/` section.
+**VALIDATION:** Run `grep -n "type: object" docs/openapi.yaml` - MUST ONLY appear under `components/schemas/`.
+Zero matches in `paths/` section.
 
 #### 3. Complete Error Coverage (MANDATORY)
 
@@ -442,7 +447,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 ```
 
-**VALIDATION:** For each path operation, count response codes. Minimum 3 (1 success + 2 errors). Protected endpoints: minimum 4 (include 401).
+**VALIDATION:** For each path operation, count response codes. Minimum 3 (1 success + 2 errors).
+Protected endpoints: minimum 4 (include 401).
 
 #### 4. Domain Policy in OpenAPI (CRITICAL)
 
@@ -472,7 +478,8 @@ servers:
     description: Development
 ```
 
-**VALIDATION:** Run `grep -o "secpal\.[a-z]*" docs/openapi.yaml | sort -u` - MUST return ONLY: secpal.app, secpal.dev. Any other match = BLOCKER.
+**VALIDATION:** Run `grep -o "secpal\.[a-z]*" docs/openapi.yaml | sort -u` - MUST return ONLY: secpal.app, secpal.dev.
+Any other match = BLOCKER.
 
 #### 5. Breaking Change Protocol (MANDATORY)
 


### PR DESCRIPTION
## 📋 Summary

Add `.markdownlint.json` configuration and fix line-length issues in copilot instructions.

## ✨ Changes

### Config
- **Line-length:** 120 characters (OpenAPI standard)
- **Exclude code_blocks & tables:** From line-length checks
- **SPDX License:** Added `.markdownlint.json.license` (CC0-1.0)

### Line-Length Fixes
- Break long VALIDATION lines (<120 chars)
- Convert long URL to reference-style link
- All markdown now passes linting

## 🎯 Why

- Reduces lint noise in copilot instructions
- Standard line-length for OpenAPI specs
- Part of multi-repo markdown standardization

## ✅ Checklist

- [x] Config file added
- [x] License file added
- [x] Line-length issues fixed
- [x] Markdown lint passes (0 errors)
- [x] Ready for merge