### PR TITLE
fix: add markdownlint exclude patterns and disable MD060 (#187)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,7 +3,8 @@
     "MD013": false,
     "MD024": false,
     "MD025": false,
+    "MD060": false // Disable table formatting to prevent conflicts with Prettier
   },
   "globs": ["**/*.md"],
-  "ignores": ["node_modules/**"],
+  "ignores": ["node_modules/**"]
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": false,
   "MD024": false,
-  "MD025": false
+  "MD025": false,
+  "MD060": false
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -54,7 +54,7 @@ if command -v npm >/dev/null 2>&1; then
   else
     npx --yes prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
   fi
-  npx --yes markdownlint-cli2 '**/*.md' || FORMAT_EXIT=1
+  npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' || FORMAT_EXIT=1
 fi
 # Workflow linting (part of documented gates)
 # NOTE: actionlint is disabled in local preflight due to known hanging issues


### PR DESCRIPTION
## Summary

Part of retroactive compliance fix for Issue SecPal/.github#187.

## Changes

- ✅ **scripts/preflight.sh**: Added exclude patterns to markdownlint-cli2 (`#node_modules #vendor #storage #build`)
- ✅ **.markdownlint.json**: Disabled MD060 rule to prevent prettier/markdownlint table alignment conflict
- ✅ **npm install**: Installed @redocly/cli dependencies from package.json

## Why

@redocly/cli was listed in package.json but not installed → OpenAPI validation failed. Fixed with `npm install`.

## Testing

```bash
bash scripts/preflight.sh  # ✅ PASS
npm run lint               # ✅ PASS (6 warnings OK)
```

Part of SecPal/.github#187