### PR TITLE
fix: model nullable customer and site contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OpenAPI 3.1 now models nullable `Customer.contact` and `Site.contact` references correctly
+
 - **Employee OpenAPI contract now matches backend request/response behavior** (#116)
   - corrected employee contract type enums to `full_time`, `part_time`, `minijob`, and `freelance`
   - documented the `data` response envelope used by employee create/show/update endpoints

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1369,9 +1369,9 @@ components:
         billing_address:
           $ref: '#/components/schemas/Address'
         contact:
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Contact'
-            - type: [object, 'null']
+            - type: 'null'
         is_active:
           type: boolean
           description: Whether customer is active
@@ -1455,9 +1455,9 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         contact:
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Contact'
-            - type: [object, 'null']
+            - type: 'null'
         access_instructions:
           type: [string, 'null']
           description: Instructions for accessing the site (conditionally visible)


### PR DESCRIPTION
Summary: model nullable Customer.contact and Site.contact references for OpenAPI 3.1. Validation: npm run validate. Related: closes #118. Follow-up warnings tracked in #120.