### PR TITLE
refactor(contracts): remove secrets endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the Secret management contract, including CRUD, sharing, and attachment endpoints and schemas.
+
 ### Security
 
 - Scoped the transitive `undici` override to `@redocly/cli` and pinned it to `6.24.0` so contract validation tooling no longer resolves the vulnerable HTTP client release reported by `npm audit`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 openapi: 3.1.0
@@ -82,7 +82,7 @@ components:
           type: string
           maxLength: 255
           description: Log name categorizing the activity type
-          example: 'secret'
+          example: 'employee'
         description:
           type: string
           description: Human-readable description of the activity
@@ -112,7 +112,7 @@ components:
           type: string
           nullable: true
           description: Polymorphic type of the entity the activity is about
-          example: 'App\Models\Secret'
+          example: 'App\Models\Employee'
         subject_id:
           type: string
           format: uuid
@@ -270,217 +270,6 @@ components:
           format: date-time
           description: Timestamp of the health check
           example: '2025-10-25T19:25:00Z'
-
-    Secret:
-      type: object
-      required:
-        - id
-        - title
-        - version
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Unique secret identifier
-          example: '550e8400-e29b-41d4-a716-446655440000'
-        title:
-          type: string
-          maxLength: 255
-          description: Secret title (decrypted)
-          example: 'AWS Production Credentials'
-        username:
-          type: string
-          maxLength: 255
-          description: Username or email (decrypted)
-          example: 'admin@company.com'
-        password:
-          type: string
-          maxLength: 1000
-          description: Password or API key (decrypted)
-          example: 'super-secret-password-123'
-        url:
-          type: string
-          format: uri
-          maxLength: 2048
-          description: URL of the service
-          example: 'https://console.aws.amazon.com'
-        notes:
-          type: string
-          maxLength: 10000
-          description: Additional notes or instructions
-          example: 'Use MFA when logging in. Token in Authenticator app.'
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 50
-          description: Tags for categorization
-          example: ['production', 'aws', 'critical']
-        expires_at:
-          type: string
-          format: date-time
-          description: Expiration date (ISO 8601)
-          example: '2025-12-31T23:59:59Z'
-        version:
-          type: integer
-          description: Version number (auto-incremented on updates)
-          example: 1
-        created_at:
-          type: string
-          format: date-time
-          description: Creation timestamp (ISO 8601)
-          example: '2025-11-16T10:00:00Z'
-        updated_at:
-          type: string
-          format: date-time
-          description: Last update timestamp (ISO 8601)
-          example: '2025-11-16T14:30:00Z'
-
-    SecretShare:
-      type: object
-      required:
-        - id
-        - secret_id
-        - permission
-        - granted_by
-        - granted_at
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Unique share identifier
-          example: '660e8400-e29b-41d4-a716-446655440000'
-        secret_id:
-          type: string
-          format: uuid
-          description: Secret being shared
-          example: '550e8400-e29b-41d4-a716-446655440000'
-        user_id:
-          type: string
-          format: uuid
-          description: User granted access (XOR with role_id)
-          example: '770e8400-e29b-41d4-a716-446655440000'
-        role_id:
-          type: integer
-          format: int64
-          description: Role granted access (XOR with user_id)
-          example: 5
-        permission:
-          type: string
-          enum: [read, write, admin]
-          description: |
-            Permission level:
-            - **read**: View secret and download attachments
-            - **write**: View + update secret and upload attachments
-            - **admin**: Write + delete secret (but not grant shares)
-          example: read
-        granted_by:
-          type: string
-          format: uuid
-          description: User who granted access (always secret owner)
-          example: '880e8400-e29b-41d4-a716-446655440000'
-        granted_at:
-          type: string
-          format: date-time
-          description: When access was granted (ISO 8601)
-          example: '2025-11-16T10:00:00Z'
-        expires_at:
-          type: string
-          format: date-time
-          description: Optional expiration timestamp (ISO 8601)
-          example: '2025-12-31T23:59:59Z'
-
-    SecretShareGrantRequestForUser:
-      type: object
-      additionalProperties: false
-      required:
-        - user_id
-        - permission
-      properties:
-        user_id:
-          type: string
-          format: uuid
-          description: User to grant access (XOR with role_id)
-          example: '770e8400-e29b-41d4-a716-446655440000'
-        permission:
-          type: string
-          enum: [read, write, admin]
-          description: Permission level
-          example: read
-        expires_at:
-          type: string
-          format: date-time
-          description: Optional expiration date
-          example: '2025-12-31T23:59:59Z'
-
-    SecretShareGrantRequestForRole:
-      type: object
-      additionalProperties: false
-      required:
-        - role_id
-        - permission
-      properties:
-        role_id:
-          type: integer
-          format: int64
-          description: Role to grant access (XOR with user_id)
-          example: 5
-        permission:
-          type: string
-          enum: [read, write, admin]
-          description: Permission level
-          example: write
-        expires_at:
-          type: string
-          format: date-time
-          description: Optional expiration date
-          example: '2025-12-31T23:59:59Z'
-
-    SecretShareGrantRequest:
-      oneOf:
-        - $ref: '#/components/schemas/SecretShareGrantRequestForUser'
-        - $ref: '#/components/schemas/SecretShareGrantRequestForRole'
-      description: Grant secret access to exactly one target, either a user or a role.
-
-    SecretAttachment:
-      type: object
-      required:
-        - id
-        - filename
-        - file_size
-        - mime_type
-        - download_url
-        - created_at
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Unique attachment identifier
-          example: '550e8400-e29b-41d4-a716-446655440000'
-        filename:
-          type: string
-          description: Original filename (decrypted)
-          example: 'confidential-report.pdf'
-        file_size:
-          type: integer
-          description: File size in bytes
-          example: 102400
-        mime_type:
-          type: string
-          description: MIME type of the file
-          example: 'application/pdf'
-        download_url:
-          type: string
-          format: uri
-          description: URL to download the file
-          example: 'https://api.secpal.app/v1/attachments/550e8400-e29b-41d4-a716-446655440000/download'
-        created_at:
-          type: string
-          format: date-time
-          description: Upload timestamp (ISO 8601)
-          example: '2025-11-16T14:30:00Z'
 
     # =============================================================================
     # Employee Management Schemas
@@ -1880,557 +1669,6 @@ paths:
                 message: Service temporarily unavailable
                 code: SERVICE_UNAVAILABLE
 
-  /secrets:
-    get:
-      summary: List Secrets
-      description: |
-        List all secrets accessible to the authenticated user (owned + shared).
-        Supports filtering and pagination.
-      operationId: listSecrets
-      tags:
-        - Secrets
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: page
-          in: query
-          required: false
-          description: Page number for pagination
-          schema:
-            type: integer
-            minimum: 1
-            default: 1
-        - name: per_page
-          in: query
-          required: false
-          description: Items per page
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            default: 15
-      responses:
-        '200':
-          description: Secrets retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Secret'
-                  meta:
-                    type: object
-                    properties:
-                      current_page:
-                        type: integer
-                        example: 1
-                      per_page:
-                        type: integer
-                        example: 15
-                      total:
-                        type: integer
-                        example: 42
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-    post:
-      summary: Create Secret
-      description: |
-        Create a new secret with encrypted storage. All sensitive fields are encrypted
-        at rest using the tenant's DEK (Data Encryption Key).
-      operationId: createSecret
-      tags:
-        - Secrets
-      security:
-        - BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - title
-              properties:
-                title:
-                  type: string
-                  maxLength: 255
-                  description: Secret title (required)
-                  example: 'Database Master Password'
-                username:
-                  type: string
-                  maxLength: 255
-                  description: Username or email
-                  example: 'db_admin'
-                password:
-                  type: string
-                  maxLength: 1000
-                  description: Password or API key
-                  example: 'my-secure-password-123'
-                url:
-                  type: string
-                  format: uri
-                  maxLength: 2048
-                  description: Service URL
-                  example: 'https://db.example.com:5432'
-                notes:
-                  type: string
-                  maxLength: 10000
-                  description: Additional notes
-                  example: 'Connect via SSL. Certificate in attachments.'
-                tags:
-                  type: array
-                  items:
-                    type: string
-                    maxLength: 50
-                  description: Tags for organization
-                  example: ['production', 'database', 'critical']
-                expires_at:
-                  type: string
-                  format: date-time
-                  description: Expiration date (must be future date)
-                  example: '2026-01-01T00:00:00Z'
-      responses:
-        '201':
-          description: Secret created successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                message: Validation failed
-                code: VALIDATION_ERROR
-                details:
-                  title: ['The title field is required.']
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /secrets/{secret}:
-    get:
-      summary: Get Secret Details
-      description: |
-        Retrieve full details of a specific secret. Requires ownership or read permission.
-      operationId: getSecret
-      tags:
-        - Secrets
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Secret retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Secret'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-    patch:
-      summary: Update Secret
-      description: |
-        Update a secret's fields. Requires ownership or write permission.
-        Version number is auto-incremented on successful update.
-      operationId: updateSecret
-      tags:
-        - Secrets
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                title:
-                  type: string
-                  maxLength: 255
-                  example: 'Updated Title'
-                username:
-                  type: string
-                  maxLength: 255
-                  example: 'new_username'
-                password:
-                  type: string
-                  maxLength: 1000
-                  example: 'new-password-456'
-                url:
-                  type: string
-                  format: uri
-                  maxLength: 2048
-                  example: 'https://new-url.com'
-                notes:
-                  type: string
-                  maxLength: 10000
-                  example: 'Updated notes'
-                tags:
-                  type: array
-                  items:
-                    type: string
-                    maxLength: 50
-                  example: ['updated', 'tag']
-                expires_at:
-                  type: string
-                  format: date-time
-                  example: '2026-06-01T00:00:00Z'
-      responses:
-        '200':
-          description: Secret updated successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-    delete:
-      summary: Delete Secret
-      description: |
-        Soft delete a secret. Requires ownership or admin permission.
-        Secret is marked as deleted but remains in database for audit.
-      operationId: deleteSecret
-      tags:
-        - Secrets
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '204':
-          description: Secret deleted successfully
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /secrets/{secret}/shares:
-    get:
-      summary: List Secret Shares
-      description: |
-        List all active shares for a secret. Only owner or users with admin permission can view.
-      operationId: listSecretShares
-      tags:
-        - Secret Sharing
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Shares retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/SecretShare'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-    post:
-      summary: Grant Secret Access
-      description: |
-        Grant read/write/admin access to a user or role. Only secret owner can grant access.
-
-        **XOR Constraint:** Must provide EITHER `user_id` OR `role_id`, not both.
-
-        **Permission Hierarchy:**
-        - `read`: View secret + download attachments
-        - `write`: Read + update secret + upload attachments
-        - `admin`: Write + delete secret (cannot grant shares - owner only)
-      operationId: grantSecretAccess
-      tags:
-        - Secret Sharing
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecretShareGrantRequest'
-            examples:
-              grantToUser:
-                summary: Grant read access to user
-                value:
-                  user_id: '770e8400-e29b-41d4-a716-446655440000'
-                  permission: read
-                  expires_at: '2025-12-31T23:59:59Z'
-              grantToRole:
-                summary: Grant write access to role
-                value:
-                  role_id: 5
-                  permission: write
-      responses:
-        '201':
-          description: Access granted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SecretShare'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                xorViolation:
-                  summary: XOR constraint violated
-                  value:
-                    message: Validation failed
-                    code: VALIDATION_ERROR
-                    details:
-                      user_id:
-                        [
-                          'The user id field is required when role id is not present.',
-                        ]
-                      role_id:
-                        [
-                          'The role id field is required when user id is not present.',
-                        ]
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /secrets/{secret}/shares/{share}:
-    delete:
-      summary: Revoke Secret Access
-      description: |
-        Revoke a user's or role's access to a secret. Only secret owner can revoke.
-      operationId: revokeSecretAccess
-      tags:
-        - Secret Sharing
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-        - name: share
-          in: path
-          required: true
-          description: Share UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '204':
-          description: Access revoked successfully
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /secrets/{secret}/attachments:
-    post:
-      summary: Upload Attachment
-      description: |
-        Upload a file attachment to a secret. File is encrypted at rest using tenant DEK.
-        Maximum file size and allowed MIME types are configurable.
-      operationId: uploadAttachment
-      tags:
-        - Secret Attachments
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              required:
-                - file
-              properties:
-                file:
-                  type: string
-                  format: binary
-                  description: File to upload (max 10MB by default)
-      responses:
-        '201':
-          description: Attachment uploaded successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SecretAttachment'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                message: Validation failed
-                code: VALIDATION_ERROR
-                details:
-                  file: ['The file field is required.']
-
-    get:
-      summary: List Attachments
-      description: |
-        List all attachments for a secret. Returns attachments in descending order by creation date.
-      operationId: listAttachments
-      tags:
-        - Secret Attachments
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: secret
-          in: path
-          required: true
-          description: Secret UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Attachments retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/SecretAttachment'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
   /activity-logs:
     get:
       summary: List Activity Logs
@@ -2482,8 +1720,8 @@ paths:
           schema:
             type: string
             maxLength: 255
-          description: Filter by log name (e.g., 'user', 'secret', 'employee')
-          example: 'secret'
+          description: Filter by log name (e.g., 'user', 'employee', 'system')
+          example: 'employee'
         - name: search
           in: query
           required: false
@@ -2520,8 +1758,8 @@ paths:
           required: false
           schema:
             type: string
-          description: Polymorphic type of the subject (e.g., 'App\Models\Secret')
-          example: 'App\Models\Secret'
+          description: Polymorphic type of the subject (e.g., 'App\Models\Employee')
+          example: 'App\Models\Employee'
         - name: subject_id
           in: query
           required: false
@@ -2605,16 +1843,16 @@ paths:
                     data:
                       - id: 550e8400-e29b-41d4-a716-446655440001
                         tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                        log_name: secret
-                        description: Created Secret "API Keys Production"
-                        subject_type: App\Models\Secret
+                        log_name: employee
+                        description: Created Employee "John Doe"
+                        subject_type: App\Models\Employee
                         subject_id: 550e8400-e29b-41d4-a716-446655440010
                         causer_type: App\Models\User
                         causer_id: 550e8400-e29b-41d4-a716-446655440020
                         event: created
                         properties:
                           attributes:
-                            name: API Keys Production
+                            name: John Doe
                             status: active
                         ip_address: 192.0.2.1
                         user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
@@ -2665,9 +1903,9 @@ paths:
                         updated_at: '2025-01-15T11:00:00Z'
                       - id: 550e8400-e29b-41d4-a716-446655440003
                         tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                        log_name: secret
-                        description: Accessed Secret "Database Credentials"
-                        subject_type: App\Models\Secret
+                        log_name: employee
+                        description: Viewed Employee "Jane Smith"
+                        subject_type: App\Models\Employee
                         subject_id: 550e8400-e29b-41d4-a716-446655440011
                         causer_type: App\Models\User
                         causer_id: 550e8400-e29b-41d4-a716-446655440022
@@ -2788,22 +2026,22 @@ paths:
                   data:
                     $ref: '#/components/schemas/Activity'
               examples:
-                secretCreation:
-                  summary: Secret creation with full relationships
+                employeeCreation:
+                  summary: Employee creation with full relationships
                   value:
                     data:
                       id: 550e8400-e29b-41d4-a716-446655440001
                       tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                      log_name: secret
-                      description: Created Secret "API Keys Production"
-                      subject_type: App\Models\Secret
+                      log_name: employee
+                      description: Created Employee "John Doe"
+                      subject_type: App\Models\Employee
                       subject_id: 550e8400-e29b-41d4-a716-446655440010
                       causer_type: App\Models\User
                       causer_id: 550e8400-e29b-41d4-a716-446655440020
                       event: created
                       properties:
                         attributes:
-                          name: API Keys Production
+                          name: John Doe
                           status: active
                           organizational_unit_id: 550e8400-e29b-41d4-a716-446655440030
                         ip: 192.0.2.1
@@ -2831,9 +2069,9 @@ paths:
                         id: 550e8400-e29b-41d4-a716-446655440020
                         name: John Doe
                       subject:
-                        type: Secret
+                        type: Employee
                         id: 550e8400-e29b-41d4-a716-446655440010
-                        name: API Keys Production
+                        name: John Doe
                 systemActivity:
                   summary: System-initiated activity (no causer)
                   value:
@@ -3111,84 +2349,6 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-
-  /attachments/{attachment}/download:
-    get:
-      summary: Download Attachment
-      description: |
-        Download and decrypt an attachment file. Returns the file with
-        appropriate Content-Type and Content-Disposition headers.
-      operationId: downloadAttachment
-      tags:
-        - Secret Attachments
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: attachment
-          in: path
-          required: true
-          description: Attachment UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: File downloaded successfully
-          content:
-            '*/*':
-              schema:
-                type: string
-                format: binary
-          headers:
-            Content-Type:
-              description: MIME type of the file
-              schema:
-                type: string
-                example: application/pdf
-            Content-Disposition:
-              description: Attachment filename
-              schema:
-                type: string
-                example: 'attachment; filename="report.pdf"'
-            Content-Length:
-              description: File size in bytes
-              schema:
-                type: integer
-                example: 102400
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
-  /attachments/{attachment}:
-    delete:
-      summary: Delete Attachment
-      description: |
-        Delete an attachment file and its metadata. File is permanently removed from storage.
-      operationId: deleteAttachment
-      tags:
-        - Secret Attachments
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: attachment
-          in: path
-          required: true
-          description: Attachment UUID
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '204':
-          description: Attachment deleted successfully
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
 
   # =============================================================================
   # Employee Management


### PR DESCRIPTION
Sub-issue of SecPal/.github#249

Summary
- remove Secrets paths and schemas from the OpenAPI contract
- replace Secret-centric examples with non-Secret domain examples where needed
- update changelog for the contract-breaking removal under the 0.x policy

Validation
- redocly lint docs/openapi.yaml --config .redocly.yaml

Notes
- editor diagnostics about nullable remain as pre-existing noise, but Redocly validation is green
- changelog updated in the same change set