### PR TITLE
fix(tooling): update Redocly CLI to 2.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `@redocly/cli` from `2.24.0` to `2.24.1` so `npm run validate` no longer emits the stale Redocly update notice tracked in #136
 - Added explicit top-level OpenAPI tag declarations for all currently used operation groups so documentation tooling can render consistent tag metadata and descriptions (#129)
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so contract work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
 - `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.24.0",
+        "@redocly/cli": "^2.24.1",
         "prettier": "^3.8.1"
       }
     },
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.24.0.tgz",
-      "integrity": "sha512-g5iKfmG1rgbpQ/mBnEH78bJbAUx2XxLSJTYdYGuvsrT8CODbOyza1xFF7kwOFo93JV62lmu3IfzNIxFj9FACYw==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.24.1.tgz",
+      "integrity": "sha512-GTAKMPtyvO7vn3CrSp8Q5SJlMUr8q6wgMN/J4K5owphyp5gOQCZqMySyWcq+V5RPPXkTuIHZYEzgnecB6RF2bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -374,8 +374,8 @@
         "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
-        "@redocly/openapi-core": "2.24.0",
-        "@redocly/respect-core": "2.24.0",
+        "@redocly/openapi-core": "2.24.1",
+        "@redocly/respect-core": "2.24.1",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -396,7 +396,7 @@
         "simple-websocket": "^9.0.0",
         "styled-components": "6.3.9",
         "ulid": "^3.0.1",
-        "undici": "^6.24.1",
+        "undici": "6.24.0",
         "yargs": "17.0.1"
       },
       "bin": {
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.24.0.tgz",
-      "integrity": "sha512-4j8+OKA+bFBOj9Uhr6LJuNnFQpKAE9uK5Smw4yd2WJS2bcsJhCqbUWOG9N1cYBUFlwRQpLBT1ZOSmDFYv81NOg==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.24.1.tgz",
+      "integrity": "sha512-Iqc/4DI/CIQkKys8HRHkX+bpF/UosVUE7lc7tuxIOKzVIOk5QhQMglbd2yzbAYgJF7YAtCDDAKWosvXnvTTWsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -442,16 +442,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.24.0.tgz",
-      "integrity": "sha512-3Gp+4X5V6DCATmB7OYpUrGKEYaR8quq2LD+PsniEAMTfG+oyuDHJRUy3zXYfGQGT7PDi0iXUZ8PEWUFzgVdyZQ==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.24.1.tgz",
+      "integrity": "sha512-WMeg9TmAc0ZINp6Tza+ZWhMuIBM28us6ZyLj5DKWZhkBZhKaTNhXlmTYES11uM35eie+mYZStTov4vXYL//wqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.24.0",
+        "@redocly/openapi-core": "2.24.1",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate": "redocly lint docs/openapi.yaml --config .redocly.yaml && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.24.0",
+    "@redocly/cli": "^2.24.1",
     "prettier": "^3.8.1"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- update `@redocly/cli` from `2.24.0` to `2.24.1`
- keep the existing scoped `undici` override in place
- record the tooling fix in `CHANGELOG.md`

## Validation
- `npm run validate`
- `npm audit --omit=dev`

Closes #136
