### PR TITLE
docs(openapi): document employee invitation request and status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- documented the employee invite flow in the OpenAPI contract by adding `send_invitation` to employee creation requests and the persisted `onboarding_invitation` delivery-status block to employee responses
+- Documented the employee invite flow in the OpenAPI contract by adding `send_invitation` to employee creation requests and the persisted `onboarding_invitation` delivery-status block to employee responses
 - Updated `@redocly/cli` from `2.24.0` to `2.24.1` so `npm run validate` no longer emits the stale Redocly update notice tracked in #136
 - Added explicit top-level OpenAPI tag declarations for all currently used operation groups so documentation tooling can render consistent tag metadata and descriptions (#129)
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so contract work never starts on local `main` and dirty non-`main` branches must be assessed before continuing

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -596,7 +596,8 @@ components:
           enum: [full_time, part_time, minijob, freelance]
         send_invitation:
           type: boolean
-          description: Sends the onboarding invitation immediately after employee creation. Allowed only for pre_contract employees.
+          default: false
+          description: If true, sends the onboarding invitation immediately after employee creation; if false or omitted, no invitation is sent. Allowed only for pre_contract employees.
         weekly_hours:
           type: [number, 'null']
           format: float


### PR DESCRIPTION
## Summary
- add `send_invitation` to employee creation requests
- add persisted `onboarding_invitation` delivery status to employee responses
- update the changelog for the contract change

## Validation
- npm run validate
