### PR TITLE
chore(tooling): refresh contracts validation deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Scoped the transitive `undici` override to `@redocly/cli` and pinned it to `6.24.0` so contract validation tooling no longer resolves the vulnerable HTTP client release reported by `npm audit`
+- Pinned transitive `brace-expansion` and `yaml` resolutions to patched semver-compatible releases so the contracts toolchain no longer reports the moderate `npm audit` findings surfaced during the Redocly CLI maintenance update
 
 ### Added
 
@@ -29,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Clarified the employee lifecycle contract by centralizing the official status set (`applicant`, `pre_contract`, `active`, `on_leave`, `terminated`), documenting that onboarding invitations are only allowed for `pre_contract`, and exposing invitation-eligibility metadata in employee response schemas
+
+- Updated `@redocly/cli` from `2.25.1` to `2.25.2` so `npm run validate` no longer emits the stale Redocly update notice tracked in #149
 
 - Documented the canonical auth/self-service contract surface in `docs/openapi.yaml` for Issue #146, including `POST /auth/login`, `POST /auth/token`, `POST /auth/logout`, the deprecated legacy alias `POST /auth/session/logout`, `POST /auth/logout-all`, and the official `/me` self-service namespace
 - Documented the employee invite flow in the OpenAPI contract by adding `send_invitation` to employee creation requests and the persisted `onboarding_invitation` delivery-status block to employee responses

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.25.1",
+        "@redocly/cli": "^2.25.2",
         "prettier": "^3.8.1"
       }
     },
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.25.1.tgz",
-      "integrity": "sha512-i17Riz3CO3KMhaxMW3OPUw8ipeipnuk4wQTRu4zi2pCA/zI6GkeO/Ku7pdEwPd1LuPIR/RNBTp0YPahmyGy+2A==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.25.2.tgz",
+      "integrity": "sha512-kn1SiHDss3t+Ami37T6ZH5ov1fiEXF1y488bUOUgrh0pEK8VOq8+HlPbdte/cH0K+dWPhuLyKNACd+KhMQPjCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -375,8 +375,8 @@
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.25.1",
-        "@redocly/respect-core": "2.25.1",
+        "@redocly/openapi-core": "2.25.2",
+        "@redocly/respect-core": "2.25.2",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -387,7 +387,7 @@
         "handlebars": "^4.7.6",
         "https-proxy-agent": "^7.0.5",
         "mobx": "^6.0.4",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
         "react-dom": "^17.0.0 || ^18.2.0 || ^19.2.1",
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.44.2",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.44.2.tgz",
-      "integrity": "sha512-/77Y/C4aDCa0XkRYffISHH1K816KDmmFY1LX3TwODJ4Li+DFhvyWiMm7ofFCEssKwNjs3fzGW/ISKOsDFdirJw==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.45.0.tgz",
+      "integrity": "sha512-V+wNusPQUaYV1c5s9iptfKQ2Ggno4bMeiyXdNILxqZS87gttwPfqlqHKHKFyz006voS3JsR295cbpx3GlsIxKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -440,20 +440,20 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.25.1.tgz",
-      "integrity": "sha512-6n1gkzvqLhU1/rCSDvLqSrceiXHMw5YTqrao63nb/SLxPzbhBEW61D9VAvu2dn5HGsanYc9QH0j73W/D3eYsVw==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.25.2.tgz",
+      "integrity": "sha512-HIvxgwxQct/IdRJjjqu4g8BLpCik6I3zxp8JFJpRtmY1TSIZAOZjJwlkoh4uQcy/nCP+psSMgQvzjVGml3k6+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.44.2",
+        "@redocly/config": "^0.45.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -463,16 +463,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.25.1.tgz",
-      "integrity": "sha512-iF/7uP/kI5BPzdp4e2Ug3UQWU1ghYJoAPURFcqPvtRc0S4G3olyecJggOhDQqyC8iDHvN7SJNmm/O3VWn4QU4Q==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.25.2.tgz",
+      "integrity": "sha512-GpvmjY2x8u4pAGNts7slexuKDzDWHNUB4gey9/rSqvC8IaqY49vkvMuRodIBwCsqXhn2rpkJbar1UK3rAOuy7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.25.1",
+        "@redocly/openapi-core": "2.25.2",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
@@ -480,7 +480,7 @@
         "jsonpath-rfc9535": "1.3.0",
         "openapi-sampler": "^1.7.1",
         "outdent": "^0.8.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
@@ -617,14 +617,6 @@
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/call-me-maybe": {
@@ -1176,9 +1168,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1741,6 +1733,16 @@
         "npm": ">=9.5.0"
       }
     },
+    "node_modules/redoc/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/redoc/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -2154,7 +2156,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "validate": "redocly lint docs/openapi.yaml --config .redocly.yaml && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.25.1",
+    "@redocly/cli": "^2.25.2",
     "prettier": "^3.8.1"
   },
   "overrides": {
     "@redocly/cli": {
       "undici": "6.24.0"
-    }
+    },
+    "brace-expansion@^2": "2.0.3",
+    "brace-expansion@^5": "5.0.5",
+    "yaml@^1": "1.10.3"
   }
 }

--- a/package.json.license
+++ b/package.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
## Summary
- update `@redocly/cli` from `2.25.1` to `2.25.2`
- remove the stale Redocly update notice from `npm run validate`
- add semver-safe transitive overrides for `brace-expansion` and `yaml` so the contracts toolchain is audit-clean

## Validation
- `npm audit --json`
- `npm run validate`
- `reuse lint`

Fixes #149