### PR TITLE
chore(deps): update redocly cli to 2.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `@redocly/cli` from `2.25.2` to `2.25.3` so `npm run validate` no longer emits the current upgrade banner tracked in #156
+
 - Aligned the contract repo's domain guidance and the OpenAPI base/server URLs with the active host split: `api.secpal.dev` for the API, `app.secpal.dev` for the PWA, `secpal.app` for the public homepage and real email addresses, and `app.secpal.app` only as the Android identifier
 - Extended the authenticated-user schema with explicit `hasCustomerAccess` and `hasSiteAccess` flags so clients can distinguish scoped collection access from pure role/permission metadata and keep customer/site route gating consistent with the API's fail-closed collection behavior
 - Clarified the employee lifecycle contract by centralizing the official status set (`applicant`, `pre_contract`, `active`, `on_leave`, `terminated`), documenting that onboarding invitations are only allowed for `pre_contract`, and exposing invitation-eligibility metadata in employee response schemas

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.25.2",
+        "@redocly/cli": "^2.25.3",
         "prettier": "^3.8.1"
       }
     },
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.25.2.tgz",
-      "integrity": "sha512-kn1SiHDss3t+Ami37T6ZH5ov1fiEXF1y488bUOUgrh0pEK8VOq8+HlPbdte/cH0K+dWPhuLyKNACd+KhMQPjCw==",
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.25.3.tgz",
+      "integrity": "sha512-02wjApwJwGD+kGWRoiFVY0Hq960ydMAMHrK3AJH2LMiYNYcrzAr1FSbA3OSylvg2gx3w/r1r710B+iMz3KJKbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -375,8 +375,8 @@
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.25.2",
-        "@redocly/respect-core": "2.25.2",
+        "@redocly/openapi-core": "2.25.3",
+        "@redocly/respect-core": "2.25.3",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.25.2.tgz",
-      "integrity": "sha512-HIvxgwxQct/IdRJjjqu4g8BLpCik6I3zxp8JFJpRtmY1TSIZAOZjJwlkoh4uQcy/nCP+psSMgQvzjVGml3k6+w==",
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.25.3.tgz",
+      "integrity": "sha512-GIu3Mdym5IDIPCvXTzMZ6TQw/+7sKd52PdysxNVe7zBk22ExSGnVE9UAk9BaLOzXT77PJWDUwaimBdJoPpxHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -463,16 +463,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.25.2.tgz",
-      "integrity": "sha512-GpvmjY2x8u4pAGNts7slexuKDzDWHNUB4gey9/rSqvC8IaqY49vkvMuRodIBwCsqXhn2rpkJbar1UK3rAOuy7g==",
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.25.3.tgz",
+      "integrity": "sha512-07m80JYdp7J7kH4D1Vqdpa2ZBFCv3QAwCoh2w9H3OjuT/rXQkBSkJQm1n70fzO/HuUf4azzULdp2XnsIpxP2qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.25.2",
+        "@redocly/openapi-core": "2.25.3",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate": "redocly lint docs/openapi.yaml --config .redocly.yaml && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.25.2",
+    "@redocly/cli": "^2.25.3",
     "prettier": "^3.8.1"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- update `@redocly/cli` from `^2.25.2` to `^2.25.3`
- refresh the lockfile for the matching `@redocly/openapi-core` and `@redocly/respect-core` releases
- record the tooling update in `CHANGELOG.md`

## Validation
- `npm run validate`
- `reuse lint`

Closes #156