### PR TITLE
refactor(openapi): reuse pagination components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the remaining inline activity-log pagination schema with shared `PaginationLinks` and `PaginationMeta` component references so paginated responses use the contract's canonical pagination building blocks
 - Updated `@redocly/cli` from `2.25.2` to `2.25.3` so `npm run validate` no longer emits the current upgrade banner tracked in #156
 
 - Aligned the contract repo's domain guidance and the OpenAPI base/server URLs with the active host split: `api.secpal.dev` for the API, `app.secpal.dev` for the PWA, `secpal.app` for the public homepage and real email addresses, and `app.secpal.app` only as the Android identifier

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2331,39 +2331,9 @@ paths:
                     items:
                       $ref: '#/components/schemas/Activity'
                   links:
-                    type: object
-                    properties:
-                      first:
-                        type: string
-                        format: uri
-                      last:
-                        type: string
-                        format: uri
-                      prev:
-                        type: string
-                        format: uri
-                        nullable: true
-                      next:
-                        type: string
-                        format: uri
-                        nullable: true
+                    $ref: '#/components/schemas/PaginationLinks'
                   meta:
-                    type: object
-                    properties:
-                      current_page:
-                        type: integer
-                      from:
-                        type: integer
-                        nullable: true
-                      last_page:
-                        type: integer
-                      per_page:
-                        type: integer
-                      to:
-                        type: integer
-                        nullable: true
-                      total:
-                        type: integer
+                    $ref: '#/components/schemas/PaginationMeta'
               examples:
                 paginatedResponse:
                   summary: Paginated list with 3 activities


### PR DESCRIPTION
## Summary
- replace the remaining inline pagination schema in the activity-log collection response with shared `PaginationLinks` and `PaginationMeta` references
- keep the existing response examples unchanged while aligning the schema with the canonical pagination components
- record the refactor in `CHANGELOG.md`

## Validation
- `npm run validate`
- `reuse lint`

Closes #86