### PR TITLE
Document email verification auth flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Extended the authenticated-user schema with an explicit `emailVerified` flag so browser and native clients can gate unverified accounts consistently without inferring verification state from downstream `403` route errors
 - Documented the previously implemented `search` and `organizational_unit_id` query filters for `GET /v1/employees` so the OpenAPI contract matches the frontend and API behavior
 - Introduced repo-local `local-prettier.yml` and `local-openapi-lint.yml` reusable workflows that produce the `Prettier Formatting / Check Code Formatting` and `OpenAPI Lint / Validate OpenAPI Specification` check names required by branch protection, working around a CI failure in the shared `reusable-prettier` and `reusable-openapi-lint` caused by the newly introduced `setup-node-with-deps` composite action (tracked in SecPal/.github#293)
 - Added the missing `chain_link_valid` field to the `GET /v1/activity-logs/{activity}/verify` response schema so generated clients and response validators match the API payload

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -370,6 +370,7 @@ components:
         - id
         - name
         - email
+        - emailVerified
         - roles
         - permissions
         - hasOrganizationalScopes
@@ -386,6 +387,10 @@ components:
           type: string
           format: email
           example: 'john.doe@secpal.app'
+        emailVerified:
+          type: boolean
+          description: Whether the authenticated user's email address has been verified.
+          example: true
         roles:
           type: array
           items:


### PR DESCRIPTION
## Summary
- document the new `emailVerified` flag on authenticated user payloads
- align the contract changelog with the auth payload change

## Validation
- `npm run validate`

## Review
- Local 4-pass self-review completed: correctness, domain/policy, best practices, security
