### PR TITLE
docs: strengthen validation governance with contract-impact and PR body-file rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,8 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - When local review finds zero issues, commit and push the finished branch before opening any PR.
 - The first PR state must be draft. Do not open a normal PR first.
 - Mark a draft PR ready only after the final self-review in the PR view still finds zero issues.
+- When creating or editing PRs programmatically, write multi-line body content to a file and use
+  `--body-file` to prevent shell escaping issues.
 
 ## Required Validation
 
@@ -71,6 +73,8 @@ At minimum verify:
 - `CHANGELOG.md` was updated for real changes
 - commits are GPG-signed
 - REUSE compliance was checked when changed files require it
+- when a contract change alters response shapes, error codes, required fields, or security schemes,
+  affected examples and validation rules were checked and updated in the same change set
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID,
   quality-first, and issue-management checks
 - no bypass was used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Strengthened Copilot governance: require contract-impact analysis when schema changes alter response shapes, error codes, or security schemes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
+
 ### Added
 
 - Documented the current onboarding runtime surface in `docs/openapi.yaml` (closes #180), including the public bootstrap endpoints (`GET /onboarding/validate-token`, `POST /onboarding/complete`), the authenticated employee dossier endpoints (`GET /onboarding/steps`, `GET /onboarding/templates`, `GET /onboarding/templates/{template}`, `GET /onboarding/submissions`, `POST /onboarding/submissions`, `GET /onboarding/completion-status`), the HR review actions (`POST /admin/onboarding/submissions/{submission}/approve`, `POST /admin/onboarding/submissions/{submission}/reject`), and the explicit `onboarding_workflow.status` field on employee resources so clients can distinguish dossier completeness from activation readiness; relates to route-drift follow-up SecPal/frontend#731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Strengthened Copilot governance: require contract-impact analysis when schema changes alter response shapes, error codes, or security schemes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
-
 ### Added
 
 - Documented the current onboarding runtime surface in `docs/openapi.yaml` (closes #180), including the public bootstrap endpoints (`GET /onboarding/validate-token`, `POST /onboarding/complete`), the authenticated employee dossier endpoints (`GET /onboarding/steps`, `GET /onboarding/templates`, `GET /onboarding/templates/{template}`, `GET /onboarding/submissions`, `POST /onboarding/submissions`, `GET /onboarding/completion-status`), the HR review actions (`POST /admin/onboarding/submissions/{submission}/approve`, `POST /admin/onboarding/submissions/{submission}/reject`), and the explicit `onboarding_workflow.status` field on employee resources so clients can distinguish dossier completeness from activation readiness; relates to route-drift follow-up SecPal/frontend#731
@@ -49,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Strengthened Copilot governance: require contract-impact analysis when contract changes alter required fields, response shapes, error codes, or security schemes, and mandate `--body-file` for programmatic PR creation to prevent shell escaping issues.
 - Clarified the repo-local branch-start and post-merge readiness workflow so new contract work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run validate`, and confirms a clean working tree
 - Restored explicit repo-local Copilot governance by making contract-first and test-first work, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the contracts runtime overlay now auto-loads repo-wide so these rules remain present while working
 - Clarified the repo-local PR workflow so finished contract work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean


### PR DESCRIPTION
## Summary

Codifies prevention learnings from the recent CI failure audit into contracts repo governance. Adds explicit rules that were missing from the validation checklists.

## Changes

### Copilot Instructions (`.github/copilot-instructions.md`)

**Required Validation** — new checklist item:
- When a contract change alters required fields, response shapes, error codes, or security schemes, affected examples and validation rules were checked and updated in the same change set.

**Issue And PR Discipline** — new rule:
- When creating or editing PRs programmatically, write multi-line body content to a file and use `--body-file` to prevent shell escaping issues.

## Motivation

Recent CI failures were caused by:
1. Behavior-changing contract updates pushed without ensuring downstream examples and validation rules were kept in sync.
2. PR bodies created with `mcp_github_create_pull_request` double-escaping `\n` characters.

These governance additions prevent recurrence by making contract-impact analysis and file-based PR bodies explicit checklist items.
