### PR TITLE
fix: document passkey challenge email fallback contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Clarified the passkey contract so registration examples remain compatibility-friendly (`resident_key: preferred`) while `require_resident_key` stays optional and omitted unless discoverable credentials are required, and `/auth/passkeys/challenges` now documents the optional email-scoped request body used to obtain `allow_credentials` for non-discoverable browser sign-in fallback.
 - Extended the onboarding runtime contract with `POST /v1/onboarding/submissions/{submission}/files`, including the multipart upload payload and returned attachment metadata, so the OpenAPI spec now covers the existing frontend dossier-upload call surface.
 - Narrowed the onboarding submission request contract to the employee-writable states `draft` and `submitted`, and added the explicit `404 Not Found` edge-case response for `POST /v1/onboarding/complete`, so the documented onboarding runtime surface no longer overstates accepted request states or omits the linked-user lookup path
 - Added the missing `403 Forbidden` response to `GET /v1/onboarding/completion-status` so the onboarding contract matches the verified-auth runtime behavior for authenticated but not fully eligible callers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -931,6 +931,7 @@ components:
           example: preferred
         require_resident_key:
           type: boolean
+          deprecated: true
           description: >-
             Deprecated compatibility flag. Omitted unless the server requires a
             discoverable credential for enrollment.
@@ -3864,6 +3865,8 @@ paths:
                 $ref: '#/components/schemas/PasskeyAuthenticationChallengeResponse'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationError'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -923,9 +923,17 @@ components:
         resident_key:
           type: string
           enum: [discouraged, preferred, required]
+          description: >-
+            Passkey enrollment defaults to `preferred` for broader browser and
+            authenticator compatibility. The sign-in flow can request an
+            `allow_credentials` list for email-scoped fallbacks when
+            discoverable credentials are unavailable.
           example: preferred
         require_resident_key:
           type: boolean
+          description: >-
+            Deprecated compatibility flag. Omitted unless the server requires a
+            discoverable credential for enrollment.
           example: false
         user_verification:
           type: string
@@ -1145,6 +1153,18 @@ components:
               type: string
               format: date-time
               example: '2026-04-05T13:45:00Z'
+
+    PasskeyAuthenticationChallengeRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          description: >-
+            Optional email address used to scope the challenge to that
+            account's enrolled passkeys when the browser cannot complete a
+            discoverable passkey flow.
+          example: user@secpal.dev
 
     PasskeyAssertionResponse:
       type: object
@@ -3822,11 +3842,19 @@ paths:
 
         This phase-2 endpoint is intended for browsers that support `PublicKeyCredential` and the WebAuthn ceremony APIs. Clients that do not support passkeys should continue to use `/auth/login` plus the existing phase-1 MFA challenge flow.
 
+        Clients may optionally provide an email address to receive an `allow_credentials` list for that account when discoverable passkey sign-in is unavailable in the browser or authenticator.
+
         Successful verification of this challenge returns an authenticated browser-session context directly and does not emit a separate phase-1 TOTP challenge.
       operationId: createPasskeyAuthenticationChallenge
       tags:
         - Authentication
       security: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasskeyAuthenticationChallengeRequest'
       responses:
         '201':
           description: Browser passkey sign-in challenge created successfully


### PR DESCRIPTION
## Summary
- document the optional email request body for /v1/auth/passkeys/challenges so non-discoverable browser fallbacks can receive allow_credentials
- clarify passkey registration compatibility guidance by keeping resident_key at preferred and require_resident_key optional/omitted unless required
- record the contract fix in CHANGELOG.md

## Validation
- npm run validate
