### PR TITLE
docs: add canonical product description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC0-1.0
 [![PR Size](https://github.com/SecPal/contracts/actions/workflows/pr-size.yml/badge.svg)](https://github.com/SecPal/contracts/actions/workflows/pr-size.yml)
 [![License: AGPL v3+](https://img.shields.io/badge/License-AGPL%20v3+-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-This repository contains the OpenAPI 3.1 specifications for the SecPal API. It serves as the single source of truth for all API contracts between the frontend, backend, and any other clients.
+SecPal is the operations software for German private security services. This repository contains the OpenAPI 3.1 specifications for the SecPal API — the single source of truth for all API contracts between frontend, backend, and other clients.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds a product context sentence before the OpenAPI spec description.

**Before:** "This repository contains the OpenAPI 3.1 specifications for the SecPal API. It serves as the single source of truth..."
**After:** "SecPal is the operations software for German private security services. This repository contains the OpenAPI 3.1 specifications for the SecPal API — the single source of truth..."

## Checklist

- [x] One topic, one PR
- [x] No behavior change — documentation only
- [x] Commit is GPG-signed

Closes #191
Part of SecPal/.github#340