### PR TITLE
docs: update openapi.yaml API description to canonical product description

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,8 +5,8 @@ openapi: 3.1.0
 info:
   title: SecPal API
   description: |
-    This is the official API for SecPal, a digital guard book and security operations platform.
-    It provides endpoints for managing guards, shifts, reports, and other security-related resources.
+    SecPal is the operations software for German private security services.
+    This API is the backend powering guard book, shift planning, and operational workflows.
 
     ## Security
 


### PR DESCRIPTION
## Summary

Replace "digital guard book and security operations platform" in the OpenAPI spec `info.description` with the canonical SecPal product description.

Closes #193.

## Changes

- `docs/openapi.yaml`: Update `info.description` to canonical two-sentence product description

## Checklist

- [x] One topic, one branch, one PR
- [x] `npm run validate` passes (redocly lint + prettier)
- [x] REUSE compliant
- [x] Domain policy check passed
- [x] Preflight OK
- [x] GPG-signed commit