### PR TITLE
docs: add onboarding submission patch contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documented the existing `PATCH /v1/onboarding/submissions/{submission}` runtime contract, including the editable submission payload, the returned submission resource, and the state-specific `409 Conflict` / workflow-sensitive `422 Validation Error` cases so the OpenAPI spec now matches the shipped onboarding update endpoint
 - Clarified the passkey contract so registration examples remain compatibility-friendly (`resident_key: preferred`) while `require_resident_key` stays optional and omitted unless discoverable credentials are required, and `/auth/passkeys/challenges` now documents the optional email-scoped request body used to obtain `allow_credentials` for non-discoverable browser sign-in fallback.
 - Extended the onboarding runtime contract with `POST /v1/onboarding/submissions/{submission}/files`, including the multipart upload payload and returned attachment metadata, so the OpenAPI spec now covers the existing frontend dossier-upload call surface.
 - Narrowed the onboarding submission request contract to the employee-writable states `draft` and `submitted`, and added the explicit `404 Not Found` edge-case response for `POST /v1/onboarding/complete`, so the documented onboarding runtime surface no longer overstates accepted request states or omits the linked-user lookup path

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2527,6 +2527,25 @@ components:
         status:
           $ref: '#/components/schemas/OnboardingFormSubmissionWriteStatus'
 
+    OnboardingSubmissionPatchRequest:
+      type: object
+      description: >-
+        Runtime payload accepted by `PATCH /onboarding/submissions/{submission}`.
+        Allows editing an existing `draft` or `rejected` submission owned by the authenticated
+        pre-contract employee.
+      properties:
+        form_data:
+          type: object
+          description: Submission data conforming to the template's `form_schema`.
+          additionalProperties: true
+        status:
+          $ref: '#/components/schemas/OnboardingFormSubmissionWriteStatus'
+      anyOf:
+        - required:
+            - form_data
+        - required:
+            - status
+
     OnboardingSubmissionRejectRequest:
       type: object
       description: Payload for rejecting a submitted onboarding form.
@@ -7054,6 +7073,91 @@ paths:
           $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /onboarding/submissions/{submission}:
+    patch:
+      summary: Update Onboarding Submission
+      description: |
+        Updates an existing editable onboarding form submission owned by the authenticated pre-contract employee.
+
+        Only submissions in `draft` or `rejected` status may be edited. A successful update may keep the
+        submission in `draft` or transition it to `submitted` for HR review.
+      operationId: updateOnboardingSubmission
+      tags:
+        - Onboarding
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+          CsrfToken: []
+      parameters:
+        - name: submission
+          in: path
+          required: true
+          description: Submission UUID.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardingSubmissionPatchRequest'
+      responses:
+        '200':
+          description: Onboarding submission updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnboardingFormSubmissionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Conflict - Submission is no longer editable in its current review state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                submittedAwaitingReview:
+                  summary: Submission already awaiting HR review
+                  value:
+                    message: Form has already been submitted and is awaiting review
+                    code: CONFLICT
+                approvedAlreadyReviewed:
+                  summary: Submission already approved by HR
+                  value:
+                    message: Form has already been reviewed and approved
+                    code: CONFLICT
+        '422':
+          description: Validation Error - Update payload invalid or onboarding workflow state disallows the change
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationProblem'
+              examples:
+                missingEditablePayload:
+                  summary: Neither editable field provided
+                  value:
+                    message: The given data was invalid.
+                    errors:
+                      form_data:
+                        - The form data field is required when status is not present.
+                      status:
+                        - The status field is required when form data is not present.
+                invalidWorkflowState:
+                  summary: Employee workflow not in a state that allows submission
+                  value:
+                    message: The given data was invalid.
+                    errors:
+                      onboarding_workflow_status:
+                        - 'Cannot submit: onboarding workflow is not in an expected state for this action'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2426,7 +2426,7 @@ components:
 
     OnboardingFormSubmissionWriteStatus:
       type: string
-      description: Employee-writable onboarding form submission state accepted by `POST /onboarding/submissions`.
+      description: Employee-writable onboarding form submission state accepted by `POST /onboarding/submissions` and `PATCH /onboarding/submissions/{submission}`.
       enum:
         - draft
         - submitted
@@ -7034,9 +7034,13 @@ paths:
     post:
       summary: Create Onboarding Submission
       description: |
-        Creates a new form submission or updates an existing draft/rejected submission for the same template.
+        Creates a new onboarding form submission for the given template.
 
-        The runtime currently uses this single `POST` endpoint for both create and update semantics.
+        Pre-contract employees with an active onboarding workflow may submit a new draft or
+        directly submit for HR review.
+
+        To update an existing draft or rejected submission, use
+        `PATCH /onboarding/submissions/{submission}`.
       operationId: createOnboardingSubmission
       tags:
         - Onboarding


### PR DESCRIPTION
Fixes #186

## Summary

- document the existing PATCH /v1/onboarding/submissions/{submission} runtime contract in docs/openapi.yaml
- add the dedicated patch request schema and runtime-accurate 409/422 response coverage
- update CHANGELOG.md for the contract fix

## Validation

- timeout 60s ./node_modules/.bin/redocly lint docs/openapi.yaml --config .redocly.yaml
- timeout 60s ./node_modules/.bin/prettier --check "**/*.{md,yml,yaml,json}"
