### PR TITLE
chore: add changelog domain policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   and resolve threads through the approved non-comment workflow.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Domain policy is strict: `secpal.app` for the public homepage and real email addresses,
+  `changelog.secpal.app` for the public changelog site,
   `apk.secpal.app` for the canonical Android artifact and download host, `api.secpal.dev` for the API,
   `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and
   `app.secpal` only as the Android application identifier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `changelog.secpal.app` to the contracts repo domain policy baseline and `scripts/check-domains.sh` allowlist/output so the public changelog host matches the approved SecPal domain split enforced elsewhere
 - Documented the stable `apk.secpal.app` Android metadata contracts in `docs/openapi.yaml`, including the concrete latest-channel path `/android/channels/{channel}/latest.json`, the versioned path `/android/releases/{version}/metadata.json`, and response schemas aligned with the merged public website metadata model
 
 - Documented the Android enrollment and non-Play distribution contract starter surface in `docs/openapi.yaml`, including admin enrollment-session create/list/read/revoke endpoints, the public bootstrap-token exchange endpoint, and the latest channel-aware Android release metadata endpoint for the single-app `app.secpal` distribution model

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,7 +16,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
+echo "Public changelog site: changelog.secpal.app"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Identifier-only: app.secpal (Android application ID)"
@@ -47,12 +48,12 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     grep -v -- '^[[:space:]]*- \[' || true)
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
-# Approved or temporarily tolerated here: secpal.app, apk.secpal.app,
+# Approved or temporarily tolerated here: secpal.app, changelog.secpal.app, apk.secpal.app,
 # secpal.dev (including api/app subdomains), and deprecated-but-allowed
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -102,6 +103,7 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
+    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact/download host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"


### PR DESCRIPTION
## Summary

- add `changelog.secpal.app` to the contracts repo domain policy baseline
- extend `scripts/check-domains.sh` output and allowlist so the public changelog host is treated as approved
- record the domain-policy alignment in the contracts changelog

## Validation

- `rg -n "changelog\.secpal\.app" .github/copilot-instructions.md scripts/check-domains.sh CHANGELOG.md`
- `./scripts/check-domains.sh`

Fixes #189
