### PR TITLE
fix: make employee create management level optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics
+- Aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics
 - Clarified the OpenAPI security overview with the shipped Sanctum session lifetime, non-rotating 24-hour bearer-token policy, and category-specific route throttles so the published contract no longer overstates a flat `100 requests per minute per API key` model
 - Documented the existing `PATCH /v1/onboarding/submissions/{submission}` runtime contract, including the editable submission payload, the returned submission resource, and the state-specific `409 Conflict` / workflow-sensitive `422 Validation Error` cases so the OpenAPI spec now matches the shipped onboarding update endpoint
 - Clarified the passkey contract so registration examples remain compatibility-friendly (`resident_key: preferred`) while `require_resident_key` stays optional and omitted unless discoverable credentials are required, and `/auth/passkeys/challenges` now documents the optional email-scoped request body used to obtain `allow_credentials` for non-discoverable browser sign-in fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics
 - Clarified the OpenAPI security overview with the shipped Sanctum session lifetime, non-rotating 24-hour bearer-token policy, and category-specific route throttles so the published contract no longer overstates a flat `100 requests per minute per API key` model
 - Documented the existing `PATCH /v1/onboarding/submissions/{submission}` runtime contract, including the editable submission payload, the returned submission resource, and the state-specific `409 Conflict` / workflow-sensitive `422 Validation Error` cases so the OpenAPI spec now matches the shipped onboarding update endpoint
 - Clarified the passkey contract so registration examples remain compatibility-friendly (`resident_key: preferred`) while `require_resident_key` stays optional and omitted unless discoverable credentials are required, and `/auth/passkeys/challenges` now documents the optional email-scoped request body used to obtain `allow_credentials` for non-discoverable browser sign-in fallback.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1465,7 +1465,6 @@ components:
         - email
         - status
         - position
-        - management_level
         - contract_start_date
         - contract_type
         - organizational_unit_id
@@ -1590,10 +1589,12 @@ components:
         position:
           type: string
           maxLength: 255
+          description: Free-text job title or position.
         management_level:
           type: integer
           minimum: 0
           maximum: 255
+          description: Optional leadership rank. Omit or use `0` for non-management employees; `1-255` represent leadership ranks.
         hire_date:
           type: [string, 'null']
           format: date
@@ -1806,10 +1807,12 @@ components:
         position:
           type: [string, 'null']
           maxLength: 255
+          description: Free-text job title or position.
         management_level:
           type: integer
           minimum: 0
           maximum: 255
+          description: Optional leadership rank update. Use `0` for non-management employees; `1-255` represent leadership ranks.
         hire_date:
           type: [string, 'null']
           format: date


### PR DESCRIPTION
## Summary
- make `EmployeeCreateRequest.management_level` optional for non-management hires
- document `position` as free-text and clarify the `0` versus `1-255` rank semantics
- keep the update schema aligned with the same runtime model

## Validation
- `npm run lint`
- `npx prettier --check docs/openapi.yaml CHANGELOG.md`

## Context
- companion runtime fix: SecPal/api#905
- companion frontend wire fix: SecPal/frontend#867
