### PR TITLE
chore: automate Copilot AI validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,6 +91,9 @@ At minimum verify:
   explicitly.
 - Reject AI-generated shell or regex cleanups that widen discovery patterns or
   collapse allowlists without positive and negative evidence.
+- Reject AI-generated contract cleanups that widen allowlists, relax regex or
+  discovery patterns, or change required fields, enums, or security schemes
+  without positive and negative examples plus validation evidence.
 
 ## Repository Conventions
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   reuse:
     name: REUSE Compliance

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,10 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
+  copilot-instructions:
+    name: Copilot Instructions
+    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+
   openapi-lint:
     name: OpenAPI Lint
     uses: ./.github/workflows/local-openapi-lint.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/instructions/org-shared.instructions.md` — org-wide Copilot principles available as a repo-local overlay that can be loaded
   manually for contract-relevant files
 
+### Changed
+
+- wired the central Copilot-instructions validator into `quality.yml` so contract pull requests now fail automatically when known OpenAPI AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline
+
 ### Fixed
 
 - Aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics


### PR DESCRIPTION
## Summary

- wire the shared Copilot-instructions validator into the contracts quality workflow
- extend contracts runtime guardrails for allowlist drift and unproven contract widening

## Testing

- bash /home/holger/code/SecPal/.github/scripts/validate-copilot-instructions.sh

## Issues

- Closes #210
- Part of SecPal/.github#373
