### PR TITLE
chore: update Redocly CLI to 2.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated `@redocly/cli` from `2.28.0` to `2.28.1` so the contracts toolchain stays aligned with the current Redocly CLI release tracked in #213
 - Aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics
 - Clarified the OpenAPI security overview with the shipped Sanctum session lifetime, non-rotating 24-hour bearer-token policy, and category-specific route throttles so the published contract no longer overstates a flat `100 requests per minute per API key` model
 - Documented the existing `PATCH /v1/onboarding/submissions/{submission}` runtime contract, including the editable submission payload, the returned submission resource, and the state-specific `409 Conflict` / workflow-sensitive `422 Validation Error` cases so the OpenAPI spec now matches the shipped onboarding update endpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.28.0",
+        "@redocly/cli": "^2.28.1",
         "prettier": "^3.8.3"
       }
     },
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.0.tgz",
-      "integrity": "sha512-hAHtMjo4fLdLqZXtZwQqlwGnAiOzEAh7EPbE01rs9j7cewj2btOXrGQW8v6Eg3gDh+i77/DOxxazRWvZ/zAa7w==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.1.tgz",
+      "integrity": "sha512-gDi0+vC905YHrtGD3WCP86gW44JdXQb0fu4128tVFpgfh5T65tFZkhs2xoPqLJn7RCtkndQ+rSwyXcALKoao0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -375,8 +375,8 @@
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.28.0",
-        "@redocly/respect-core": "2.28.0",
+        "@redocly/openapi-core": "2.28.1",
+        "@redocly/respect-core": "2.28.1",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.0.tgz",
-      "integrity": "sha512-Htpp4PsjKMgEuMT9iJu4iuFFzWCDe8FylvpGaQEA5D7jZXWv+8XvnqhpGCKN2cM/n/Uri2QfqNdw0JlKIC59sg==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.1.tgz",
+      "integrity": "sha512-PXulQY+lUJzeLWfhtJ8UPBFaMvlPDvW/dkozDhUAlYDotEYNMOaKFbJxKcrPCtRYtZ0TJsh5MohdcDLCBAJbFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -463,16 +463,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.0.tgz",
-      "integrity": "sha512-svjCRzXsj/EyN7chfB9pTVYvWT1+hlOqMkZVlkrH6PqFKXAHYeP47YRW9+3omUSDBd1Ph4A4J4NBUW1PRph5+g==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.1.tgz",
+      "integrity": "sha512-r8sf7damvSviJwVif4hZVP/Qw7ciLgwLvHVy9AsUWxWh6JQtTZpV2/lJB681bqjn+GM9EMzhcNL1rBUo4K6Uyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.28.0",
+        "@redocly/openapi-core": "2.28.1",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate": "redocly lint docs/openapi.yaml --config .redocly.yaml && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.28.0",
+    "@redocly/cli": "^2.28.1",
     "prettier": "^3.8.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- update `@redocly/cli` from `2.28.0` to `2.28.1` in the contracts repo
- refresh the lockfile so the repo resolves the current Redocly CLI release consistently
- document the tooling update in the unreleased changelog entry for issue #213

## Validation
- `npm run validate`
- `npm ls @redocly/cli`

## Notes
- Closes #213
