### PR TITLE
fix: pin transitive postcss to 8.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned transitive `postcss` to `8.5.10` via npm overrides so the contracts validation toolchain no longer resolves the moderate XSS advisory reported through `@redocly/cli`'s `styled-components` dependency chain
 - Scoped the transitive `undici` override to `@redocly/cli` and pinned it to `6.24.0` so contract validation tooling no longer resolves the vulnerable HTTP client release reported by `npm audit`
 - Pinned transitive `brace-expansion` and `yaml` resolutions to patched semver-compatible releases so the contracts toolchain no longer reports the moderate `npm audit` findings surfaced during the Redocly CLI maintenance update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned transitive `postcss` to `8.5.10` via npm overrides so the contracts validation toolchain no longer resolves the moderate XSS advisory reported through `@redocly/cli`'s `styled-components` dependency chain
+- Scoped transitive `postcss` override to `postcss@^8: 8.5.10` (was unscoped `"postcss"`) so future PostCSS major versions are not pinned to `8.x` and the override only applies to the affected v8 range used by `@redocly/cli`'s `styled-components` dependency chain
 - Scoped the transitive `undici` override to `@redocly/cli` and pinned it to `6.24.0` so contract validation tooling no longer resolves the vulnerable HTTP client release reported by `npm audit`
 - Pinned transitive `brace-expansion` and `yaml` resolutions to patched semver-compatible releases so the contracts toolchain no longer reports the moderate `npm audit` findings surfaced during the Redocly CLI maintenance update
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -1579,7 +1579,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     },
     "brace-expansion@^2": "2.0.3",
     "brace-expansion@^5": "5.0.5",
+    "postcss": "8.5.10",
     "yaml@^1": "1.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "brace-expansion@^2": "2.0.3",
     "brace-expansion@^5": "5.0.5",
-    "postcss": "8.5.10",
+    "postcss@^8": "8.5.10",
     "yaml@^1": "1.10.3"
   }
 }


### PR DESCRIPTION
## Summary

- pin transitive `postcss` to `8.5.10` via npm overrides to remediate the advisory surfaced through `@redocly/cli` -> `styled-components`
- refresh `package-lock.json` so the resolved toolchain installs the patched PostCSS release
- document the security remediation in `CHANGELOG.md`

## Validation

- `git diff --check`
- `npm audit --audit-level=moderate --json`
- `npm run validate`

## Issue Management

- Follow-up: #223 tracks the separate `@redocly/cli` 2.30.0 upgrade notice seen during validation.
