### PR TITLE
fix: fail fast on stale Redocly CLI installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a fail-fast `prevalidate` guard that blocks `npm run validate` when local `node_modules` still resolve a stale `@redocly/cli` version instead of the lockfile-pinned release, so the follow-up tracked in #223 now reports an actionable `npm ci` requirement instead of a misleading Redocly upgrade banner
+- Updated `@redocly/cli` from `2.29.2` to `2.30.3` across the follow-up maintenance bumps tracked from #223 so the contracts validation toolchain now stays on the current compatible Redocly CLI release line already recorded in `package.json` and `package-lock.json`
 - Updated `@redocly/cli` from `2.28.0` to `2.28.1` so the contracts toolchain stays aligned with the current Redocly CLI release tracked in #213
 - Aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics
 - Clarified the OpenAPI security overview with the shipped Sanctum session lifetime, non-rotating 24-hour bearer-token policy, and category-specific route throttles so the published contract no longer overstates a flat `100 requests per minute per API key` model

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
+    "prevalidate": "bash scripts/check-redocly-cli-sync.sh",
     "lint": "redocly lint docs/openapi.yaml --config .redocly.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",

--- a/scripts/check-redocly-cli-sync.sh
+++ b/scripts/check-redocly-cli-sync.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: node is required to verify the installed @redocly/cli version." >&2
+  exit 1
+fi
+
+if [ ! -f package.json ] || [ ! -f package-lock.json ]; then
+  echo "Error: package.json and package-lock.json are required." >&2
+  exit 1
+fi
+
+DECLARED_VERSION="$(node -p "require('./package.json').devDependencies?.['@redocly/cli'] ?? ''")"
+LOCKED_VERSION="$(node -p "require('./package-lock.json').packages?.['node_modules/@redocly/cli']?.version ?? ''")"
+
+if [ -z "$LOCKED_VERSION" ]; then
+  echo "Error: package-lock.json does not contain a node_modules/@redocly/cli entry." >&2
+  exit 1
+fi
+
+if [ ! -f node_modules/@redocly/cli/package.json ]; then
+  echo "Error: @redocly/cli is not installed. Run npm ci before validation." >&2
+  exit 1
+fi
+
+INSTALLED_VERSION="$(node -p "require('./node_modules/@redocly/cli/package.json').version")"
+
+if [ "$INSTALLED_VERSION" != "$LOCKED_VERSION" ]; then
+  echo "Error: installed @redocly/cli version $INSTALLED_VERSION does not match lockfile version $LOCKED_VERSION (declared range: $DECLARED_VERSION)." >&2
+  echo "Run npm ci to refresh local dependencies before running validation." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a fail-fast prevalidate guard so npm run validate stops immediately when local node_modules still resolve a stale @redocly/cli version
- point the local recovery path at npm ci instead of surfacing a misleading Redocly upgrade banner
- document both the new guard and the already-landed 2.29.2 -> 2.30.3 Redocly CLI upgrade line in CHANGELOG.md

## Validation

- npm run validate
- reuse lint
- git diff --check
- exercised scripts/check-redocly-cli-sync.sh against a stale fixture (installed 2.29.2 vs lockfile 2.30.3)

## Issue Management

- Closes #223
