### PR TITLE
fix(openapi): tighten onboarding submission form-data contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected onboarding submission contract consistency in `docs/openapi.yaml`: replaced duplicated inline `form_data` objects with shared `OnboardingSubmissionFormData`, removed contradictory tax-ID-only `anyOf` modeling that could be bypassed, and enforced that `PATCH /onboarding/submissions/{submission}` requires `form_data` when `status` is set to `submitted`
 - Corrected `QualificationResource` schema: removed `description` from `required` (nullable field, may be absent per spec pattern), made `created_at`/`updated_at` non-nullable (`type: string`) to align with all other resource timestamps, and aligned union-type style from `['string', 'null']` to `[string, 'null']` consistently across all new schemas (`docs/openapi.yaml`)
 - Added `created_at`/`updated_at` (required, non-nullable `type: string, format: date-time`) to `EmployeeQualificationResource`, consistent with all other resource schemas (`docs/openapi.yaml`)
 - Fixed file-size note: `10240 KiB (10 MB)` → `10240 KiB (10 MiB)` in `UploadEmployeeDocumentRequest` description (`docs/openapi.yaml`)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2891,7 +2891,11 @@ components:
           example: Basic personal information required for onboarding.
         form_schema:
           type: object
-          description: JSON Schema definition used to render the dynamic form.
+          description: >-
+            JSON Schema definition used to render the dynamic form. The system
+            `tax_identification_number` onboarding template is required during onboarding and
+            includes required `tax_id` and `social_security_number` properties; those Employee
+            master-data fields remain nullable outside the onboarding workflow.
           additionalProperties: true
         is_required:
           type: boolean
@@ -2946,6 +2950,14 @@ components:
         - draft
         - submitted
 
+    OnboardingSubmissionFormData:
+      type: object
+      description: >-
+        Submission data conforming to the template's `form_schema`.
+        For the system `tax_identification_number` template, `form_schema` requires
+        `tax_id` and `social_security_number`.
+      additionalProperties: true
+
     OnboardingFormSubmission:
       type: object
       description: A single form submission within the onboarding dossier.
@@ -2970,9 +2982,7 @@ components:
           format: uuid
           example: 'aab14c00-e29b-41d4-a716-446655440001'
         form_data:
-          type: object
-          description: Employee-submitted form data conforming to the template's `form_schema`.
-          additionalProperties: true
+          $ref: '#/components/schemas/OnboardingSubmissionFormData'
         status:
           $ref: '#/components/schemas/OnboardingSubmissionStatus'
         submitted_at:
@@ -3036,9 +3046,7 @@ components:
           format: uuid
           example: 'aab14c00-e29b-41d4-a716-446655440001'
         form_data:
-          type: object
-          description: Submission data conforming to the template's `form_schema`.
-          additionalProperties: true
+          $ref: '#/components/schemas/OnboardingSubmissionFormData'
         status:
           $ref: '#/components/schemas/OnboardingFormSubmissionWriteStatus'
 
@@ -3050,16 +3058,27 @@ components:
         pre-contract employee.
       properties:
         form_data:
-          type: object
-          description: Submission data conforming to the template's `form_schema`.
-          additionalProperties: true
+          $ref: '#/components/schemas/OnboardingSubmissionFormData'
         status:
           $ref: '#/components/schemas/OnboardingFormSubmissionWriteStatus'
-      anyOf:
-        - required:
-            - form_data
-        - required:
-            - status
+      allOf:
+        - anyOf:
+            - required:
+                - form_data
+            - required:
+                - status
+        - if:
+            properties:
+              status:
+                const: submitted
+            required:
+              - status
+          then:
+            properties:
+              form_data:
+                $ref: '#/components/schemas/OnboardingSubmissionFormData'
+            required:
+              - form_data
 
     OnboardingSubmissionRejectRequest:
       type: object
@@ -8735,6 +8754,11 @@ paths:
       description: |
         HR review action. Approves a submitted onboarding form submission, transitioning
         its status to `approved`.
+
+        Approving the system tax identification submission copies `tax_id` and
+        `social_security_number` from `form_data` into the encrypted Employee master-data fields.
+        Those Employee fields remain nullable outside onboarding so HR can create employees before
+        onboarding is completed.
 
         Requires the explicit `onboarding.approve` permission. Only submissions in `submitted` status may be approved.
       operationId: approveOnboardingSubmission


### PR DESCRIPTION
## Summary
- replace duplicated inline onboarding submission `form_data` schemas with shared `OnboardingSubmissionFormData`
- remove contradictory `anyOf` shape that implied strict tax fields but still allowed unrestricted objects
- enforce `PATCH /onboarding/submissions/{submission}` invariant: when `status` is `submitted`, `form_data` is required
- document the fix in `CHANGELOG.md` under `[Unreleased] -> Fixed`

## Why
The previous schema update introduced a contract inconsistency:
- strict tax-field wording was added, but schema validation still allowed bypass via a catch-all object branch
- PATCH allowed `{ "status": "submitted" }` without `form_data`, contradicting review-submission semantics

This change restores consistent contract behavior and schema semantics.

## Validation
- `npm run validate`
- `bash scripts/preflight.sh`

## Scope
- one topic only: onboarding submission contract consistency in `docs/openapi.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes OpenAPI documentation/validation rules, but it may break generated clients or request validators that previously relied on looser `PATCH /onboarding/submissions/{submission}` semantics.
> 
> **Overview**
> Tightens the onboarding submission contract in `docs/openapi.yaml` by introducing a shared `OnboardingSubmissionFormData` schema and reusing it across submission resource and request bodies instead of duplicated inline `form_data` objects.
> 
> Fixes inconsistent `PATCH /onboarding/submissions/{submission}` modeling by requiring `form_data` whenever `status` is set to `submitted` (while still allowing patching either `form_data` or `status`), and removes the contradictory tax-ID-only `anyOf` shape that could be bypassed. Updates `CHANGELOG.md` to record the contract correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc988addf0412c811c6e4044d2d19295149f4ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->