### PR TITLE
chore: pin Redocly transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed optional request fields `description` and `expiry_date` in `UploadEmployeeDocumentRequest` to use nullable union type `[string, 'null']`, consistent with other optional nullable fields across the spec (`docs/openapi.yaml`)
 - Updated `check-openapi-verified-endpoints.mjs` guard comment to accurately describe all operation groups in the allowlist (qualification catalog + employee qualifications were missing from the description)
 
+### Security
+
+- Pinned transitive `fast-uri` to `3.1.2` and `fast-xml-builder` to `1.2.0` via `overrides` so the local Redocly validation toolchain no longer reports the high-severity `npm audit` findings surfaced during preflight
+
 ### Added
 
 - Documented employee emergency contacts in `docs/openapi.yaml` by introducing the reusable `EmployeeEmergencyContactEntry` schema and exposing nullable `emergency_contacts` arrays on `EmployeeCreateRequest`, `EmployeeUpdateRequest`, and `Employee` response payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scoped transitive `postcss` override to `postcss@^8: 8.5.10` (was unscoped `"postcss"`) so future PostCSS major versions are not pinned to `8.x` and the override only applies to the affected v8 range used by `@redocly/cli`'s `styled-components` dependency chain
 - Scoped the transitive `undici` override to `@redocly/cli` and pinned it to `6.24.0` so contract validation tooling no longer resolves the vulnerable HTTP client release reported by `npm audit`
 - Pinned transitive `brace-expansion` and `yaml` resolutions to patched semver-compatible releases so the contracts toolchain no longer reports the moderate `npm audit` findings surfaced during the Redocly CLI maintenance update
+- Scoped transitive `fast-uri` and `fast-xml-builder` overrides to the vulnerable semver ranges used by the Redocly toolchain so local contract validation no longer reports the high-severity `npm audit` findings without pinning unrelated future dependency lines
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -909,9 +909,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -921,7 +921,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -2109,6 +2110,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     },
     "brace-expansion@^2": "2.0.3",
     "brace-expansion@^5": "5.0.5",
+    "fast-uri": "3.1.2",
+    "fast-xml-builder": "1.2.0",
     "postcss@^8": "8.5.10",
     "yaml@^1": "1.10.3"
   }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     },
     "brace-expansion@^2": "2.0.3",
     "brace-expansion@^5": "5.0.5",
-    "fast-uri": "3.1.2",
-    "fast-xml-builder": "1.2.0",
+    "fast-uri@^3.0.1": "3.1.2",
+    "fast-xml-builder@^1.1.5": "1.2.0",
     "postcss@^8": "8.5.10",
     "yaml@^1": "1.10.3"
   }


### PR DESCRIPTION
## Summary
- pin the Redocly toolchain's transitive `fast-uri` and `fast-xml-builder` dependencies via package overrides
- update the lockfile so local preflight and contract validation stop surfacing the known audit findings
- document the security maintenance change in the changelog

## Test plan
- [x] `bash scripts/preflight.sh` in the frontend workspace completed successfully after the dependency update was available locally
- [ ] CI