### PR TITLE
chore(deps): bump @redocly/cli to 2.30.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added a fail-fast `prevalidate` guard that blocks `npm run validate` when local `node_modules` still resolve a stale `@redocly/cli` version instead of the lockfile-pinned release, so the follow-up tracked in #223 now reports an actionable `npm ci` requirement instead of a misleading Redocly upgrade banner
+- Updated `@redocly/cli` to `2.30.6` after reviewing the `2.30.5`/`2.30.6` upstream patch releases (query-language handling, `redocly.yaml` env-var validation, Respect `--har-output` fixes, `@redocly/openapi-core` bumps, no-API crash fix) so `redocly lint` stops printing the stale upgrade banner from #252 once `node_modules` matches the lockfile; no npm `overrides` changes were required and `npm audit` stays clean (closes #252)
 - Updated `@redocly/cli` from `2.29.2` to `2.30.3` across the follow-up maintenance bumps tracked from #223 so the contracts validation toolchain now stays on the current compatible Redocly CLI release line already recorded in `package.json` and `package-lock.json`
 - Updated `@redocly/cli` from `2.28.0` to `2.28.1` so the contracts toolchain stays aligned with the current Redocly CLI release tracked in #213
 - Aligned `EmployeeCreateRequest` with the live employee-create runtime by making `management_level` optional for non-management hires and by documenting `position` as free-text plus the `0`/`1-255` management-rank semantics

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.30.5",
+        "@redocly/cli": "^2.30.6",
         "js-yaml": "^4.1.0",
         "prettier": "^3.8.3"
       }
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.30.5.tgz",
-      "integrity": "sha512-jjPXcTJbpH14Nu1EdD8DorkLmtiaKQV945YPVlpS627GIwJ6FJp9qeoNeS0JksVkmWYQyNLwNq3qCapKgelMHg==",
+      "version": "2.30.6",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.30.6.tgz",
+      "integrity": "sha512-BFkviDxeuLbisRdaSfPmSehL0AIBGfA9mziZF0APumaFo92D2g+a3r25mPbhdD3EgmIKPZRvAe8AR8BudebVJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -429,8 +429,8 @@
         "@opentelemetry/sdk-trace-node": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.30.5",
-        "@redocly/respect-core": "2.30.5",
+        "@redocly/openapi-core": "2.30.6",
+        "@redocly/respect-core": "2.30.6",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.5.tgz",
-      "integrity": "sha512-ikljMaow1wX3GoRvLiJvqOq8H3f6XsuMBZqCGmeY0+UPmlnVhrvW8m/gC1vkKcGNvYINUrgi/Z6dBtzQ7854wA==",
+      "version": "2.30.6",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.6.tgz",
+      "integrity": "sha512-nxyqXRzWQQlvpLLv686ycOQg+fNWbF/ZvkyC8bXoDU6LxMM5qSjrNomcVwoExbNpvGt9qJilpT6qQlk155RnmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -516,16 +516,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.30.5.tgz",
-      "integrity": "sha512-8rmMr5/8CCIFU5fghxSQ+SZC+W4ewM15w4U+ZH36MVSjdROLrwiPjC+lfe6VxdaJunbmRACzent2HTLLgw4+BQ==",
+      "version": "2.30.6",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.30.6.tgz",
+      "integrity": "sha512-rE38QmhQ6EQNFR5Ry99oFXVL5q6D8W/CcyLGfdA/jf7Hv4fT/35M6Q6zONueC+j9N6fxbQC+Vvpd6JJKukrGFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.1",
-        "@redocly/openapi-core": "2.30.5",
+        "@redocly/openapi-core": "2.30.6",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "better-ajv-errors": "^2.0.3",
         "colorette": "^2.0.20",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "validate": "npm run lint && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.30.5",
+    "@redocly/cli": "^2.30.6",
     "js-yaml": "^4.1.0",
     "prettier": "^3.8.3"
   },


### PR DESCRIPTION
## Problem

Local `redocly lint` (via `npm run validate` and `bash scripts/preflight.sh`) emitted the Redocly CLI upgrade banner: an outdated `node_modules` install could still run **2.30.4** while the lockfile advanced, and after a lockfile-aligned install the registry advertised **2.30.6**, so the banner persisted until the pinned CLI matched the **latest reviewed patch**.

## What changed

- **Single topic — toolchain only:** bump `@redocly/cli` to **2.30.6** in `package.json` and `package-lock.json` (upstream patch notes reviewed for **2.30.5** and **2.30.6**). **No** `docs/openapi.yaml` edits; OpenAPI 3.1 contract surface unchanged per contract-first rules.
- **`CHANGELOG.md`:** `[Unreleased]` → **Fixed** entry referencing #252.

## Validations already run (local)

- `npm run validate` (`scripts/check-redocly-cli-sync.sh`, Redocly lint, verified-endpoints guard, Prettier).
- `bash scripts/preflight.sh` (Prettier, markdownlint-cli2, REUSE, domain policy, `npm ci`, lint).

## Linked workspaces / cross-repo impact

- **None.** Changes are confined to this `SecPal/contracts` repository (dev dependency only). Linked Polyscope workspaces (e.g. frontend/api clones) were **not** modified.

## Out-of-scope findings

- **None** requiring a new GitHub issue: `npm audit` clean after install; existing npm `overrides` for the Redocly toolchain left unchanged.

## Before marking the PR ready (not done in this step)

- Confirm **GitHub Actions** on this draft PR are **green** (full CI was not re-run from this environment after push).
- Complete the **final self-review in the PR view** with **zero** open issues, then convert from **Draft** to **Ready for review** per repository PR discipline (draft first; never ship a normal PR before draft).

Closes #252.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-dependency patch update affecting only local/CI contract linting behavior, not runtime code or the OpenAPI spec itself.
> 
> **Overview**
> Updates the contracts validation toolchain by bumping `@redocly/cli` from `2.30.5` to `2.30.6` in `package.json`/`package-lock.json` (and the corresponding `@redocly/openapi-core`/`@redocly/respect-core` transitive pins).
> 
> Adds a matching `[Unreleased]` changelog entry noting the upgrade to eliminate the persistent Redocly upgrade banner during `npm run validate` (closes #252).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42c2fd54a7d6e19cba924f7eb08c0191ed395cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->