### PR TITLE
Security: pin protobufjs OTLP chain for npm audit (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Pinned transitive `fast-uri` to `3.1.2` and `fast-xml-builder` to `1.2.0` via `overrides` so the local Redocly validation toolchain no longer reports the high-severity `npm audit` findings surfaced during preflight
+- Pinned transitive `protobufjs` to `7.5.8` and its sub-dependency `@protobufjs/utf8` to `1.1.1` via scoped `overrides` to address the `npm audit` finding in the `@redocly/cli` → `@opentelemetry/otlp-transformer` dependency chain
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "@redocly/cli": {
       "undici": "6.24.0"
     },
+    "protobufjs": {
+      "@protobufjs/utf8": "1.1.1",
+      ".": "7.5.8"
+    },
     "brace-expansion@^2": "2.0.3",
     "brace-expansion@^5": "5.0.5",
     "fast-uri@^3.0.1": "3.1.2",


### PR DESCRIPTION
## Failing signal / reproduced defect

GitHub issue #251 (`Security: investigate remaining protobufjs npm audit findings in contracts toolchain`) documents unresolved `npm audit` findings after `npm ci`, affecting **`protobufjs`** (advisories including GHSA-66ff-xgx4-vchm, GHSA-75px-5xx7-5xc7, GHSA-jvwf-75h9-cwgg, GHSA-685m-2w69-288q, and related ranges summarized as `<=7.5.5`) and **`@protobufjs/utf8`** (GHSA-q6x5-8v7m-xcrf, summarized as `<=1.1.0`). The dependency path is transitive: **`@redocly/cli`** → **`@opentelemetry/exporter-trace-otlp-http`** → **`@opentelemetry/otlp-transformer`** → **`protobufjs`** → **`@protobufjs/utf8`**. Local `npm audit` / `bash scripts/preflight.sh` are the relevant gates.

## What this PR changes

- **`package.json`**: add repo-local **`overrides`** so **`protobufjs`** resolves to **`7.5.8`** and its nested **`@protobufjs/utf8`** dependency resolves to **`1.1.1`** (nested override object: `"."` / `"@protobufjs/utf8"`), preventing lockfile regeneration from pulling back into the vulnerable ranges accepted by `protobufjs@^7.0.0` on the transformer.
- **`CHANGELOG.md`**: record the security/toolchain pin under **Unreleased → Security**.

No OpenAPI edits: `docs/openapi.yaml` is unchanged (per `openapi.instructions.md`, contract edits are out of scope for this toolchain-only fix).

## Validations already run (local)

- `npm ci`
- `npm audit` (0 vulnerabilities)
- `npm run validate` (Redocly lint + verified-endpoint guard + Prettier check)
- `bash scripts/preflight.sh` (Prettier, markdownlint-cli2, REUSE, domain policy, `npm ci`, OpenAPI lint)

## Linked workspaces

None were required for this change. Polyscope-linked **SecPal/frontend** and **SecPal/api** clones were not consulted and are unrelated to this npm toolchain pin.

## Before marking the PR ready for review (maintainer checklist)

Per repo governance: keep this PR as **draft** until a **final self-review in the GitHub PR view** still finds **zero** issues; only then use **Ready for review**.

- Confirm **GitHub Actions** on this PR are green (not re-run here after push).
- Re-run `npm ci`, `npm audit`, and `npm run validate` locally after any review feedback.
- No additional out-of-scope findings are pending without a filed issue.

Closes #251.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk toolchain-only change that pins transitive dependencies to patched versions; main risk is unexpected incompatibility in the local OpenAPI validation CLI dependency chain.
> 
> **Overview**
> Pins transitive dependencies in `package.json` via `overrides` so `protobufjs` resolves to `7.5.8` and nested `@protobufjs/utf8` resolves to `1.1.1`, addressing the `npm audit` issue in the `@redocly/cli` → OTLP dependency chain.
> 
> Updates `CHANGELOG.md` to record the new security pin under *Unreleased → Security*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a6317e07266d81205900092adec933ad68d703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->