### PR TITLE
OpenAPI: reuse Simple* responses on qualification routes (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks (closes #234)
+
 ### Fixed
 
 - Corrected onboarding submission contract consistency in `docs/openapi.yaml`: replaced duplicated inline `form_data` objects with shared `OnboardingSubmissionFormData`, removed contradictory tax-ID-only `anyOf` modeling that could be bypassed, and enforced that `PATCH /onboarding/submissions/{submission}` requires `form_data` when `status` is set to `submitted`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks (closes #234)
+- Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks; aligned `PATCH` and `DELETE` `/qualifications/{qualification}` `404` descriptions and examples with the same tenant-aware route-binding semantics documented for `GET` on that path (closes #234)
 
 ### Fixed
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6528,23 +6528,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/QualificationCollectionResponse'
         '401':
-          description: Unauthenticated (e.g. `Unauthenticated.`) — **no** `code` field; see `SimpleMessageResponse`.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: >
-            `qualification.read` missing, or `QualificationPolicy::viewAny` denied. Laravel returns a **message-only** JSON body
-            (commonly `This action is unauthorized.`) without the shared `Error` `code` field.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -6577,17 +6563,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/QualificationSingleResponse'
         '401':
-          description: Unauthenticated.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing `qualification.write` or create denied.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -6625,15 +6603,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/QualificationSingleResponse'
         '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Unknown id, invalid UUID, or not visible to the current tenant binding rules.
           content:
@@ -6682,17 +6654,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/QualificationSingleResponse'
         '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing `qualification.write`, policy denied, or system qualification.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
+          description: Qualification not found.
           content:
             application/json:
               schema:
@@ -6729,16 +6695,11 @@ paths:
         '204':
           description: Qualification soft-deleted
         '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
+          description: Qualification not found.
           content:
             application/json:
               schema:
@@ -6779,21 +6740,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeQualificationCollectionResponse'
         '401':
-          description: Unauthenticated — **no** `code` field; see `SimpleMessageResponse`.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing `employee_qualification.read`, policy denied, or organizational scope blocked.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Unknown employee id or out-of-scope implicit binding (**404** `Resource not found.`).
           content:
@@ -6842,21 +6791,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeQualificationSingleResponse'
         '401':
-          description: Unauthenticated — **no** `code` field.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing permission or organizational scope denied.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Employee not found for tenant binding.
           content:
@@ -6913,21 +6850,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeQualificationSingleResponse'
         '401':
-          description: Unauthenticated — **no** `code` field.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Caller cannot view this assignment (permission / scope).
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Invalid UUID format or pivot outside tenant binding (`EmployeeQualificationControllerTest`).
           content:
@@ -6976,21 +6901,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeQualificationSingleResponse'
         '401':
-          description: Unauthenticated — **no** `code` field.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing permission or organizational scope denied.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Unknown pivot id or binding failure.
           content:
@@ -7029,21 +6942,9 @@ paths:
         '204':
           description: Pivot removed
         '401':
-          description: Unauthenticated — **no** `code` field.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '403':
-          description: Missing permission or organizational scope denied.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
+          $ref: '#/components/responses/SimpleForbidden'
         '404':
           description: Unknown pivot id or binding failure.
           content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6658,11 +6658,15 @@ paths:
         '403':
           $ref: '#/components/responses/SimpleForbidden'
         '404':
-          description: Qualification not found.
+          description: Unknown id, invalid UUID, or not visible to the current tenant binding rules.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleMessageResponse'
+              examples:
+                notFound:
+                  value:
+                    message: Resource not found.
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -6699,11 +6703,15 @@ paths:
         '403':
           $ref: '#/components/responses/SimpleForbidden'
         '404':
-          description: Qualification not found.
+          description: Unknown id, invalid UUID, or not visible to the current tenant binding rules.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleMessageResponse'
+              examples:
+                notFound:
+                  value:
+                    message: Resource not found.
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
## Problem / validation signal

There was no failing Redocly rule or broken runtime contract: the spec already validated. The defect is **schema hygiene and drift risk** called out in GitHub issue #234 (Copilot review on PR #232): qualification catalog and employee-qualification operations duplicated inline `401` / `403` bodies that only referenced `#/components/schemas/SimpleMessageResponse`, instead of reusing the existing shared `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` components.

## What changed

- `docs/openapi.yaml`: for the qualification catalog (`GET`/`POST` `/qualifications`, `GET`/`PATCH`/`DELETE` `/qualifications/{qualification}`) and employee-qualification surfaces (`GET`/`POST` `/employees/{employee}/qualifications`, `GET`/`PATCH`/`DELETE` `/employee-qualifications/{employeeQualification}`), replaced duplicated inline `401` / `403` response objects with `$ref` to the shared simple-message response components. **404**, **409**, and other message-only responses that are not the shared auth pair stay inline with operation-specific descriptions/examples.
- `CHANGELOG.md`: recorded the change under `[Unreleased]` → **Changed**.

## Validations already run (local)

- `npm ci` (local `node_modules` was stale vs lockfile; prevalidate required a refresh).
- `npm run validate` (`redocly lint` + verified-endpoint guard + Prettier check) — **green**.

## Out-of-scope follow-up (tracked)

- Remaining inline `SimpleMessageResponse` usage on some **auth** routes (e.g. `POST` `/auth/email/verification-notification` `401`/`429`, and logout success payloads) is **not** part of #234. Filed separately: https://github.com/SecPal/contracts/issues/259

## Workspaces / checks

- Changes authored in Polyscope workspace clone: `/home/secpal/.polyscope/clones/7d9ca942/lucky-toad` (contracts). No linked API/frontend workspace edits.
- **GitHub Actions** on this PR were not re-run from this environment after push; please wait for CI before marking the PR ready for review.

## Review note (draft)

This PR is opened as a **draft** per repo policy. It should only be marked ready after a final self-review in the PR UI with zero remaining issues.

Closes #234.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates OpenAPI response component references and clarifies `404` examples/descriptions without affecting runtime behavior.
> 
> **Overview**
> Updates `docs/openapi.yaml` for qualification catalog and employee-qualification assignment endpoints to replace duplicated inline `401`/`403` response bodies with `$ref` reuse of `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden`.
> 
> Also aligns `PATCH` and `DELETE` `/qualifications/{qualification}` `404` descriptions/examples with the tenant-aware route-binding semantics already documented on `GET`, and records the change in `CHANGELOG.md` under **Unreleased → Changed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3172b60ea0caf15eebee1c38ecefad0322ef051d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->