### PR TITLE
OpenAPI: reuse Simple* responses on email verification notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored `POST /auth/email/verification-notification` `401` and `429` responses in `docs/openapi.yaml` to reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleTooManyRequests` instead of duplicating inline `SimpleMessageResponse` blocks (closes #259)
 - Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks; aligned `PATCH` and `DELETE` `/qualifications/{qualification}` `404` descriptions and examples with the same tenant-aware route-binding semantics documented for `GET` on that path (closes #234)
 
 ### Fixed

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5146,25 +5146,9 @@ paths:
                   value:
                     message: Verification link sent successfully.
         '401':
-          description: Missing or invalid Sanctum session or bearer token.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                unauthenticated:
-                  value:
-                    message: Unauthenticated.
+          $ref: '#/components/responses/SimpleUnauthorized'
         '429':
-          description: Per-route throttle exceeded (`throttle:6,1`).
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleMessageResponse'
-              examples:
-                throttled:
-                  value:
-                    message: Too Many Attempts.
+          $ref: '#/components/responses/SimpleTooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
## Summary

Reuses the shared `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleTooManyRequests` components for `POST /auth/email/verification-notification` instead of duplicating inline `SimpleMessageResponse` blocks, matching the DRY pattern used for qualification routes.

## Changelog

- [Unreleased] `### Changed` entry added.

Closes https://github.com/SecPal/contracts/issues/259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that deduplicates error response definitions without altering endpoint behavior or schemas.
> 
> **Overview**
> Updates `docs/openapi.yaml` for `POST /auth/email/verification-notification` to replace the inline `401` and `429` response bodies with `$ref` links to the shared `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleTooManyRequests` components.
> 
> Adds a corresponding `[Unreleased]` changelog entry noting the refactor (closes #259).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d79e3722432278826102b9a5d9ec22b5d61f98b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->