### PR TITLE
OpenAPI: auto-discover Redocly health lint config

### DIFF
--- a/.github/instructions/openapi.instructions.md
+++ b/.github/instructions/openapi.instructions.md
@@ -13,4 +13,5 @@ applyTo: 'docs/openapi.yaml'
 - Keep response coverage complete for success and applicable error states.
 - Maintain consistent security schemes, examples, naming, and reusable parameters.
 - Treat breaking changes as versioned API changes and document them in `CHANGELOG.md`.
-- Run the relevant Redocly validation and formatting after edits.
+- Run the relevant Redocly validation and formatting after edits (`npm run lint` from the repo root; it uses `redocly.yaml`).
+- `GET /health` documents `200` and `503` only; `operation-4xx-response` is disabled in `redocly.yaml` because health checks have no applicable client-error responses.

--- a/.github/instructions/openapi.instructions.md
+++ b/.github/instructions/openapi.instructions.md
@@ -13,5 +13,7 @@ applyTo: 'docs/openapi.yaml'
 - Keep response coverage complete for success and applicable error states.
 - Maintain consistent security schemes, examples, naming, and reusable parameters.
 - Treat breaking changes as versioned API changes and document them in `CHANGELOG.md`.
-- Run the relevant Redocly validation and formatting after edits (`npm run lint` from the repo root; it uses `redocly.yaml`).
-- `GET /health` documents `200` and `503` only; `operation-4xx-response` is disabled in `redocly.yaml` because health checks have no applicable client-error responses.
+- Run the relevant Redocly validation and formatting after edits (`npm run lint` from the repo root; it uses
+  `redocly.yaml`).
+- `GET /health` documents `200` and `503` only; `operation-4xx-response` is disabled in `redocly.yaml` because
+  health checks have no applicable client-error responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `.redocly.yaml` to `redocly.yaml` so the Redocly CLI auto-discovers the configuration file when `npm run lint` or `npx @redocly/cli lint` runs from the repository root; removed the explicit `--config .redocly.yaml` flag from the `lint` script in `package.json`; updated `README.md` and `.github/instructions/openapi.instructions.md` to document the auto-discovery behaviour and the rationale for disabling `operation-4xx-response` on `GET /health`
 - Refactored `POST /auth/email/verification-notification` `401` and `429` responses in `docs/openapi.yaml` to reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleTooManyRequests` instead of duplicating inline `SimpleMessageResponse` blocks (closes #259)
 - Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks; aligned `PATCH` and `DELETE` `/qualifications/{qualification}` `404` descriptions and examples with the same tenant-aware route-binding semantics documented for `GET` on that path (closes #234)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ To validate the OpenAPI specification locally, run:
 npm run lint
 ```
 
-This uses `@redocly/cli` to lint the `docs/openapi.yaml` file against the configured rules.
+This uses `@redocly/cli` to lint `docs/openapi.yaml` against the repository rules in `redocly.yaml` (auto-discovered when lint runs from the repo root).
+
+To lint directly with the CLI instead of `npm run lint`, run from the repository root so `redocly.yaml` is picked up:
+
+```bash
+npx @redocly/cli lint docs/openapi.yaml
+```
+
+`GET /health` documents `200` and `503` only. Redocly's recommended `operation-4xx-response` rule expects a `4XX` response on every operation, but health checks accept no input and do not produce client errors. That rule is disabled in `redocly.yaml`; without that config file, standalone lint reports a warning on `#/paths/~1health/get/responses`.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prevalidate": "bash scripts/check-redocly-cli-sync.sh",
-    "lint": "redocly lint docs/openapi.yaml --config .redocly.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
+    "lint": "redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
     "validate": "npm run lint && prettier --check '**/*.{md,yml,yaml,json}'"

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,7 +1,10 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 #
 # Redocly Configuration for SecPal API
+#
+# This file is named `redocly.yaml` so the Redocly CLI auto-discovers it when
+# lint runs from the repository root (for example `npx @redocly/cli lint docs/openapi.yaml`).
 #
 # Rules customization:
 # - operation-4xx-response: Disabled for health/monitoring endpoints.


### PR DESCRIPTION
## Summary
- Failing reproduction: `npx @redocly/cli lint docs/openapi.yaml` from the repository root warned on `#/paths/~1health/get/responses` with `operation-4xx-response` because Redocly auto-discovers `redocly.yaml`, not `.redocly.yaml`.
- Rename `.redocly.yaml` to `redocly.yaml`, remove the now-unnecessary explicit `--config .redocly.yaml` from `package.json`, and document the auto-discovery and `GET /health` exception in `README.md` and `.github/instructions/openapi.instructions.md`.
- `GET /health` already documents the applicable non-2xx response (`503`), so this change fixes the standalone lint workflow without inventing a fake `4XX` contract response.

## Validation
- Reproduced the warning before the fix with `npx @redocly/cli lint docs/openapi.yaml`.
- Ran `npm ci` after the repo prevalidation guard reported a stale local `@redocly/cli` install (`2.30.4` vs lockfile `2.30.6`).
- Ran `npm run validate`.
- Ran `npx @redocly/cli lint docs/openapi.yaml`.
- Ran `reuse lint`.

## Ready Checklist
- Linked workspaces used: none.
- Unresolved before marking ready: wait for GitHub Actions to finish and perform the final PR-view self-review; this PR must stay draft until both are clean.

Closes #263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/tooling change that only affects how OpenAPI linting discovers Redocly configuration and suppresses a health-check lint rule.
> 
> **Overview**
> Updates the Redocly lint workflow to rely on CLI auto-discovery by renaming `.redocly.yaml` to `redocly.yaml` and removing the explicit `--config` flag from the `npm run lint` script.
> 
> Documents the linting expectations and the `GET /health` exception (no `4xx` responses) in `README.md` and `.github/instructions/openapi.instructions.md`, and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef0a9c45f38c4a18bda6215a29f840281f0647c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->