### PR TITLE
OpenAPI: remove dead Redocly struct override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the dead `struct: off` rule override from `redocly.yaml`; all `nullable: true` fields have been migrated to OpenAPI 3.1 union-type syntax, so the `struct` rule can enforce schema consistency again (closes #265)
 - Renamed `.redocly.yaml` to `redocly.yaml` so the Redocly CLI auto-discovers the configuration file when `npm run lint` or `npx @redocly/cli lint` runs from the repository root; removed the explicit `--config .redocly.yaml` flag from the `lint` script in `package.json`; updated `README.md` and `.github/instructions/openapi.instructions.md` to document the auto-discovery behaviour and the rationale for disabling `operation-4xx-response` on `GET /health`
 - Refactored `POST /auth/email/verification-notification` `401` and `429` responses in `docs/openapi.yaml` to reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleTooManyRequests` instead of duplicating inline `SimpleMessageResponse` blocks (closes #259)
 - Refactored qualification catalog and employee-qualification assignment operations in `docs/openapi.yaml` so HTTP `401` and `403` message-only Laravel bodies reuse `#/components/responses/SimpleUnauthorized` and `#/components/responses/SimpleForbidden` instead of duplicating inline `SimpleMessageResponse` blocks; aligned `PATCH` and `DELETE` `/qualifications/{qualification}` `404` descriptions and examples with the same tenant-aware route-binding semantics documented for `GET` on that path (closes #234)

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -26,4 +26,3 @@ extends:
 
 rules:
   operation-4xx-response: off
-  struct: off # Allow nullable property (OpenAPI 3.0 compatibility)


### PR DESCRIPTION
## Reproduced defect

`docs/openapi.yaml` no longer contains any `nullable: true` fields, but `redocly.yaml` still disabled the Redocly `struct` rule with an outdated OpenAPI 3.0 compatibility comment. That dead override would mask future regressions back to `nullable: true`.

## Current change

- Remove the dead `struct: off` override and its stale compatibility comment from `redocly.yaml`.
- Update `CHANGELOG.md` under `[Unreleased]` to document the cleanup.

Closes #265.

## Validation already run

- `npm ci`
- `npm run validate`

## Before marking ready

- Linked workspaces used for this change: none.
- Unresolved checks: GitHub Actions for this branch have not run yet in the draft PR view.
- Final self-review in the PR view must still confirm zero issues before converting this draft PR to ready for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/documentation-only change that tightens linting by re-enabling the Redocly `struct` rule; potential impact is limited to surfacing new lint failures in future/spec changes.
> 
> **Overview**
> Removes the outdated `struct: off` override from `redocly.yaml`, re-enabling Redocly’s `struct` rule now that the spec no longer relies on OpenAPI 3.0 `nullable: true` compatibility.
> 
> Updates `CHANGELOG.md` to record the linting cleanup (closes #265).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf21102796c0ef81384d043d585c1a4fd74ec94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->