### PR TITLE
OpenAPI: remove qualification document_path (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed `document_path` from `AttachQualificationRequest`, `UpdateEmployeeQualificationRequest`, and `EmployeeQualificationResource`; the API stores certificate files at an internal storage path (`employee_qualifications.document_path`) that must not be exposed to consumers, consistent with `EmployeeDocumentResource` omitting `file_path` (closes #233)
 - Migrated all `nullable: true` fields in the `Activity` component schema and the `verifyActivityLog` response `details` inline object to OpenAPI 3.1 union-type syntax (`type: [T, 'null']`); extracted the `details` object into the reusable `ActivityVerificationDetails` component schema to eliminate inline duplication (`docs/openapi.yaml`)
 - Corrected onboarding submission contract consistency in `docs/openapi.yaml`: replaced duplicated inline `form_data` objects with shared `OnboardingSubmissionFormData`, removed contradictory tax-ID-only `anyOf` modeling that could be bypassed, and enforced that `PATCH /onboarding/submissions/{submission}` requires `form_data` when `status` is set to `submitted`
 - Documented the onboarding upload `document_subtype` requirement for `id_document` attachments in `docs/openapi.yaml`, including explicit subtype enums, request examples, and the dedicated `422` validation response for missing subtype payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed `document_path` from `AttachQualificationRequest`, `UpdateEmployeeQualificationRequest`, and `EmployeeQualificationResource`; the API stores certificate files at an internal storage path (`employee_qualifications.document_path`) that must not be exposed to consumers, consistent with `EmployeeDocumentResource` omitting `file_path` (closes #233)
+- Removed `document_path` from `AttachQualificationRequest`, `UpdateEmployeeQualificationRequest`, and `EmployeeQualificationResource`; the API stores certificate files at an internal storage path that must not be exposed to consumers, consistent with `EmployeeDocumentResource` omitting `file_path` (closes #233)
 - Migrated all `nullable: true` fields in the `Activity` component schema and the `verifyActivityLog` response `details` inline object to OpenAPI 3.1 union-type syntax (`type: [T, 'null']`); extracted the `details` object into the reusable `ActivityVerificationDetails` component schema to eliminate inline duplication (`docs/openapi.yaml`)
 - Corrected onboarding submission contract consistency in `docs/openapi.yaml`: replaced duplicated inline `form_data` objects with shared `OnboardingSubmissionFormData`, removed contradictory tax-ID-only `anyOf` modeling that could be bypassed, and enforced that `PATCH /onboarding/submissions/{submission}` requires `form_data` when `status` is set to `submitted`
 - Documented the onboarding upload `document_subtype` requirement for `id_document` attachments in `docs/openapi.yaml`, including explicit subtype enums, request examples, and the dedicated `422` validation response for missing subtype payloads

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -834,9 +834,6 @@ components:
         notes:
           type: [string, 'null']
           maxLength: 1000
-        document_path:
-          type: [string, 'null']
-          maxLength: 255
         status:
           description: Optional; server defaults to `valid` when omitted (`EmployeeQualificationController::store`).
           anyOf:
@@ -867,9 +864,6 @@ components:
         notes:
           type: [string, 'null']
           maxLength: 1000
-        document_path:
-          type: [string, 'null']
-          maxLength: 255
         status:
           anyOf:
             - $ref: '#/components/schemas/EmployeeQualificationStatus'
@@ -879,6 +873,9 @@ components:
       type: object
       description: |
         Pivot row returned by `EmployeeQualificationResource`.
+
+        Responses never include the internal certificate storage path (`document_path` on the model is omitted), consistent with
+        `EmployeeDocumentResource` omitting `file_path`. Certificate file upload and download are not yet part of this contract surface.
 
         `qualification` is included when that relation is eager-loaded (list, show, create, and update responses load it where applicable).
         `employee` is included when loaded (list and show paths); create/update responses may omit it when not loaded.
@@ -911,8 +908,6 @@ components:
         issuing_authority:
           type: [string, 'null']
         notes:
-          type: [string, 'null']
-        document_path:
           type: [string, 'null']
         status:
           $ref: '#/components/schemas/EmployeeQualificationStatus'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -874,7 +874,7 @@ components:
       description: |
         Pivot row returned by `EmployeeQualificationResource`.
 
-        Responses never include the internal certificate storage path (`document_path` on the model is omitted), consistent with
+        Responses never include an internal certificate storage path, consistent with
         `EmployeeDocumentResource` omitting `file_path`. Certificate file upload and download are not yet part of this contract surface.
 
         `qualification` is included when that relation is eager-loaded (list, show, create, and update responses load it where applicable).


### PR DESCRIPTION
## Reproduced defect

While tracing SecPal/contracts#233 back to the implementation, I confirmed that the API currently maps `document_path` directly to `employee_qualifications.document_path`, which is described in the migration as a storage path for uploaded certificate files. The contracts PR from #232 therefore exposed an internal storage path in public request and response schemas.

## Current change

- remove `document_path` from `AttachQualificationRequest`
- remove `document_path` from `UpdateEmployeeQualificationRequest`
- remove `document_path` from `EmployeeQualificationResource`
- document on `EmployeeQualificationResource` that the internal storage path is intentionally omitted, consistent with `EmployeeDocumentResource`
- add the contract changelog entry for the fix

Closes #233.

## Validation already run

- `npm run lint`

## Linked follow-up before marking ready

- Linked workspace checked: `SecPal/api (peaceful-toad)`
- Out-of-scope implementation follow-up is now tracked in SecPal/api#1055 because the API repo still accepts and returns `document_path`
- This PR is contract-only; before marking it ready, confirm the implementation alignment plan for the API follow-up and verify there are no additional contract-review findings in the PR view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a contract-breaking change for any clients sending or reading `document_path`, but it reduces information leakage by removing an internal storage path from public request/response schemas.
> 
> **Overview**
> Removes `document_path` from the OpenAPI schemas for `AttachQualificationRequest`, `UpdateEmployeeQualificationRequest`, and `EmployeeQualificationResource` so the contract no longer exposes an internal certificate storage path.
> 
> Updates `EmployeeQualificationResource` documentation to explicitly state the storage path is intentionally omitted (consistent with `EmployeeDocumentResource`), and adds a corresponding `CHANGELOG.md` fix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9b35986f782d49a28a0e557f785f7488c2986b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->