### PR TITLE
docs: clarify RBAC coverage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The contract file `docs/openapi.yaml` is the source of truth. It documents a lar
 
 - Health-related paths (for example `GET /health`) appear in the spec as deployed.
 
-Some backend-only or admin-heavy routes (for example RBAC role and permission administration under `/v1/roles` and `/v1/permissions`) are described in the API repository ([`SecPal/api` docs](https://github.com/SecPal/api)) and may not yet appear in OpenAPI — compare with `routes/api.php` when auditing coverage.
+Some backend-only or admin-heavy routes (for example RBAC role administration under `/v1/roles` and direct user-permission administration under `/v1/users/{user}/permissions*`) are described in the API repository ([`SecPal/api` docs](https://github.com/SecPal/api)) and may not yet appear in OpenAPI — compare with `routes/api.php` when auditing coverage.
 
 _See `docs/openapi.yaml` for paths, operations, and schemas._
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ SecPal is the operations software for German private security services. This rep
 
 The contract file `docs/openapi.yaml` is the source of truth. It documents a large portion of the live `/v1` surface, including authentication and session flows, self-service (`/me`), employees (including nested qualifications and documents), the qualification catalog, customers, sites, assignments, onboarding, activity logs, Android enrollment/release metadata, and more.
 
-**Monitoring:**
-
-- Health-related paths (for example `GET /health`) appear in the spec as deployed.
-
-Some backend-only or admin-heavy routes (for example RBAC role administration under `/v1/roles` and direct user-permission administration under `/v1/users/{user}/permissions*`) are described in the API repository ([`SecPal/api` docs](https://github.com/SecPal/api)) and may not yet appear in OpenAPI — compare with `routes/api.php` when auditing coverage.
+- **Monitoring:** Health-related paths (for example `GET /health`) appear in the spec as deployed.
+- **Coverage:** Some backend-only or admin-heavy routes — for example RBAC role administration under `/v1/roles` and direct user-permission administration under `/v1/users/{user}/permissions` and `/v1/users/{user}/permissions/direct` — are described in the API repository ([`SecPal/api` docs](https://github.com/SecPal/api)) and may not yet appear in OpenAPI; compare with `routes/api.php` when auditing coverage.
 
 _See `docs/openapi.yaml` for paths, operations, and schemas._
 


### PR DESCRIPTION
## Failing Check / Reproduced Defect

Cross-checking the README coverage note against the linked `SecPal/api` workspace showed the current wording points auditors at `/v1/permissions`, but the API routes define direct permission administration under `/v1/users/{user}/permissions` and `/v1/users/{user}/permissions/direct`.

Evidence checked:
- `SecPal/api` linked workspace: `routes/api.php`
- `SecPal/api` linked workspace: `docs/rbac-architecture.md`

## Change

Updates the README coverage note so it distinguishes:
- RBAC role administration under `/v1/roles`
- direct user-permission administration under `/v1/users/{user}/permissions*`

This keeps the branch to one documentation topic and does not change `docs/openapi.yaml` schemas, response shapes, security schemes, or examples.

## Validation

- `git diff --check origin/main...HEAD`
- `npm ci`
- `npm run validate`
- `npm audit --audit-level=moderate` was run; the existing moderate `brace-expansion`/`minimatch` finding is out of scope and tracked immediately as #275.

## Linked Workspaces

- `SecPal/api` (`/home/secpal/.polyscope/clones/47d112dd/snowy-eagle`) was used to verify the route names and RBAC documentation.

## Before Ready

- Keep this PR draft until the GitHub PR view self-review finds zero issues.
- Confirm CI after GitHub runs it.
- Do not mark ready while #275 is confused with this README-only scope; it remains separate dependency-maintenance work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates endpoint references in the README; no contract/spec or runtime behavior changes.
> 
> **Overview**
> Clarifies the README’s endpoint coverage notes by collapsing the monitoring section into a single bullet and correcting the RBAC coverage guidance.
> 
> Specifically, it now distinguishes role administration under `/v1/roles` from direct user-permission administration under `/v1/users/{user}/permissions` and `/v1/users/{user}/permissions/direct`, and points auditors to compare against `routes/api.php` when checking OpenAPI completeness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb47cf64490d069145fed1a3f77a7628ca232654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->