### PR TITLE
docs: document public API release metadata contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Documented the public `GET /release` contract in `docs/openapi.yaml`, including the narrow deployed API release response (`version` plus immutable `source_url`), the shared source-offer throttle `429` message-only response shape, and the explicit `500 RELEASE_STATE_INVALID` fail-closed shape for incomplete deployment metadata, so frontend and other clients can discover the active backend release without widening the existing public bootstrap contract surface
+
 ### Changed
 
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Documented the public `GET /release` contract in `docs/openapi.yaml`, including the narrow deployed API release response (`version` plus immutable `source_url`), the shared source-offer throttle `429` message-only response shape, and the explicit `500 RELEASE_STATE_INVALID` fail-closed shape for incomplete deployment metadata, so frontend and other clients can discover the active backend release without widening the existing public bootstrap contract surface
+- Documented the public `GET /release` contract in `docs/openapi.yaml`, including the narrow deployed API release response (`version` plus immutable `source_url`), the tightened absolute `http`/`https` `source_url` constraint that fails closed for invalid localhost or userinfo metadata, the shared source-offer throttle `429` message-only response shape, and the explicit `500 RELEASE_STATE_INVALID` fail-closed shape for incomplete deployment metadata, so frontend and other clients can discover the active backend release without widening the existing public bootstrap contract surface
 
 ### Changed
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4713,6 +4713,73 @@ components:
         data:
           $ref: '#/components/schemas/BootstrapConfiguration'
 
+    ApiReleaseMetadata:
+      type: object
+      description: |
+        Narrow public deployment metadata returned by `GET /release`.
+
+        This document is intentionally smaller than the bootstrap contract. It exists so clients can identify
+        the currently deployed API release and fetch the immutable corresponding-source archive for that exact
+        backend release without exposing broader runtime diagnostics.
+      additionalProperties: false
+      required:
+        - version
+        - source_url
+      properties:
+        version:
+          type: string
+          maxLength: 255
+          description: Deployment-defined identifier for the currently active API release.
+          example: api-2026-07-03
+        source_url:
+          type: string
+          format: uri
+          description: Immutable corresponding-source archive URL for the currently active API release.
+          example: 'https://github.com/SecPal/api/releases/download/api-2026-07-03/source.tar.gz'
+
+    ApiReleaseResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/ApiReleaseMetadata'
+
+    ReleaseStateInvalidDetails:
+      type: object
+      description: Structured detail fields for an invalid public API release configuration response.
+      additionalProperties: false
+      required:
+        - missing_fields
+      properties:
+        missing_fields:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+            - api_release.version
+            - api_release.source_url
+
+    ReleaseStateInvalidError:
+      type: object
+      additionalProperties: false
+      required:
+        - message
+        - code
+        - details
+      properties:
+        message:
+          type: string
+          example: Public API release metadata is incomplete for this deployment.
+        code:
+          type: string
+          enum:
+            - RELEASE_STATE_INVALID
+        details:
+          $ref: '#/components/schemas/ReleaseStateInvalidDetails'
+
     BootstrapStateInvalidDetails:
       type: object
       description: Structured detail fields for an invalid bootstrap configuration response.
@@ -5536,6 +5603,23 @@ components:
                 details:
                   retryable: true
                   retry_after_seconds: 60
+
+    ReleaseStateInvalid:
+      description: Internal Server Error - public API release metadata is enabled but deployment configuration is internally inconsistent.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReleaseStateInvalidError'
+          examples:
+            missingRequiredReleaseFields:
+              summary: Deployment-local API release metadata is enabled but incomplete.
+              value:
+                message: Public API release metadata is incomplete for this deployment.
+                code: RELEASE_STATE_INVALID
+                details:
+                  missing_fields:
+                    - api_release.version
+                    - api_release.source_url
 
   securitySchemes:
     BearerAuth:
@@ -10844,6 +10928,44 @@ paths:
           $ref: '#/components/responses/BootstrapStateInvalid'
         '503':
           $ref: '#/components/responses/BootstrapConfigurationUnavailable'
+
+  /release:
+    get:
+      summary: Get Public API Release Metadata
+      description: |
+        Returns the narrow public release-metadata document for the currently deployed SecPal API instance.
+
+        Clients use this endpoint to identify the active API release and retrieve the immutable corresponding-source
+        archive URL for that exact backend release. The response intentionally stays smaller than `GET /bootstrap`
+        and does not expose deployment display names, feature flags, schema negotiation data, or broader diagnostics.
+
+        Under SecPal's current `0.x` policy, clients must consume this canonical response shape and should not assume
+        undocumented aliases, fallback keys, or extra release metadata fields survive.
+
+        **Rate limiting:** This route uses the shared `source-offer` throttle bucket. When exceeded, Laravel returns
+        HTTP 429 with a JSON body that contains only `message`, not the richer reusable `Error` shape.
+      operationId: getPublicApiRelease
+      tags:
+        - Bootstrap
+      security: []
+      responses:
+        '200':
+          description: Public API release metadata returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiReleaseResponse'
+              examples:
+                deployedApiRelease:
+                  summary: Public client receives the active API release identifier and immutable corresponding-source URL.
+                  value:
+                    data:
+                      version: api-2026-07-03
+                      source_url: 'https://github.com/SecPal/api/releases/download/api-2026-07-03/source.tar.gz'
+        '429':
+          $ref: '#/components/responses/SimpleTooManyRequests'
+        '500':
+          $ref: '#/components/responses/ReleaseStateInvalid'
 
   /android/channels/{channel}/latest.json:
     get:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4734,7 +4734,8 @@ components:
         source_url:
           type: string
           format: uri
-          description: Immutable corresponding-source archive URL for the currently active API release.
+          pattern: '^https?://(?![^/?#]*@)(?!localhost(?:[/:?#]|$))[^\s]+$'
+          description: Immutable corresponding-source archive URL for the currently active API release. Only absolute `http` or `https` URLs are valid; `localhost` hosts and URI userinfo are treated as invalid deployment metadata and fail closed.
           example: 'https://github.com/SecPal/api/releases/download/api-2026-07-03/source.tar.gz'
 
     ApiReleaseResponse:


### PR DESCRIPTION
## Why

Reproduced defect: the linked `SecPal/api` workspace already implements public `GET /v1/release`, and the linked `SecPal/frontend` workspace already consumes `GET /v1/release` for the source-offer flow, but this contracts repo did not yet publish that endpoint or its fail-closed error semantics in `docs/openapi.yaml`.

## What Changed

- added reusable `ApiReleaseMetadata`, `ApiReleaseResponse`, and `ReleaseStateInvalid*` schemas in `docs/openapi.yaml:4716`
- documented public `GET /release` in `docs/openapi.yaml:10932` with:
  - unauthenticated `200` response carrying only `data.version` and `data.source_url`
  - shared source-offer throttle `429` using the existing simple message-only response shape
  - explicit `500 RELEASE_STATE_INVALID` response for incomplete deployment metadata
- recorded the contract addition in `CHANGELOG.md:15`

## Validation

- `npm run lint`
- `git diff --check`
- verified the commit is GPG-signed

## Linked Workspaces And Draft Follow-Up

- SecPal/api PR #1218 implements the route and tests the behavior this contract now documents: https://github.com/SecPal/api/pull/1218
- SecPal/frontend PR #1315 consumes `GET /v1/release` for the deployed source-offer page: https://github.com/SecPal/frontend/pull/1315
- no extra out-of-scope findings were identified in this contracts-only scope
- keep this PR as draft until the final PR-view self-review confirms zero issues and the linked workspace changes are ready for coordinated review
