### PR TITLE
fix: add contract test entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `npm test` as the standard contract-test entry point; it runs the repository's canonical lint and formatting validation pipeline (closes #339).
 - Documented the public `GET /release` contract in `docs/openapi.yaml`, including the narrow deployed API release response (`version` plus immutable `source_url`), the tightened absolute `http`/`https` `source_url` constraint that fails closed for invalid localhost or userinfo metadata, the shared source-offer throttle `429` message-only response shape, and the explicit `500 RELEASE_STATE_INVALID` fail-closed shape for incomplete deployment metadata, so frontend and other clients can discover the active backend release without widening the existing public bootstrap contract surface
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -71,7 +71,19 @@ npm install
 
 ### Validation
 
-To validate the OpenAPI specification locally, run:
+Run the standard contract-test entry point:
+
+```bash
+npm test
+```
+
+This runs the repository's complete contract validation pipeline: OpenAPI linting, verified-endpoint checks, and formatting checks. To run the same pipeline explicitly, use:
+
+```bash
+npm run validate
+```
+
+To run only the OpenAPI lint and verified-endpoint checks, use:
 
 ```bash
 npm run lint

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
+    "test": "npm run validate",
     "validate": "npm run lint && prettier --check '**/*.{md,yml,yaml,json}'"
   },
   "devDependencies": {


### PR DESCRIPTION
## Reproduced defect

Before this change, `npm test` failed with `Missing script: "test"`, so the standard validation checklist could not invoke a contract-test entry point.

## Change

- Add `npm test` as an alias for the canonical `npm run validate` contract-validation pipeline.
- Document the standard and explicit validation commands in `README.md`.
- Record the entry point in `CHANGELOG.md`.

## Validation

- `npm test`
- Markdown lint for `README.md` and `CHANGELOG.md`
- `reuse lint`
- `git diff --check`
- Push preflight, including OpenAPI lint, endpoint coverage, formatting, REUSE, domain-policy validation, and `npm test`

## Follow-up before ready

- Linked workspaces: none.
- Local preflight intentionally skips actionlint; it remains a CI check. No other unresolved checks were found.

Closes #339
