### PR TITLE
fix: declare PR-size permissions

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   pr-size:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Declared the least-privilege `contents: read` and `pull-requests: read` token permissions for the PR-size reusable-workflow caller and added a validation guard that rejects either scope being removed (closes #337)
 - Updated `scripts/preflight.sh` to run `npm ci` before the repo-local `node_modules/.bin/markdownlint` check when the pinned markdownlint toolchain is not installed yet, so fresh clones and post-lockfile updates can bootstrap validation successfully again
 - Removed `document_path` from `AttachQualificationRequest`, `UpdateEmployeeQualificationRequest`, and `EmployeeQualificationResource`; the API stores certificate files at an internal storage path that must not be exposed to consumers, consistent with `EmployeeDocumentResource` omitting `file_path` (closes #233)
 - Migrated all `nullable: true` fields in the `Activity` component schema and the `verifyActivityLog` response `details` inline object to OpenAPI 3.1 union-type syntax (`type: [T, 'null']`); extracted the `details` object into the reusable `ActivityVerificationDetails` component schema to eliminate inline duplication (`docs/openapi.yaml`)

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
-    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node --test scripts/check-pr-size-workflow.test.mjs",
-    "lint": "redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
+    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
+    "lint": "node --test scripts/check-pr-size-workflow.test.mjs && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
     "validate": "npm run lint && prettier --check '**/*.{md,yml,yaml,json}'"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
-    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node scripts/check-pr-size-workflow.mjs",
+    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node --test scripts/check-pr-size-workflow.test.mjs",
     "lint": "redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
-    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
+    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node scripts/check-pr-size-workflow.mjs",
     "lint": "redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import { readFileSync } from "node:fs";
+import * as yaml from "js-yaml";
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+const workflowPath = new URL(
+  "../.github/workflows/pr-size.yml",
+  import.meta.url,
+);
+
+let workflow;
+try {
+  workflow = yaml.load(readFileSync(workflowPath, "utf8"), {
+    schema: yaml.JSON_SCHEMA,
+  });
+} catch (error) {
+  fail(`could not parse .github/workflows/pr-size.yml: ${error}`);
+}
+
+const expectedPermissions = {
+  contents: "read",
+  "pull-requests": "read",
+};
+
+if (!workflow?.permissions || typeof workflow.permissions !== "object") {
+  fail(".github/workflows/pr-size.yml must define top-level permissions.");
+}
+
+for (const [scope, access] of Object.entries(expectedPermissions)) {
+  if (workflow.permissions[scope] !== access) {
+    fail(
+      `.github/workflows/pr-size.yml permissions.${scope} must be ${access}.`,
+    );
+  }
+}
+
+console.log("PR-size workflow permission guard OK.");

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -10,10 +10,9 @@ function fail(message) {
   process.exit(1);
 }
 
-const workflowPath = new URL(
-  "../.github/workflows/pr-size.yml",
-  import.meta.url,
-);
+const workflowPath = process.argv[2]
+  ? new URL(process.argv[2], `file://${process.cwd()}/`)
+  : new URL("../.github/workflows/pr-size.yml", import.meta.url);
 
 let workflow;
 try {
@@ -31,6 +30,15 @@ const expectedPermissions = {
 
 if (!workflow?.permissions || typeof workflow.permissions !== "object") {
   fail(".github/workflows/pr-size.yml must define top-level permissions.");
+}
+
+if (
+  Object.keys(workflow.permissions).length !==
+  Object.keys(expectedPermissions).length
+) {
+  fail(
+    ".github/workflows/pr-size.yml must define exactly the required permissions.",
+  );
 }
 
 for (const [scope, access] of Object.entries(expectedPermissions)) {

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -49,10 +49,12 @@ for (const [scope, access] of Object.entries(expectedPermissions)) {
   }
 }
 
-if (Object.hasOwn(workflow?.jobs?.["pr-size"] ?? {}, "permissions")) {
-  fail(
-    ".github/workflows/pr-size.yml jobs.pr-size must not override permissions.",
-  );
+for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
+  if (job && typeof job === "object" && Object.hasOwn(job, "permissions")) {
+    fail(
+      `.github/workflows/pr-size.yml jobs.${jobName} must not override permissions.`,
+    );
+  }
 }
 
 console.log("PR-size workflow permission guard OK.");

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -49,4 +49,10 @@ for (const [scope, access] of Object.entries(expectedPermissions)) {
   }
 }
 
+if (Object.hasOwn(workflow?.jobs?.["pr-size"] ?? {}, "permissions")) {
+  fail(
+    ".github/workflows/pr-size.yml jobs.pr-size must not override permissions.",
+  );
+}
+
 console.log("PR-size workflow permission guard OK.");

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -54,12 +54,25 @@ for (const [name, permissions] of [
     const workflow = `permissions:\n  ${permissions.replaceAll("\n", "\n  ")}\n`;
     const result = runGuard(workflow);
 
-    assert.notEqual(result.status, 0, result.stdout);
+    assert.notEqual(result.status, 0, result.stderr || result.stdout);
   });
 }
+
+test("rejects a PR-size job-level permission override", () => {
+  const result = runGuard(`permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  pr-size:
+    permissions:
+      contents: write
+`);
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout);
+});
 
 test("rejects malformed YAML", () => {
   const result = runGuard("permissions: [\n");
 
-  assert.notEqual(result.status, 0, result.stdout);
+  assert.notEqual(result.status, 0, result.stderr || result.stdout);
 });

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -71,6 +71,20 @@ jobs:
   assert.notEqual(result.status, 0, result.stderr || result.stdout);
 });
 
+test("rejects a permission override in another job", () => {
+  const result = runGuard(`permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  pr-size: {}
+  unexpected-job:
+    permissions:
+      issues: write
+`);
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout);
+});
+
 test("rejects malformed YAML", () => {
   const result = runGuard("permissions: [\n");
 

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const guardPath = fileURLToPath(
+  new URL("./check-pr-size-workflow.mjs", import.meta.url),
+);
+
+test("accepts the repository workflow", () => {
+  const result = spawnSync(process.execPath, [guardPath], { encoding: "utf8" });
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+function runGuard(workflow) {
+  const directory = mkdtempSync(join(tmpdir(), "check-pr-size-workflow-"));
+  const workflowPath = join(directory, "pr-size.yml");
+  writeFileSync(workflowPath, workflow);
+
+  try {
+    return spawnSync(process.execPath, [guardPath, workflowPath], {
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("accepts exactly the required read permissions", () => {
+  const result = runGuard(`permissions:\n  contents: read\n  pull-requests: read\n`);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const [name, permissions] of [
+  ["missing contents", "pull-requests: read"],
+  ["writable contents", "contents: write\n  pull-requests: read"],
+  ["missing pull requests", "contents: read"],
+  ["writable pull requests", "contents: read\n  pull-requests: write"],
+  [
+    "an unexpected scope",
+    "contents: read\n  pull-requests: read\n  issues: write",
+  ],
+]) {
+  test(`rejects ${name}`, () => {
+    const workflow = `permissions:\n  ${permissions.replaceAll("\n", "\n  ")}\n`;
+    const result = runGuard(workflow);
+
+    assert.notEqual(result.status, 0, result.stdout);
+  });
+}
+
+test("rejects malformed YAML", () => {
+  const result = runGuard("permissions: [\n");
+
+  assert.notEqual(result.status, 0, result.stdout);
+});


### PR DESCRIPTION
# Fix PR-size permissions

## Validation evidence

The new permission guard initially failed against the existing workflow because `.github/workflows/pr-size.yml` had no top-level `permissions` block. It now passes after the least-privilege scopes are declared.

## Change summary

- Declare `contents: read` and `pull-requests: read` for the PR-size reusable-workflow caller.
- Add a repository validation guard that rejects removal or weakening of either required scope.
- Run the guard test through `npm run lint`, including the CI lint workflow, and record the fix in `CHANGELOG.md`.

Closes #337

## Checks completed

- `node scripts/check-pr-size-workflow.mjs` (failing before the workflow change; passing after)
- `yamllint .github/workflows/pr-size.yml`
- `npm run validate`
- `bash scripts/preflight.sh`
- `git diff --check`

## Follow-up before ready for review

No linked-workspace changes or unresolved local checks. Keep this PR as a draft until the final PR-view self-review finds no issues and required CI checks complete.
