### PR TITLE
Document custom type name update validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-empty `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
 - Grouped `github-actions` Dependabot updates in `.github/dependabot.yml` under readable identifiers (`secpal-workflows`, `github-actions`, `third-party-actions`) and added a repo-local validation guard so future PR and branch names do not fall back to full reusable-workflow paths plus pinned SHAs.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.
 - Corrected the contracts repo's workflow-governance baseline so reusable workflow caller jobs follow the valid timeout policy, pinned shared `.github` reusable workflows in `.github/workflows/quality.yml` to an immutable commit SHA with matching governance refs for reproducible AI-instructions and markdown-lint checks, and restored `.github/instructions/github-workflows.instructions.md` to the AGENTS/Copilot authoritative-source lists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-empty `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
+- Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-blank `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
 - Grouped `github-actions` Dependabot updates in `.github/dependabot.yml` under readable identifiers (`secpal-workflows`, `github-actions`, `third-party-actions`) and added a repo-local validation guard so future PR and branch names do not fall back to full reusable-workflow paths plus pinned SHAs.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.
 - Corrected the contracts repo's workflow-governance baseline so reusable workflow caller jobs follow the valid timeout policy, pinned shared `.github` reusable workflows in `.github/workflows/quality.yml` to an immutable commit SHA with matching governance refs for reproducible AI-instructions and markdown-lint checks, and restored `.github/instructions/github-workflows.instructions.md` to the AGENTS/Copilot authoritative-source lists.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5073,7 +5073,7 @@ components:
     OrganizationalUnitUpdateRequest:
       type: object
       additionalProperties: false
-      description: PATCH payload; all fields are optional and omitted fields keep their current values.
+      description: PATCH payload; all fields are optional and omitted fields keep their current values. When `type` is set to `custom`, `custom_type_name` is required and must be non-empty. Clearing `custom_type_name` with `null` or an empty string is invalid for an existing custom unit.
       properties:
         name:
           type: string
@@ -5084,6 +5084,7 @@ components:
         custom_type_name:
           type: [string, 'null']
           maxLength: 255
+          description: Optional custom type label. It is required and non-empty when this payload sets `type` to `custom`; an existing custom unit cannot clear it with `null` or an empty string.
           example: Special operations cell
         description:
           type: [string, 'null']
@@ -5110,6 +5111,21 @@ components:
           type: boolean
           description: Optional eligibility for new operational assignments, scopes, and related workflows. Omission preserves the current value; independent of `is_active`, hierarchy, soft deletion, parent status, and unit type.
           example: true
+      allOf:
+        - if:
+            properties:
+              type:
+                const: custom
+            required:
+              - type
+          then:
+            properties:
+              custom_type_name:
+                type: string
+                minLength: 1
+                maxLength: 255
+            required:
+              - custom_type_name
 
     OrganizationalUnitHasChildrenConflict:
       type: object
@@ -9034,7 +9050,7 @@ paths:
       description: |
         Update organizational-unit fields with PATCH semantics.
 
-        `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; status flags remain independent and are never inferred from `type`.
+        `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; changing it to `custom` requires a non-empty `custom_type_name` in the same payload. The API returns `422` if the name is absent, `null`, or empty when changing to `custom`, or if a caller clears the name of an existing custom unit. Status flags remain independent and are never inferred from `type`.
       operationId: updateOrganizationalUnit
       tags:
         - Organizational Units

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5073,7 +5073,7 @@ components:
     OrganizationalUnitUpdateRequest:
       type: object
       additionalProperties: false
-      description: PATCH payload; all fields are optional and omitted fields keep their current values. When `type` is set to `custom`, `custom_type_name` is required and must be non-empty. Clearing `custom_type_name` with `null` or an empty string is invalid for an existing custom unit.
+      description: PATCH payload; all fields are optional and omitted fields keep their current values. When `type` is set to `custom`, `custom_type_name` is required and must contain a non-whitespace character. Clearing `custom_type_name` with `null`, an empty string, or whitespace-only text is invalid for an existing custom unit.
       properties:
         name:
           type: string
@@ -5084,7 +5084,7 @@ components:
         custom_type_name:
           type: [string, 'null']
           maxLength: 255
-          description: Optional custom type label. It is required and non-empty when this payload sets `type` to `custom`; an existing custom unit cannot clear it with `null` or an empty string.
+          description: Optional custom type label. It is required and must contain a non-whitespace character when this payload sets `type` to `custom`; an existing custom unit cannot clear it with `null`, an empty string, or whitespace-only text.
           example: Special operations cell
         description:
           type: [string, 'null']
@@ -5124,8 +5124,39 @@ components:
                 type: string
                 minLength: 1
                 maxLength: 255
+                pattern: '.*\S.*'
             required:
               - custom_type_name
+      x-validation-examples:
+        accepted:
+          - name: Change a unit to a custom type
+            value:
+              type: custom
+              custom_type_name: Special operations cell
+          - name: Preserve the name while changing another field on a custom unit
+            existing_type: custom
+            value:
+              description: Updated regional operating unit.
+        rejected:
+          - name: Missing name while changing to a custom type
+            value:
+              type: custom
+          - name: Null name while changing to a custom type
+            value:
+              type: custom
+              custom_type_name: null
+          - name: Empty name while changing to a custom type
+            value:
+              type: custom
+              custom_type_name: ''
+          - name: Whitespace-only name while changing to a custom type
+            value:
+              type: custom
+              custom_type_name: '   '
+          - name: Clear the name of an existing custom unit
+            existing_type: custom
+            value:
+              custom_type_name: null
 
     OrganizationalUnitHasChildrenConflict:
       type: object
@@ -9050,7 +9081,7 @@ paths:
       description: |
         Update organizational-unit fields with PATCH semantics.
 
-        `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; changing it to `custom` requires a non-empty `custom_type_name` in the same payload. The API returns `422` if the name is absent, `null`, or empty when changing to `custom`, or if a caller clears the name of an existing custom unit. Status flags remain independent and are never inferred from `type`.
+        `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; changing it to `custom` requires a `custom_type_name` containing a non-whitespace character in the same payload. The API returns `422` if the name is absent, `null`, empty, or whitespace-only when changing to `custom`, or if a caller clears the name of an existing custom unit. Status flags remain independent and are never inferred from `type`.
       operationId: updateOrganizationalUnit
       tags:
         - Organizational Units

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -148,6 +148,36 @@ if (
   )
 }
 
+const updateCustomTypeNameRule = updateRequest.allOf?.find(
+  (schema) =>
+    schema?.if?.properties?.type?.const === 'custom' &&
+    schema?.if?.required?.includes('type')
+)
+if (
+  !updateCustomTypeNameRule?.then?.required?.includes('custom_type_name') ||
+  updateCustomTypeNameRule?.then?.properties?.custom_type_name?.type !==
+    'string' ||
+  updateCustomTypeNameRule?.then?.properties?.custom_type_name?.minLength !== 1
+) {
+  contractErrors.push(
+    'Updating an organizational unit to custom must require a non-empty custom_type_name.'
+  )
+}
+
+const organizationalUnitUpdateDescription =
+  paths['/organizational-units/{organizational_unit}']?.patch?.description ?? ''
+const customTypeNameDescription =
+  updateRequest.properties?.custom_type_name?.description ?? ''
+if (
+  !organizationalUnitUpdateDescription.includes('custom_type_name') ||
+  !organizationalUnitUpdateDescription.includes('422') ||
+  !customTypeNameDescription.includes('existing custom unit')
+) {
+  contractErrors.push(
+    'Organizational-unit PATCH must document the custom_type_name validation errors.'
+  )
+}
+
 for (const flag of ['is_legal_entity', 'is_establishment']) {
   if ('default' in (updateRequest.properties?.[flag] ?? {})) {
     contractErrors.push(

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -159,6 +159,7 @@ if (
   !updateCustomTypeNameRule?.then?.required?.includes('custom_type_name') ||
   updateCustomTypeNameSchema?.type !== 'string' ||
   updateCustomTypeNameSchema?.minLength !== 1 ||
+  updateCustomTypeNameSchema?.maxLength !== 255 ||
   updateCustomTypeNameSchema?.pattern !== '.*\\S.*'
 ) {
   contractErrors.push(
@@ -169,6 +170,13 @@ if (
 const updateValidationExamples = updateRequest['x-validation-examples'] ?? {}
 const acceptedUpdateExamples = updateValidationExamples.accepted ?? []
 const rejectedUpdateExamples = updateValidationExamples.rejected ?? []
+
+const hasExistingCustomUnitClearExample = rejectedUpdateExamples.some(
+  (example) =>
+    example?.existing_type === 'custom' &&
+    !Object.hasOwn(example?.value ?? {}, 'type') &&
+    example?.value?.custom_type_name === null
+)
 
 function acceptsCustomTypeNameExample(example) {
   const payload = example?.value ?? {}
@@ -193,10 +201,13 @@ if (
     (example) => !acceptsCustomTypeNameExample(example)
   ) ||
   rejectedUpdateExamples.length < 4 ||
-  rejectedUpdateExamples.some((example) => acceptsCustomTypeNameExample(example))
+  rejectedUpdateExamples.some((example) =>
+    acceptsCustomTypeNameExample(example)
+  ) ||
+  !hasExistingCustomUnitClearExample
 ) {
   contractErrors.push(
-    'OrganizationalUnitUpdateRequest must include executable accepted and rejected examples for custom_type_name validation.'
+    'OrganizationalUnitUpdateRequest must include executable accepted and rejected examples, including a standalone clear for an existing custom unit.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -153,14 +153,50 @@ const updateCustomTypeNameRule = updateRequest.allOf?.find(
     schema?.if?.properties?.type?.const === 'custom' &&
     schema?.if?.required?.includes('type')
 )
+const updateCustomTypeNameSchema =
+  updateCustomTypeNameRule?.then?.properties?.custom_type_name
 if (
   !updateCustomTypeNameRule?.then?.required?.includes('custom_type_name') ||
-  updateCustomTypeNameRule?.then?.properties?.custom_type_name?.type !==
-    'string' ||
-  updateCustomTypeNameRule?.then?.properties?.custom_type_name?.minLength !== 1
+  updateCustomTypeNameSchema?.type !== 'string' ||
+  updateCustomTypeNameSchema?.minLength !== 1 ||
+  updateCustomTypeNameSchema?.pattern !== '.*\\S.*'
 ) {
   contractErrors.push(
-    'Updating an organizational unit to custom must require a non-empty custom_type_name.'
+    'Updating an organizational unit to custom must require a non-blank custom_type_name.'
+  )
+}
+
+const updateValidationExamples = updateRequest['x-validation-examples'] ?? {}
+const acceptedUpdateExamples = updateValidationExamples.accepted ?? []
+const rejectedUpdateExamples = updateValidationExamples.rejected ?? []
+
+function acceptsCustomTypeNameExample(example) {
+  const payload = example?.value ?? {}
+  const effectiveType = payload.type ?? example?.existing_type
+  const touchesCustomTypeName =
+    Object.hasOwn(payload, 'type') || Object.hasOwn(payload, 'custom_type_name')
+
+  if (effectiveType !== 'custom' || !touchesCustomTypeName) {
+    return true
+  }
+
+  return (
+    typeof payload.custom_type_name === 'string' &&
+    payload.custom_type_name.trim().length > 0 &&
+    payload.custom_type_name.length <= 255
+  )
+}
+
+if (
+  acceptedUpdateExamples.length === 0 ||
+  acceptedUpdateExamples.some(
+    (example) => !acceptsCustomTypeNameExample(example)
+  ) ||
+  rejectedUpdateExamples.length < 4 ||
+  rejectedUpdateExamples.some((example) => acceptsCustomTypeNameExample(example))
+) {
+  contractErrors.push(
+    'OrganizationalUnitUpdateRequest must include executable accepted and rejected examples for custom_type_name validation.'
   )
 }
 


### PR DESCRIPTION
## Failing test first

Before this change, the organizational-unit contract guard failed because `OrganizationalUnitUpdateRequest` did not require a non-empty `custom_type_name` when a PATCH payload set `type` to `custom`, and the PATCH documentation did not describe the validation errors.

## Summary

- add the OpenAPI 3.1 conditional update rule for custom type names;
- document `422` responses for missing, null, empty, or cleared custom type names; and
- extend the verified-endpoint guard to preserve the rule and its documentation.

Closes #346

## Validation

- `npm run validate`
- `reuse lint`
- `git diff --check`

## Follow-up before ready for review

No linked workspace changes. GitHub CI checks are pending; this PR remains draft until they complete and the final self-review in the PR view finds zero issues.
