### PR TITLE
feat: add optional customer VAT ID contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Breaking:** Required `legal_entity_id` on customer responses and
+  `POST /customers` request payloads, and documented the narrow
+  `GET /customers/legal-entities` lookup for same-tenant, active,
+  non-deleted Legal Entity options with organizational write access (US-002).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.
 - Added `npm test` as the standard contract-test entry point; it runs the repository's canonical lint and formatting validation pipeline (closes #339).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `PATCH /customers/{customer}` must use their reusable request schemas,
   and customer list/create/read/update responses must continue to reference
   the reusable `Customer` response schema.
+- Aligned customer Legal Entity create, lookup, and reassignment semantics with
+  the API by documenting and guarding that eligible target units must also be
+  assignable.
 - Declared the least-privilege `contents: read` and `pull-requests: read` token permissions for the PR-size reusable-workflow caller and added a validation guard that rejects either scope being removed (closes #337)
 - Removed the tracked `.preflight-allow-large-pr` file left by the completed customer-and-site contract PR, so the documented gitignored local override once again requires an explicit, temporary opt-in for each exceptional large PR (closes #340)
 - Updated `scripts/preflight.sh` to run `npm ci` before the repo-local `node_modules/.bin/markdownlint` check when the pinned markdownlint toolchain is not installed yet, so fresh clones and post-lockfile updates can bootstrap validation successfully again

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Strengthened the customer contract regression guard so `POST /customers`
+  and `PATCH /customers/{customer}` must use their reusable request schemas,
+  and customer list/create/read/update responses must continue to reference
+  the reusable `Customer` response schema.
 - Declared the least-privilege `contents: read` and `pull-requests: read` token permissions for the PR-size reusable-workflow caller and added a validation guard that rejects either scope being removed (closes #337)
 - Removed the tracked `.preflight-allow-large-pr` file left by the completed customer-and-site contract PR, so the documented gitignored local override once again requires an explicit, temporary opt-in for each exceptional large PR (closes #340)
 - Updated `scripts/preflight.sh` to run `npm ci` before the repo-local `node_modules/.bin/markdownlint` check when the pinned markdownlint toolchain is not installed yet, so fresh clones and post-lockfile updates can bootstrap validation successfully again

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the optional nullable customer `vat_id` field to customer responses and
   create/update request contracts.
 - **Breaking:** Required `legal_entity_id` on customer responses and
-  `POST /customers` request payloads, and documented the narrow
+  `POST /customers` request payloads, documented optional authorized
+  Legal Entity reassignment through `PATCH /customers/{customer}`, and documented the narrow
   `GET /customers/legal-entities` lookup for same-tenant, active,
   non-deleted Legal Entity options with organizational write access (US-002).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the optional nullable customer `vat_id` field to customer responses and
+  create/update request contracts.
 - **Breaking:** Required `legal_entity_id` on customer responses and
   `POST /customers` request payloads, and documented the narrow
   `GET /customers/legal-entities` lookup for same-tenant, active,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5453,6 +5453,7 @@ components:
 
     CustomerLegalEntityLookup:
       type: object
+      additionalProperties: false
       description: Minimal Legal Entity option for creating customers. This intentionally does not expose the general organizational-unit resource.
       required:
         - id
@@ -5506,6 +5507,36 @@ components:
           type: [object, 'null']
           additionalProperties: true
           example: { 'industry': 'retail' }
+
+    CustomerUpdateRequest:
+      type: object
+      properties:
+        legal_entity_id:
+          type: string
+          format: uuid
+          description: Same-tenant active, non-deleted Legal Entity organizational unit to assign to the customer
+          example: '770e8400-e29b-41d4-a716-446655440000'
+        vat_id:
+          type: [string, 'null']
+          maxLength: 32
+          description: Customer VAT identification number
+          example: 'DE123456789'
+        name:
+          type: string
+          maxLength: 255
+        billing_address:
+          $ref: '#/components/schemas/Address'
+        contact:
+          anyOf:
+            - $ref: '#/components/schemas/Contact'
+            - type: 'null'
+        is_active:
+          type: boolean
+        notes:
+          type: [string, 'null']
+        metadata:
+          type: [object, 'null']
+          additionalProperties: true
 
     Site:
       type: object
@@ -9514,6 +9545,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: false
                 required:
                   - data
                 properties:
@@ -9579,7 +9611,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires customers.update permission and view access to customer.
+        Requires `customers.update` and view access to the customer. If supplied, `legal_entity_id` must be a same tenant, active, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
       operationId: updateCustomer
       tags:
         - Customers
@@ -9598,26 +9630,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  maxLength: 255
-                vat_id:
-                  type: [string, 'null']
-                  maxLength: 32
-                  description: Customer VAT identification number
-                billing_address:
-                  $ref: '#/components/schemas/Address'
-                contact:
-                  $ref: '#/components/schemas/Contact'
-                is_active:
-                  type: boolean
-                notes:
-                  type: string
-                metadata:
-                  type: object
-                  additionalProperties: true
+              $ref: '#/components/schemas/CustomerUpdateRequest'
       responses:
         '200':
           description: Customer updated successfully

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5380,6 +5380,7 @@ components:
       required:
         - id
         - customer_number
+        - legal_entity_id
         - name
         - billing_address
         - is_active
@@ -5396,6 +5397,11 @@ components:
           maxLength: 50
           description: Auto-generated customer number (KD-YYYY-####)
           example: 'KD-2025-0001'
+        legal_entity_id:
+          type: string
+          format: uuid
+          description: Same-tenant Legal Entity organizational unit assigned to this customer
+          example: '770e8400-e29b-41d4-a716-446655440000'
         name:
           type: string
           maxLength: 255
@@ -5439,6 +5445,57 @@ components:
             - $ref: '#/components/schemas/NullableApiTimestamp'
           description: Soft deletion timestamp
           example: null
+
+    CustomerLegalEntityLookup:
+      type: object
+      description: Minimal Legal Entity option for creating customers. This intentionally does not expose the general organizational-unit resource.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Legal Entity organizational unit UUID
+          example: '770e8400-e29b-41d4-a716-446655440000'
+        name:
+          type: string
+          maxLength: 255
+          description: Display name for the Legal Entity option
+          example: 'SecPal GmbH'
+
+    CustomerCreateRequest:
+      type: object
+      required:
+        - legal_entity_id
+        - name
+        - billing_address
+      properties:
+        legal_entity_id:
+          type: string
+          format: uuid
+          description: Same-tenant active, non-deleted Legal Entity organizational unit for the new customer
+          example: '770e8400-e29b-41d4-a716-446655440000'
+        name:
+          type: string
+          maxLength: 255
+          example: 'ACME Corporation GmbH'
+        billing_address:
+          $ref: '#/components/schemas/Address'
+        contact:
+          anyOf:
+            - $ref: '#/components/schemas/Contact'
+            - type: 'null'
+        is_active:
+          type: boolean
+          default: true
+        notes:
+          type: [string, 'null']
+          example: 'VIP customer'
+        metadata:
+          type: [object, 'null']
+          additionalProperties: true
+          example: { 'industry': 'retail' }
 
     Site:
       type: object
@@ -9393,7 +9450,7 @@ paths:
       summary: Create Customer
       description: |
         Create a new customer. Customer number is auto-generated (KD-YYYY-####).
-        Requires customers.create permission.
+        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
       operationId: createCustomer
       tags:
         - Customers
@@ -9404,26 +9461,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - name
-                - billing_address
-              properties:
-                name:
-                  type: string
-                  maxLength: 255
-                  example: 'ACME Corporation GmbH'
-                billing_address:
-                  $ref: '#/components/schemas/Address'
-                contact:
-                  $ref: '#/components/schemas/Contact'
-                notes:
-                  type: string
-                  example: 'VIP customer'
-                metadata:
-                  type: object
-                  additionalProperties: true
-                  example: { 'industry': 'retail' }
+              $ref: '#/components/schemas/CustomerCreateRequest'
       responses:
         '201':
           description: Customer created successfully
@@ -9444,6 +9482,39 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '422':
           $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /customers/legal-entities:
+    get:
+      summary: List Customer Legal Entity Options
+      description: |
+        Return only the Legal Entity options allowed for customer creation.
+
+        Requires `customers.create`. Results are limited to same tenant, active, non-deleted Legal Entity organizational units for which the caller has organizational write access. The response is intentionally minimal and does not expose the general organizational-unit resource or hierarchy metadata.
+      operationId: listCustomerLegalEntities
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Legal Entity options retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CustomerLegalEntityLookup'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5480,7 +5480,7 @@ components:
         legal_entity_id:
           type: string
           format: uuid
-          description: Same-tenant active, non-deleted Legal Entity organizational unit for the new customer
+          description: Same-tenant active, assignable, non-deleted Legal Entity organizational unit for the new customer
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -5514,7 +5514,7 @@ components:
         legal_entity_id:
           type: string
           format: uuid
-          description: Same-tenant active, non-deleted Legal Entity organizational unit to assign to the customer
+          description: Target Legal Entity for reassignment. When different from the customer's current value, it must be same-tenant, active, assignable, and non-deleted.
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -9491,7 +9491,7 @@ paths:
       summary: Create Customer
       description: |
         Create a new customer. Customer number is auto-generated (KD-YYYY-####).
-        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
+        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, assignable, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
       operationId: createCustomer
       tags:
         - Customers
@@ -9532,7 +9532,7 @@ paths:
       description: |
         Return only the Legal Entity options allowed for customer creation.
 
-        Requires `customers.create`. Results are limited to same tenant, active, non-deleted Legal Entity organizational units for which the caller has organizational write access. The response is intentionally minimal and does not expose the general organizational-unit resource or hierarchy metadata.
+        Requires `customers.create`. Results are limited to same tenant, active, assignable, non-deleted Legal Entity organizational units for which the caller has organizational write access. The response is intentionally minimal and does not expose the general organizational-unit resource or hierarchy metadata.
       operationId: listCustomerLegalEntities
       tags:
         - Customers
@@ -9611,7 +9611,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires `customers.update` and view access to the customer. If supplied, `legal_entity_id` must be a same tenant, active, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
+        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
       operationId: updateCustomer
       tags:
         - Customers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5402,6 +5402,11 @@ components:
           format: uuid
           description: Same-tenant Legal Entity organizational unit assigned to this customer
           example: '770e8400-e29b-41d4-a716-446655440000'
+        vat_id:
+          type: [string, 'null']
+          maxLength: 32
+          description: Customer VAT identification number
+          example: 'DE123456789'
         name:
           type: string
           maxLength: 255
@@ -5476,6 +5481,11 @@ components:
           format: uuid
           description: Same-tenant active, non-deleted Legal Entity organizational unit for the new customer
           example: '770e8400-e29b-41d4-a716-446655440000'
+        vat_id:
+          type: [string, 'null']
+          maxLength: 32
+          description: Customer VAT identification number
+          example: 'DE123456789'
         name:
           type: string
           maxLength: 255
@@ -9593,6 +9603,10 @@ paths:
                 name:
                   type: string
                   maxLength: 255
+                vat_id:
+                  type: [string, 'null']
+                  maxLength: 32
+                  description: Customer VAT identification number
                 billing_address:
                   $ref: '#/components/schemas/Address'
                 contact:

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -131,13 +131,19 @@ const isNullableVatId = (schema) =>
   schema.type.includes('null') &&
   schema.maxLength === 32
 
-if (!isNullableVatId(customer.properties?.vat_id)) {
+if (
+  customer.required?.includes('vat_id') ||
+  !isNullableVatId(customer.properties?.vat_id)
+) {
   contractErrors.push(
     'Customer.vat_id must be a nullable string response field with maxLength 32.'
   )
 }
 
-if (!isNullableVatId(customerCreateRequest.properties?.vat_id)) {
+if (
+  customerCreateRequest.required?.includes('vat_id') ||
+  !isNullableVatId(customerCreateRequest.properties?.vat_id)
+) {
   contractErrors.push(
     'CustomerCreateRequest.vat_id must be an optional nullable string field with maxLength 32.'
   )

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -277,8 +277,7 @@ for (const [label, description, requiredPermission] of [
   for (const requiredText of [
     requiredPermission,
     'same tenant',
-    'active',
-    'non-deleted Legal Entity',
+    'active, assignable, non-deleted Legal Entity',
     'organizational write access',
   ]) {
     if (!description.includes(requiredText)) {

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -100,10 +100,13 @@ const schemas = doc?.components?.schemas ?? {}
 const responses = doc?.components?.responses ?? {}
 const customer = schemas.Customer ?? {}
 const customerCreateRequest = schemas.CustomerCreateRequest ?? {}
+const customerCreateRequestBody = paths['/customers']?.post?.requestBody ?? {}
+const customerCreateSchema =
+  customerCreateRequestBody?.content?.['application/json']?.schema ?? {}
+const customerUpdateRequestBody =
+  paths['/customers/{customer}']?.patch?.requestBody ?? {}
 const customerUpdateSchema =
-  paths['/customers/{customer}']?.patch?.requestBody?.content?.[
-    'application/json'
-  ]?.schema ?? {}
+  customerUpdateRequestBody?.content?.['application/json']?.schema ?? {}
 const customerLegalEntityLookup = schemas.CustomerLegalEntityLookup ?? {}
 const customerUpdateRequest = schemas.CustomerUpdateRequest ?? {}
 const organizationalUnit = schemas.OrganizationalUnit ?? {}
@@ -160,13 +163,45 @@ if (
 }
 
 if (
+  customerCreateRequestBody.required !== true ||
+  customerCreateSchema?.$ref !== '#/components/schemas/CustomerCreateRequest' ||
   !customerCreateRequest.required?.includes('legal_entity_id') ||
   customerCreateRequest.properties?.legal_entity_id?.type !== 'string' ||
   customerCreateRequest.properties?.legal_entity_id?.format !== 'uuid'
 ) {
   contractErrors.push(
-    'CustomerCreateRequest.legal_entity_id must be a required UUID request field.'
+    'POST /customers must require and reference CustomerCreateRequest with a required legal_entity_id UUID.'
   )
+}
+
+const customerResponseRef = '#/components/schemas/Customer'
+for (const [label, responseSchema] of [
+  [
+    'GET /customers',
+    paths['/customers']?.get?.responses?.['200']?.content?.['application/json']
+      ?.schema?.properties?.data?.items,
+  ],
+  [
+    'POST /customers',
+    paths['/customers']?.post?.responses?.['201']?.content?.['application/json']
+      ?.schema?.properties?.data,
+  ],
+  [
+    'GET /customers/{customer}',
+    paths['/customers/{customer}']?.get?.responses?.['200']?.content?.[
+      'application/json'
+    ]?.schema?.properties?.data,
+  ],
+  [
+    'PATCH /customers/{customer}',
+    paths['/customers/{customer}']?.patch?.responses?.['200']?.content?.[
+      'application/json'
+    ]?.schema?.properties?.data,
+  ],
+]) {
+  if (responseSchema?.$ref !== customerResponseRef) {
+    contractErrors.push(`${label} must return the Customer schema.`)
+  }
 }
 
 const legalEntityLookupProperties = Object.keys(
@@ -210,14 +245,14 @@ if (
 }
 
 if (
-  customerUpdateSchema?.$ref !==
-    '#/components/schemas/CustomerUpdateRequest' ||
+  customerUpdateRequestBody.required !== true ||
+  customerUpdateSchema?.$ref !== '#/components/schemas/CustomerUpdateRequest' ||
   customerUpdateRequest.required?.includes('legal_entity_id') ||
   customerUpdateRequest.properties?.legal_entity_id?.type !== 'string' ||
   customerUpdateRequest.properties?.legal_entity_id?.format !== 'uuid'
 ) {
   contractErrors.push(
-    'PATCH /customers/{customer} must reference CustomerUpdateRequest with an optional legal_entity_id UUID.'
+    'PATCH /customers/{customer} must require and reference CustomerUpdateRequest with an optional legal_entity_id UUID.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -100,6 +100,10 @@ const schemas = doc?.components?.schemas ?? {}
 const responses = doc?.components?.responses ?? {}
 const customer = schemas.Customer ?? {}
 const customerCreateRequest = schemas.CustomerCreateRequest ?? {}
+const customerUpdateRequest =
+  paths['/customers/{customer}']?.patch?.requestBody?.content?.[
+    'application/json'
+  ]?.schema ?? {}
 const customerLegalEntityLookup = schemas.CustomerLegalEntityLookup ?? {}
 const organizationalUnit = schemas.OrganizationalUnit ?? {}
 const createRequest = schemas.OrganizationalUnitCreateRequest ?? {}
@@ -118,6 +122,30 @@ if (
 ) {
   contractErrors.push(
     'Customer.legal_entity_id must be a required UUID response field.'
+  )
+}
+
+const isNullableVatId = (schema) =>
+  Array.isArray(schema?.type) &&
+  schema.type.includes('string') &&
+  schema.type.includes('null') &&
+  schema.maxLength === 32
+
+if (!isNullableVatId(customer.properties?.vat_id)) {
+  contractErrors.push(
+    'Customer.vat_id must be a nullable string response field with maxLength 32.'
+  )
+}
+
+if (!isNullableVatId(customerCreateRequest.properties?.vat_id)) {
+  contractErrors.push(
+    'CustomerCreateRequest.vat_id must be an optional nullable string field with maxLength 32.'
+  )
+}
+
+if (!isNullableVatId(customerUpdateRequest.properties?.vat_id)) {
+  contractErrors.push(
+    'PATCH /customers/{customer} vat_id must be an optional nullable string field with maxLength 32.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -45,6 +45,7 @@ const REQUIRED_OPERATIONS = [
   ['get', '/organizational-units/{organizational_unit}/ancestors'],
   ['post', '/organizational-units/{organizational_unit}/parent'],
   ['delete', '/organizational-units/{organizational_unit}/parent/{parent}'],
+  ['get', '/customers/legal-entities'],
 ]
 
 const target = process.argv[2]
@@ -97,6 +98,9 @@ if (missing.length) {
 
 const schemas = doc?.components?.schemas ?? {}
 const responses = doc?.components?.responses ?? {}
+const customer = schemas.Customer ?? {}
+const customerCreateRequest = schemas.CustomerCreateRequest ?? {}
+const customerLegalEntityLookup = schemas.CustomerLegalEntityLookup ?? {}
 const organizationalUnit = schemas.OrganizationalUnit ?? {}
 const createRequest = schemas.OrganizationalUnitCreateRequest ?? {}
 const updateRequest = schemas.OrganizationalUnitUpdateRequest ?? {}
@@ -106,6 +110,84 @@ const parentIdParameter = paths['/organizational-units']?.get?.parameters?.find(
 const organizationalUnitListParameters =
   paths['/organizational-units']?.get?.parameters ?? []
 const contractErrors = []
+
+if (
+  !customer.required?.includes('legal_entity_id') ||
+  customer.properties?.legal_entity_id?.type !== 'string' ||
+  customer.properties?.legal_entity_id?.format !== 'uuid'
+) {
+  contractErrors.push(
+    'Customer.legal_entity_id must be a required UUID response field.'
+  )
+}
+
+if (
+  !customerCreateRequest.required?.includes('legal_entity_id') ||
+  customerCreateRequest.properties?.legal_entity_id?.type !== 'string' ||
+  customerCreateRequest.properties?.legal_entity_id?.format !== 'uuid'
+) {
+  contractErrors.push(
+    'CustomerCreateRequest.legal_entity_id must be a required UUID request field.'
+  )
+}
+
+const legalEntityLookupProperties = Object.keys(
+  customerLegalEntityLookup.properties ?? {}
+)
+const legalEntityLookupAllowed = new Set(['id', 'name'])
+if (
+  customerLegalEntityLookup.type !== 'object' ||
+  legalEntityLookupProperties.some(
+    (property) => !legalEntityLookupAllowed.has(property)
+  ) ||
+  !customerLegalEntityLookup.required?.includes('id') ||
+  !customerLegalEntityLookup.required?.includes('name') ||
+  customerLegalEntityLookup.properties?.id?.type !== 'string' ||
+  customerLegalEntityLookup.properties?.id?.format !== 'uuid' ||
+  customerLegalEntityLookup.properties?.name?.type !== 'string'
+) {
+  contractErrors.push(
+    'CustomerLegalEntityLookup must expose only required id and name fields.'
+  )
+}
+
+const customerLegalEntitiesResponse =
+  paths['/customers/legal-entities']?.get?.responses?.['200']?.content?.[
+    'application/json'
+  ]?.schema
+const customerLegalEntitiesItems =
+  customerLegalEntitiesResponse?.properties?.data?.items
+if (
+  customerLegalEntitiesResponse?.type !== 'object' ||
+  !customerLegalEntitiesResponse?.required?.includes('data') ||
+  customerLegalEntitiesResponse?.properties?.data?.type !== 'array' ||
+  customerLegalEntitiesItems?.$ref !==
+    '#/components/schemas/CustomerLegalEntityLookup'
+) {
+  contractErrors.push(
+    'GET /customers/legal-entities must return data[] of CustomerLegalEntityLookup.'
+  )
+}
+
+const customerCreateDescription = paths['/customers']?.post?.description ?? ''
+const legalEntitiesDescription =
+  paths['/customers/legal-entities']?.get?.description ?? ''
+for (const [label, description] of [
+  ['POST /customers', customerCreateDescription],
+  ['GET /customers/legal-entities', legalEntitiesDescription],
+]) {
+  for (const requiredText of [
+    'customers.create',
+    'same tenant',
+    'active',
+    'non-deleted Legal Entity',
+    'organizational write access',
+  ]) {
+    if (!description.includes(requiredText)) {
+      contractErrors.push(`${label} must document ${requiredText}.`)
+    }
+  }
+}
 
 for (const relationship of [
   'parent',

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -100,11 +100,12 @@ const schemas = doc?.components?.schemas ?? {}
 const responses = doc?.components?.responses ?? {}
 const customer = schemas.Customer ?? {}
 const customerCreateRequest = schemas.CustomerCreateRequest ?? {}
-const customerUpdateRequest =
+const customerUpdateSchema =
   paths['/customers/{customer}']?.patch?.requestBody?.content?.[
     'application/json'
   ]?.schema ?? {}
 const customerLegalEntityLookup = schemas.CustomerLegalEntityLookup ?? {}
+const customerUpdateRequest = schemas.CustomerUpdateRequest ?? {}
 const organizationalUnit = schemas.OrganizationalUnit ?? {}
 const createRequest = schemas.OrganizationalUnitCreateRequest ?? {}
 const updateRequest = schemas.OrganizationalUnitUpdateRequest ?? {}
@@ -149,7 +150,10 @@ if (
   )
 }
 
-if (!isNullableVatId(customerUpdateRequest.properties?.vat_id)) {
+if (
+  customerUpdateRequest.required?.includes('vat_id') ||
+  !isNullableVatId(customerUpdateRequest.properties?.vat_id)
+) {
   contractErrors.push(
     'PATCH /customers/{customer} vat_id must be an optional nullable string field with maxLength 32.'
   )
@@ -171,6 +175,7 @@ const legalEntityLookupProperties = Object.keys(
 const legalEntityLookupAllowed = new Set(['id', 'name'])
 if (
   customerLegalEntityLookup.type !== 'object' ||
+  customerLegalEntityLookup.additionalProperties !== false ||
   legalEntityLookupProperties.some(
     (property) => !legalEntityLookupAllowed.has(property)
   ) ||
@@ -193,6 +198,7 @@ const customerLegalEntitiesItems =
   customerLegalEntitiesResponse?.properties?.data?.items
 if (
   customerLegalEntitiesResponse?.type !== 'object' ||
+  customerLegalEntitiesResponse?.additionalProperties !== false ||
   !customerLegalEntitiesResponse?.required?.includes('data') ||
   customerLegalEntitiesResponse?.properties?.data?.type !== 'array' ||
   customerLegalEntitiesItems?.$ref !==
@@ -203,15 +209,38 @@ if (
   )
 }
 
+if (
+  customerUpdateSchema?.$ref !==
+    '#/components/schemas/CustomerUpdateRequest' ||
+  customerUpdateRequest.required?.includes('legal_entity_id') ||
+  customerUpdateRequest.properties?.legal_entity_id?.type !== 'string' ||
+  customerUpdateRequest.properties?.legal_entity_id?.format !== 'uuid'
+) {
+  contractErrors.push(
+    'PATCH /customers/{customer} must reference CustomerUpdateRequest with an optional legal_entity_id UUID.'
+  )
+}
+
 const customerCreateDescription = paths['/customers']?.post?.description ?? ''
+const customerUpdateDescription =
+  paths['/customers/{customer}']?.patch?.description ?? ''
 const legalEntitiesDescription =
   paths['/customers/legal-entities']?.get?.description ?? ''
-for (const [label, description] of [
-  ['POST /customers', customerCreateDescription],
-  ['GET /customers/legal-entities', legalEntitiesDescription],
+for (const [label, description, requiredPermission] of [
+  ['POST /customers', customerCreateDescription, 'customers.create'],
+  [
+    'PATCH /customers/{customer}',
+    customerUpdateDescription,
+    'customers.update',
+  ],
+  [
+    'GET /customers/legal-entities',
+    legalEntitiesDescription,
+    'customers.create',
+  ],
 ]) {
   for (const requiredText of [
-    'customers.create',
+    requiredPermission,
     'same tenant',
     'active',
     'non-deleted Legal Entity',


### PR DESCRIPTION
## Summary

- Require `legal_entity_id` for customers and add the restricted Legal Entity lookup contract.
- Add optional nullable customer `vat_id` fields to read, create, and update contracts.

## Merge dependency

- Do not merge until [SecPal/api#1280](https://github.com/SecPal/api/issues/1280) restores the matching VAT ID persistence, validation, response, and regression-test coverage in the API implementation.

## Validation

- `npm test`

## Related workspace PRs

- API implementation: https://github.com/SecPal/api/pull/1289
- Frontend integration: https://github.com/SecPal/frontend/pull/1399
