### PR TITLE
Define Legal Entity customer assignment contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Strengthened the customer Legal Entity validation-example guard to reject
+  malformed tenant metadata, request-schema violations, non-UUID assignment
+  values, and contradictory accepted/rejected examples that reuse the same
+  Legal Entity identifier, including case-only UUID differences.
 - Strengthened the customer contract regression guard so `POST /customers`
   and `PATCH /customers/{customer}` must use their reusable request schemas,
   and customer list/create/read/update responses must continue to reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Defined the customer Legal Entity assignment contract: customer responses and
+  customer create/update payloads carry the explicit same-tenant
+  `legal_entity_id` relationship, while the contract explicitly prohibits a
+  default assignment for existing customers. Any backfill remains blocked until
+  a product-approved deterministic tenant-consistent rule is available.
+  Create and reassignment schemas include accepted same-tenant and rejected
+  cross-tenant validation examples (closes #351; parent epic
+  `SecPal/frontend#1391`).
 - Added the optional nullable customer `vat_id` field to customer responses and
   create/update request contracts.
 - **Breaking:** Required `legal_entity_id` on customer responses and

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5376,7 +5376,12 @@ components:
 
     Customer:
       type: object
-      description: Customer (client organization) entity
+      description: |
+        Customer (client organization) entity with an explicit Legal Entity assignment.
+
+        No default Legal Entity assignment is permitted for existing customers. A customer
+        may be backfilled only after a product-approved deterministic tenant-consistent rule
+        identifies an explicit Legal Entity from the customer's own tenant.
       required:
         - id
         - customer_number
@@ -5400,7 +5405,10 @@ components:
         legal_entity_id:
           type: string
           format: uuid
-          description: Same-tenant Legal Entity organizational unit assigned to this customer
+          description: |
+            Same-tenant Legal Entity organizational unit explicitly assigned to this customer.
+            No default Legal Entity assignment is permitted for existing customers; backfill
+            requires a product-approved deterministic tenant-consistent rule.
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -5507,6 +5515,32 @@ components:
           type: [object, 'null']
           additionalProperties: true
           example: { 'industry': 'retail' }
+      x-validation-examples:
+        accepted:
+          - name: Explicit Legal Entity from the customer's tenant
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            value:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              name: ACME Corporation GmbH
+              billing_address:
+                street: Hauptstraße 123
+                city: Berlin
+                postal_code: '10115'
+                country: DE
+        rejected:
+          - name: Legal Entity from another tenant
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440002'
+            status: 422
+            value:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
+              name: ACME Corporation GmbH
+              billing_address:
+                street: Hauptstraße 123
+                city: Berlin
+                postal_code: '10115'
+                country: DE
 
     CustomerUpdateRequest:
       type: object
@@ -5537,6 +5571,20 @@ components:
         metadata:
           type: [object, 'null']
           additionalProperties: true
+      x-validation-examples:
+        accepted:
+          - name: Reassign to a Legal Entity from the customer's tenant
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            value:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+        rejected:
+          - name: Reassign to a Legal Entity from another tenant
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440002'
+            status: 422
+            value:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
 
     Site:
       type: object

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
-    "lint": "node --test scripts/*.test.mjs && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
+    "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
     "test": "npm run validate",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
-    "lint": "node --test scripts/check-pr-size-workflow.test.mjs && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
+    "lint": "node --test scripts/*.test.mjs && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
     "test": "npm run validate",

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -135,6 +135,98 @@ const isNullableVatId = (schema) =>
   schema.type.includes('null') &&
   schema.maxLength === 32
 
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const isUuid = (value) => typeof value === 'string' && uuidPattern.test(value)
+const normalizeUuid = (value) =>
+  typeof value === 'string' ? value.toLowerCase() : value
+
+function matchesType(type, value) {
+  if (type === 'null') return value === null
+  if (type === 'string') return typeof value === 'string'
+  if (type === 'boolean') return typeof value === 'boolean'
+  if (type === 'integer') return Number.isInteger(value)
+  if (type === 'number') return typeof value === 'number'
+  if (type === 'array') return Array.isArray(value)
+  if (type === 'object') {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+  }
+  return false
+}
+
+function matchesSchema(schema, value) {
+  if (!schema || typeof schema !== 'object') return false
+
+  if (schema.$ref) {
+    const prefix = '#/components/schemas/'
+    if (!schema.$ref.startsWith(prefix)) return false
+    return matchesSchema(schemas[schema.$ref.slice(prefix.length)], value)
+  }
+  if (
+    schema.anyOf &&
+    !schema.anyOf.some((entry) => matchesSchema(entry, value))
+  ) {
+    return false
+  }
+  if (
+    schema.allOf &&
+    !schema.allOf.every((entry) => matchesSchema(entry, value))
+  ) {
+    return false
+  }
+  if (Object.hasOwn(schema, 'const') && value !== schema.const) return false
+  if (schema.enum && !schema.enum.includes(value)) return false
+
+  const declaredTypes = Array.isArray(schema.type)
+    ? schema.type
+    : schema.type
+      ? [schema.type]
+      : []
+  if (
+    declaredTypes.length > 0 &&
+    !declaredTypes.some((type) => matchesType(type, value))
+  ) {
+    return false
+  }
+  if (value === null) {
+    return declaredTypes.length === 0 || declaredTypes.includes('null')
+  }
+
+  if (typeof value === 'string') {
+    if (schema.minLength !== undefined && value.length < schema.minLength)
+      return false
+    if (schema.maxLength !== undefined && value.length > schema.maxLength)
+      return false
+    if (schema.pattern && !new RegExp(schema.pattern).test(value)) return false
+    if (schema.format === 'uuid' && !isUuid(value)) return false
+  }
+  if (typeof value === 'number') {
+    if (schema.minimum !== undefined && value < schema.minimum) return false
+    if (schema.maximum !== undefined && value > schema.maximum) return false
+  }
+  if (Array.isArray(value) && schema.items) {
+    if (!value.every((entry) => matchesSchema(schema.items, entry)))
+      return false
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (
+      (schema.required ?? []).some(
+        (property) => !Object.hasOwn(value, property)
+      )
+    ) {
+      return false
+    }
+    for (const [property, propertyValue] of Object.entries(value)) {
+      const propertySchema = schema.properties?.[property]
+      if (propertySchema && !matchesSchema(propertySchema, propertyValue))
+        return false
+      if (!propertySchema && schema.additionalProperties === false) return false
+    }
+  }
+
+  return true
+}
+
 if (
   customer.required?.includes('vat_id') ||
   !isNullableVatId(customer.properties?.vat_id)
@@ -261,25 +353,51 @@ for (const [schemaName, schema] of [
   ['CustomerUpdateRequest', customerUpdateRequest],
 ]) {
   const validationExamples = schema['x-validation-examples'] ?? {}
-  const acceptedExamples = validationExamples.accepted ?? []
-  const rejectedExamples = validationExamples.rejected ?? []
-  const hasSameTenantExample = acceptedExamples.some(
-    (example) =>
-      example?.customer_tenant_id &&
-      example.customer_tenant_id === example?.legal_entity_tenant_id &&
-      typeof example?.value?.legal_entity_id === 'string'
-  )
-  const hasCrossTenantRejection = rejectedExamples.some(
-    (example) =>
-      example?.customer_tenant_id &&
-      example.customer_tenant_id !== example?.legal_entity_tenant_id &&
-      typeof example?.value?.legal_entity_id === 'string' &&
-      example?.status === 422
+  const acceptedExamples = Array.isArray(validationExamples.accepted)
+    ? validationExamples.accepted
+    : []
+  const rejectedExamples = Array.isArray(validationExamples.rejected)
+    ? validationExamples.rejected
+    : []
+  const isAssignmentExample = (example) =>
+    typeof example?.name === 'string' &&
+    example.name.trim().length > 0 &&
+    isUuid(example?.customer_tenant_id) &&
+    isUuid(example?.legal_entity_tenant_id) &&
+    isUuid(example?.value?.legal_entity_id) &&
+    matchesSchema(schema, example?.value)
+  const hasOnlySameTenantExamples =
+    acceptedExamples.length > 0 &&
+    acceptedExamples.every(
+      (example) =>
+        isAssignmentExample(example) &&
+        normalizeUuid(example.customer_tenant_id) ===
+          normalizeUuid(example.legal_entity_tenant_id)
+    )
+  const hasOnlyCrossTenantRejections =
+    rejectedExamples.length > 0 &&
+    rejectedExamples.every(
+      (example) =>
+        isAssignmentExample(example) &&
+        normalizeUuid(example.customer_tenant_id) !==
+          normalizeUuid(example.legal_entity_tenant_id) &&
+        example.status === 422
+    )
+  const usesDistinctLegalEntities = acceptedExamples.every((accepted) =>
+    rejectedExamples.every(
+      (rejected) =>
+        normalizeUuid(accepted.value.legal_entity_id) !==
+        normalizeUuid(rejected.value.legal_entity_id)
+    )
   )
 
-  if (!hasSameTenantExample || !hasCrossTenantRejection) {
+  if (
+    !hasOnlySameTenantExamples ||
+    !hasOnlyCrossTenantRejections ||
+    !usesDistinctLegalEntities
+  ) {
     contractErrors.push(
-      `${schemaName} must include accepted same-tenant and rejected cross-tenant Legal Entity assignment examples.`
+      `${schemaName} must include structurally valid accepted same-tenant and rejected cross-tenant Legal Entity assignment examples with distinct UUIDs.`
     )
   }
 }

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -256,11 +256,42 @@ if (
   )
 }
 
+for (const [schemaName, schema] of [
+  ['CustomerCreateRequest', customerCreateRequest],
+  ['CustomerUpdateRequest', customerUpdateRequest],
+]) {
+  const validationExamples = schema['x-validation-examples'] ?? {}
+  const acceptedExamples = validationExamples.accepted ?? []
+  const rejectedExamples = validationExamples.rejected ?? []
+  const hasSameTenantExample = acceptedExamples.some(
+    (example) =>
+      example?.customer_tenant_id &&
+      example.customer_tenant_id === example?.legal_entity_tenant_id &&
+      typeof example?.value?.legal_entity_id === 'string'
+  )
+  const hasCrossTenantRejection = rejectedExamples.some(
+    (example) =>
+      example?.customer_tenant_id &&
+      example.customer_tenant_id !== example?.legal_entity_tenant_id &&
+      typeof example?.value?.legal_entity_id === 'string' &&
+      example?.status === 422
+  )
+
+  if (!hasSameTenantExample || !hasCrossTenantRejection) {
+    contractErrors.push(
+      `${schemaName} must include accepted same-tenant and rejected cross-tenant Legal Entity assignment examples.`
+    )
+  }
+}
+
 const customerCreateDescription = paths['/customers']?.post?.description ?? ''
 const customerUpdateDescription =
   paths['/customers/{customer}']?.patch?.description ?? ''
 const legalEntitiesDescription =
   paths['/customers/legal-entities']?.get?.description ?? ''
+const customerDescription = customer.description ?? ''
+const customerLegalEntityDescription =
+  customer.properties?.legal_entity_id?.description ?? ''
 for (const [label, description, requiredPermission] of [
   ['POST /customers', customerCreateDescription, 'customers.create'],
   [
@@ -282,6 +313,22 @@ for (const [label, description, requiredPermission] of [
   ]) {
     if (!description.includes(requiredText)) {
       contractErrors.push(`${label} must document ${requiredText}.`)
+    }
+  }
+}
+
+for (const [label, description] of [
+  ['Customer', customerDescription],
+  ['Customer.legal_entity_id', customerLegalEntityDescription],
+]) {
+  for (const requiredText of [
+    'No default Legal Entity assignment',
+    'product-approved deterministic tenant-consistent rule',
+  ]) {
+    if (!description.includes(requiredText)) {
+      contractErrors.push(
+        `${label} must document the blocked no-default customer backfill invariant.`
+      )
     }
   }
 }

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -386,8 +386,8 @@ for (const [schemaName, schema] of [
   const usesDistinctLegalEntities = acceptedExamples.every((accepted) =>
     rejectedExamples.every(
       (rejected) =>
-        normalizeUuid(accepted.value.legal_entity_id) !==
-        normalizeUuid(rejected.value.legal_entity_id)
+        normalizeUuid(accepted?.value?.legal_entity_id) !==
+        normalizeUuid(rejected?.value?.legal_entity_id)
     )
   )
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -208,7 +208,7 @@ function matchesSchema(schema, value) {
     if (!value.every((entry) => matchesSchema(schema.items, entry)))
       return false
   }
-  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+  if (typeof value === 'object' && !Array.isArray(value)) {
     if (
       (schema.required ?? []).some(
         (property) => !Object.hasOwn(value, property)

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -68,6 +68,22 @@ test('rejects contradictory accepted and rejected Legal Entity IDs', () => {
   assert.notEqual(result.status, 0, result.stdout)
 })
 
+for (const [kind, legalEntityId] of [
+  ['accepted', '770e8400-e29b-41d4-a716-446655440000'],
+  ['rejected', '770e8400-e29b-41d4-a716-446655440002'],
+]) {
+  test(`reports malformed ${kind} assignment examples without throwing`, () => {
+    const candidate = contract.replaceAll(
+      `            value:\n              legal_entity_id: '${legalEntityId}'`,
+      `            malformed_value:\n              legal_entity_id: '${legalEntityId}'`
+    )
+    const result = runGuard(candidate)
+
+    assert.equal(result.status, 1, result.stderr)
+    assert.doesNotMatch(result.stderr, /TypeError/)
+  })
+}
+
 test('compares Legal Entity UUIDs case-insensitively', () => {
   const candidate = contract.replaceAll(
     "legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'",

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const guardPath = fileURLToPath(
+  new URL('./check-openapi-verified-endpoints.mjs', import.meta.url)
+)
+const contractPath = fileURLToPath(
+  new URL('../docs/openapi.yaml', import.meta.url)
+)
+const contract = readFileSync(contractPath, 'utf8')
+
+function runGuard(source) {
+  const directory = mkdtempSync(join(tmpdir(), 'verified-endpoints-'))
+  const candidatePath = join(directory, 'openapi.yaml')
+  writeFileSync(candidatePath, source)
+
+  try {
+    return spawnSync(process.execPath, [guardPath, candidatePath], {
+      encoding: 'utf8',
+    })
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+test('accepts the repository contract', () => {
+  const result = runGuard(contract)
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('accepts schema-valid nullable example fields', () => {
+  const candidate = contract.replaceAll(
+    '              name: ACME Corporation GmbH\n',
+    '              name: ACME Corporation GmbH\n              contact: null\n'
+  )
+  const result = runGuard(candidate)
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('rejects non-UUID Legal Entity assignment examples', () => {
+  const candidate = contract.replaceAll(
+    "legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'",
+    'legal_entity_id: not-a-uuid'
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects contradictory accepted and rejected Legal Entity IDs', () => {
+  const candidate = contract.replaceAll(
+    "legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'",
+    "legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'"
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('compares Legal Entity UUIDs case-insensitively', () => {
+  const candidate = contract.replaceAll(
+    "legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'",
+    "legal_entity_id: '770E8400-E29B-41D4-A716-446655440000'"
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects malformed tenant metadata', () => {
+  const candidate = contract.replaceAll(
+    "legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440002'",
+    'legal_entity_tenant_id: not-a-uuid'
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('compares tenant UUIDs case-insensitively', () => {
+  const candidate = contract.replaceAll(
+    "legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440002'",
+    "legal_entity_tenant_id: '660E8400-E29B-41D4-A716-446655440001'"
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects assignment examples missing required request fields', () => {
+  const candidate = contract.replaceAll('              billing_address:\n', '')
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects assignment examples with invalid required field types', () => {
+  const candidate = contract.replaceAll(
+    '              name: ACME Corporation GmbH',
+    '              name: null'
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects assignment examples that violate nested request schemas', () => {
+  const candidate = contract.replaceAll(
+    '                country: DE',
+    '                country: 123'
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})


### PR DESCRIPTION
## Failing contract check

Before this change, the verified-endpoint guard failed because the `Customer`
schema and its `legal_entity_id` field did not document the blocked backfill
invariant. It also lacked accepted same-tenant and rejected cross-tenant
assignment examples for customer creation and reassignment.

## Summary

- Document the explicit Legal Entity relationship and prohibit default
  assignment for existing customers.
- Require a product-approved deterministic tenant-consistent rule before any
  backfill.
- Add same-tenant accepted and cross-tenant `422` rejected validation examples
  for customer create and update contracts.
- Extend the verified-endpoint guard to protect these invariants.

Closes #351

## Validation

- `npm run validate`
- `reuse lint`
- Remote branch preflight

## Follow-up before ready

- Keep this pull request as a draft until the final pull-request-view
  self-review finds zero issues.
- SecPal/api#1278 implements persistence and runtime tenant validation after
  this contract merges.
- SecPal/frontend#1390 consumes the finalized API contract after the API work
  is available.
