### PR TITLE
Document organizational-unit boolean query encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented the `GET /organizational-units` `is_active` and `is_assignable`
+  boolean filters' numeric query encoding: clients send `1` for `true` and `0`
+  for `false`; textual boolean values are rejected (#348).
 - Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-blank `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
 - Grouped `github-actions` Dependabot updates in `.github/dependabot.yml` under readable identifiers (`secpal-workflows`, `github-actions`, `third-party-actions`) and added a repo-local validation guard so future PR and branch names do not fall back to full reusable-workflow paths plus pinned SHAs.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9121,13 +9121,27 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Filter by independent administrative status.
+          description: Filter by independent administrative status. Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.
+          x-wire-examples:
+            active:
+              summary: Filter for active units.
+              value: '1'
+            inactive:
+              summary: Filter for inactive units.
+              value: '0'
         - name: is_assignable
           in: query
           required: false
           schema:
             type: boolean
-          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows.
+          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.
+          x-wire-examples:
+            assignable:
+              summary: Filter for assignable units.
+              value: '1'
+            unassignable:
+              summary: Filter for unassignable units.
+              value: '0'
       responses:
         '200':
           description: Organizational units retrieved successfully.

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -621,6 +621,21 @@ for (const flag of ['is_active', 'is_assignable']) {
       `GET /organizational-units must define ${flag} as an optional boolean query filter.`
     )
   }
+
+  const wireExamples = Object.values(parameter?.['x-wire-examples'] ?? {})
+  const documentedWireValues = wireExamples.map((example) => example?.value)
+  if (
+    !parameter?.description?.includes(
+      'Query-string values must be `1` for `true` and `0` for `false`'
+    ) ||
+    documentedWireValues.length !== 2 ||
+    !documentedWireValues.includes('1') ||
+    !documentedWireValues.includes('0')
+  ) {
+    contractErrors.push(
+      `GET /organizational-units must document ${flag} true and false as query-string values 1 and 0.`
+    )
+  }
 }
 
 const parentIdAlternatives = parentIdParameter?.schema?.anyOf ?? []

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -577,7 +577,10 @@ for (const flag of ['is_legal_entity', 'is_establishment']) {
   }
 }
 
-for (const flag of ['is_active', 'is_assignable']) {
+for (const [flag, trueExample, falseExample] of [
+  ['is_active', 'active', 'inactive'],
+  ['is_assignable', 'assignable', 'unassignable'],
+]) {
   if (
     !organizationalUnit.required?.includes(flag) ||
     organizationalUnit.properties?.[flag]?.type !== 'boolean'
@@ -622,15 +625,14 @@ for (const flag of ['is_active', 'is_assignable']) {
     )
   }
 
-  const wireExamples = Object.values(parameter?.['x-wire-examples'] ?? {})
-  const documentedWireValues = wireExamples.map((example) => example?.value)
+  const wireExamples = parameter?.['x-wire-examples'] ?? {}
   if (
     !parameter?.description?.includes(
-      'Query-string values must be `1` for `true` and `0` for `false`'
+      'Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.'
     ) ||
-    documentedWireValues.length !== 2 ||
-    !documentedWireValues.includes('1') ||
-    !documentedWireValues.includes('0')
+    Object.keys(wireExamples).length !== 2 ||
+    wireExamples[trueExample]?.value !== '1' ||
+    wireExamples[falseExample]?.value !== '0'
   ) {
     contractErrors.push(
       `GET /organizational-units must document ${flag} true and false as query-string values 1 and 0.`

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -38,6 +38,23 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('rejects organizational-unit boolean filters without numeric wire encoding', () => {
+  const candidate = contract.replaceAll(
+    'Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.',
+    'Filter by independent administrative status.'
+  )
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects organizational-unit boolean filters without both numeric wire values', () => {
+  const candidate = contract.replaceAll("value: '0'", "value: '1'")
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
 test('accepts schema-valid nullable example fields', () => {
   const candidate = contract.replaceAll(
     '              name: ACME Corporation GmbH\n',

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
 
 const guardPath = fileURLToPath(
   new URL('./check-openapi-verified-endpoints.mjs', import.meta.url)
@@ -17,6 +18,10 @@ const contractPath = fileURLToPath(
   new URL('../docs/openapi.yaml', import.meta.url)
 )
 const contract = readFileSync(contractPath, 'utf8')
+
+const parsedContract = yaml.load(contract)
+const organizationalUnitListParameters =
+  parsedContract.paths['/organizational-units'].get.parameters
 
 function runGuard(source) {
   const directory = mkdtempSync(join(tmpdir(), 'verified-endpoints-'))
@@ -38,6 +43,18 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('defines organizational-unit filters as booleans', () => {
+  for (const name of ['is_active', 'is_assignable']) {
+    const parameter = organizationalUnitListParameters.find(
+      (candidate) => candidate.name === name && candidate.in === 'query'
+    )
+
+    assert.deepEqual(parameter.schema, {
+      type: 'boolean',
+    })
+  }
+})
+
 test('rejects organizational-unit boolean filters without numeric wire encoding', () => {
   const candidate = contract.replaceAll(
     'Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.',
@@ -50,6 +67,16 @@ test('rejects organizational-unit boolean filters without numeric wire encoding'
 
 test('rejects organizational-unit boolean filters without both numeric wire values', () => {
   const candidate = contract.replaceAll("value: '0'", "value: '1'")
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects organizational-unit boolean filters with inverted wire examples', () => {
+  const candidate = contract
+    .replaceAll("value: '1'", 'value: __placeholder__')
+    .replaceAll("value: '0'", "value: '1'")
+    .replaceAll('value: __placeholder__', "value: '0'")
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)


### PR DESCRIPTION
# Organizational-unit boolean query encoding

Closes #348

## Verification

- A regression test first demonstrated that removing the documented numeric encoding left the organizational-unit contract guard passing; the guard now rejects that regression.
- `npm run validate` passes: 26 tests, Redocly validation, the verified-endpoints guard, and formatting.
- Push preflight also passed REUSE, domain-policy, lint, test, and formatting checks.
- The linked API validation accepts numeric boolean query values, and the linked frontend keeps boolean filter types while serializing them as `1`/`0`.

## Summary

- Document `1` for `true` and `0` for `false` for the `is_active` and `is_assignable` query filters on `GET /organizational-units`.
- Retain boolean OpenAPI schemas for generated client types and add numeric wire examples for both values of each filter.
- Guard the descriptions and both documented wire values against regression, and record the contract clarification in the changelog.

## Review status

- No linked-workspace changes are included.
- OpenAPI 3.1 has no standard primitive-boolean mapping for `true`/`false` to `1`/`0`; retaining the boolean schema, validating the wire extension, and testing the active client serializer preserves both semantic typing and the accepted request encoding.
- Cross-client generator interoperability is tracked separately in #357 and does not leave the active client path unprotected.
- All required CI checks pass, and the final PR-view self-review found no additional in-scope issues.
