### PR TITLE
Document dual boolean query encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Documented the `GET /organizational-units` `is_active` and `is_assignable`
-  boolean filters' numeric query encoding: clients send `1` for `true` and `0`
-  for `false`; textual boolean values are rejected (#348).
+- Documented interoperable `GET /organizational-units` `is_active` and
+  `is_assignable` boolean-query encodings: clients may send `1` or `true` for
+  `true`, and `0` or `false` for `false`; all other values are rejected (#358).
 - Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-blank `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
 - Grouped `github-actions` Dependabot updates in `.github/dependabot.yml` under readable identifiers (`secpal-workflows`, `github-actions`, `third-party-actions`) and added a repo-local validation guard so future PR and branch names do not fall back to full reusable-workflow paths plus pinned SHAs.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented interoperable `GET /organizational-units` `is_active` and
   `is_assignable` boolean-query encodings: clients may send `1` or `true` for
-  `true`, and `0` or `false` for `false`; all other values are rejected (#358).
+  `true`, and `0` or `false` for `false`; omitted or empty values do not apply
+  the filter, and all other non-empty values are rejected (#358).
 - Documented organizational-unit PATCH validation: changing a unit to `type: custom` requires a non-blank `custom_type_name`, and callers cannot clear the name of an existing custom unit (#346).
 - Grouped `github-actions` Dependabot updates in `.github/dependabot.yml` under readable identifiers (`secpal-workflows`, `github-actions`, `third-party-actions`) and added a repo-local validation guard so future PR and branch names do not fall back to full reusable-workflow paths plus pinned SHAs.
 - Replaced the repo-local `markdownlint-cli2` pre-commit and preflight wiring with pinned `markdownlint-cli@0.49.0` usage so markdown validation now aligns with the shared `.github` governance baseline.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9121,7 +9121,7 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Filter by independent administrative status. Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.
+          description: Filter by independent administrative status. Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.
           x-wire-examples:
             active:
               summary: Filter for active units.
@@ -9129,12 +9129,18 @@ paths:
             inactive:
               summary: Filter for inactive units.
               value: '0'
+            active_text:
+              summary: Filter for active units with textual encoding.
+              value: 'true'
+            inactive_text:
+              summary: Filter for inactive units with textual encoding.
+              value: 'false'
         - name: is_assignable
           in: query
           required: false
           schema:
             type: boolean
-          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.
+          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.
           x-wire-examples:
             assignable:
               summary: Filter for assignable units.
@@ -9142,6 +9148,12 @@ paths:
             unassignable:
               summary: Filter for unassignable units.
               value: '0'
+            assignable_text:
+              summary: Filter for assignable units with textual encoding.
+              value: 'true'
+            unassignable_text:
+              summary: Filter for unassignable units with textual encoding.
+              value: 'false'
       responses:
         '200':
           description: Organizational units retrieved successfully.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9121,7 +9121,7 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Filter by independent administrative status. Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.
+          description: Filter by independent administrative status. Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.
           x-wire-examples:
             active:
               summary: Filter for active units.
@@ -9140,7 +9140,7 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.
+          description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.
           x-wire-examples:
             assignable:
               summary: Filter for assignable units.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9119,6 +9119,7 @@ paths:
         - name: is_active
           in: query
           required: false
+          allowEmptyValue: true
           schema:
             type: boolean
           description: Filter by independent administrative status. Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.
@@ -9138,6 +9139,7 @@ paths:
         - name: is_assignable
           in: query
           required: false
+          allowEmptyValue: true
           schema:
             type: boolean
           description: Filter by independent eligibility for new operational assignments, scopes, and related workflows. Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -577,6 +577,13 @@ for (const flag of ['is_legal_entity', 'is_establishment']) {
   }
 }
 
+const allowedOrganizationalUnitBooleanWireValues = new Set([
+  '1',
+  '0',
+  'true',
+  'false',
+])
+
 for (const [
   flag,
   numericTrueExample,
@@ -642,14 +649,17 @@ for (const [
     !parameter?.description?.includes(
       'Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.'
     ) ||
-    Object.keys(wireExamples).length !== 4 ||
     wireExamples[numericTrueExample]?.value !== '1' ||
     wireExamples[numericFalseExample]?.value !== '0' ||
     wireExamples[textTrueExample]?.value !== 'true' ||
-    wireExamples[textFalseExample]?.value !== 'false'
+    wireExamples[textFalseExample]?.value !== 'false' ||
+    Object.values(wireExamples).some(
+      (example) =>
+        !allowedOrganizationalUnitBooleanWireValues.has(example?.value)
+    )
   ) {
     contractErrors.push(
-      `GET /organizational-units must document ${flag} true and false as query-string values 1/true and 0/false only.`
+      `GET /organizational-units must document ${flag} query-string values as 1 or true for true and 0 or false for false, without unrelated values.`
     )
   }
 }

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -640,9 +640,13 @@ for (const [
   const parameter = organizationalUnitListParameters.find(
     (candidate) => candidate?.name === flag && candidate?.in === 'query'
   )
-  if (parameter?.schema?.type !== 'boolean' || parameter.required !== false) {
+  if (
+    parameter?.schema?.type !== 'boolean' ||
+    parameter.required !== false ||
+    parameter.allowEmptyValue !== true
+  ) {
     contractErrors.push(
-      `GET /organizational-units must define ${flag} as an optional boolean query filter.`
+      `GET /organizational-units must define ${flag} as an optional boolean query filter that permits an empty value.`
     )
   }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -577,9 +577,21 @@ for (const flag of ['is_legal_entity', 'is_establishment']) {
   }
 }
 
-for (const [flag, trueExample, falseExample] of [
-  ['is_active', 'active', 'inactive'],
-  ['is_assignable', 'assignable', 'unassignable'],
+for (const [
+  flag,
+  numericTrueExample,
+  numericFalseExample,
+  textTrueExample,
+  textFalseExample,
+] of [
+  ['is_active', 'active', 'inactive', 'active_text', 'inactive_text'],
+  [
+    'is_assignable',
+    'assignable',
+    'unassignable',
+    'assignable_text',
+    'unassignable_text',
+  ],
 ]) {
   if (
     !organizationalUnit.required?.includes(flag) ||
@@ -628,14 +640,16 @@ for (const [flag, trueExample, falseExample] of [
   const wireExamples = parameter?.['x-wire-examples'] ?? {}
   if (
     !parameter?.description?.includes(
-      'Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.'
+      'Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.'
     ) ||
-    Object.keys(wireExamples).length !== 2 ||
-    wireExamples[trueExample]?.value !== '1' ||
-    wireExamples[falseExample]?.value !== '0'
+    Object.keys(wireExamples).length !== 4 ||
+    wireExamples[numericTrueExample]?.value !== '1' ||
+    wireExamples[numericFalseExample]?.value !== '0' ||
+    wireExamples[textTrueExample]?.value !== 'true' ||
+    wireExamples[textFalseExample]?.value !== 'false'
   ) {
     contractErrors.push(
-      `GET /organizational-units must document ${flag} true and false as query-string values 1 and 0.`
+      `GET /organizational-units must document ${flag} true and false as query-string values 1/true and 0/false only.`
     )
   }
 }

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -583,6 +583,8 @@ const allowedOrganizationalUnitBooleanWireValues = new Set([
   'true',
   'false',
 ])
+const organizationalUnitBooleanWireDescription =
+  'Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.'
 
 for (const [
   flag,
@@ -647,7 +649,7 @@ for (const [
   const wireExamples = parameter?.['x-wire-examples'] ?? {}
   if (
     !parameter?.description?.includes(
-      'Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.'
+      organizationalUnitBooleanWireDescription
     ) ||
     wireExamples[numericTrueExample]?.value !== '1' ||
     wireExamples[numericFalseExample]?.value !== '0' ||
@@ -659,7 +661,7 @@ for (const [
     )
   ) {
     contractErrors.push(
-      `GET /organizational-units must document ${flag} query-string values as 1 or true for true and 0 or false for false, without unrelated values.`
+      `GET /organizational-units must document omitted or empty ${flag} query-string values as not applying the filter, and non-empty values as 1 or true for true and 0 or false for false, without unrelated values.`
     )
   }
 }

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -55,9 +55,9 @@ test('defines organizational-unit filters as booleans', () => {
   }
 })
 
-test('rejects organizational-unit boolean filters without numeric wire encoding', () => {
+test('rejects organizational-unit boolean filters without dual wire encoding', () => {
   const candidate = contract.replaceAll(
-    'Query-string values must be `1` for `true` and `0` for `false`; textual `true` and `false` are not accepted.',
+    'Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.',
     'Filter by independent administrative status.'
   )
   const result = runGuard(candidate)
@@ -72,11 +72,25 @@ test('rejects organizational-unit boolean filters without both numeric wire valu
   assert.notEqual(result.status, 0, result.stdout)
 })
 
-test('rejects organizational-unit boolean filters with inverted wire examples', () => {
+test('rejects organizational-unit boolean filters without both textual wire values', () => {
+  const candidate = contract.replaceAll("value: 'false'", "value: 'true'")
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects organizational-unit boolean filters with inverted numeric wire examples', () => {
   const candidate = contract
     .replaceAll("value: '1'", 'value: __placeholder__')
     .replaceAll("value: '0'", "value: '1'")
     .replaceAll('value: __placeholder__', "value: '0'")
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+})
+
+test('rejects organizational-unit boolean filters with unrelated wire values', () => {
+  const candidate = contract.replaceAll("value: 'false'", "value: 'yes'")
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -89,11 +89,37 @@ test('rejects organizational-unit boolean filters with inverted numeric wire exa
   assert.notEqual(result.status, 0, result.stdout)
 })
 
-test('rejects organizational-unit boolean filters with unrelated wire values', () => {
-  const candidate = contract.replaceAll("value: 'false'", "value: 'yes'")
-  const result = runGuard(candidate)
+test('accepts additional organizational-unit wire examples with allowed values', () => {
+  const candidate = structuredClone(parsedContract)
 
-  assert.notEqual(result.status, 0, result.stdout)
+  for (const name of ['is_active', 'is_assignable']) {
+    const parameter = candidate.paths[
+      '/organizational-units'
+    ].get.parameters.find(
+      (entry) => entry.name === name && entry.in === 'query'
+    )
+    parameter['x-wire-examples'].additional_text_true = { value: 'true' }
+  }
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('rejects organizational-unit boolean filters with unrelated wire values', () => {
+  for (const name of ['is_active', 'is_assignable']) {
+    const candidate = structuredClone(parsedContract)
+    const parameter = candidate.paths[
+      '/organizational-units'
+    ].get.parameters.find(
+      (entry) => entry.name === name && entry.in === 'query'
+    )
+    parameter['x-wire-examples'].unsupported = { value: 'yes' }
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${name}: ${result.stdout}`)
+  }
 })
 
 test('accepts schema-valid nullable example fields', () => {

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -23,6 +23,30 @@ const parsedContract = yaml.load(contract)
 const organizationalUnitListParameters =
   parsedContract.paths['/organizational-units'].get.parameters
 
+function organizationalUnitListParameter(parameters, name) {
+  const parameter = parameters.find(
+    (candidate) => candidate.name === name && candidate.in === 'query'
+  )
+
+  assert.ok(
+    parameter,
+    `GET /organizational-units must define the ${name} query parameter`
+  )
+
+  return parameter
+}
+
+function organizationalUnitWireExamples(parameter, name) {
+  const wireExamples = parameter['x-wire-examples']
+
+  assert.ok(
+    wireExamples,
+    `GET /organizational-units ${name} must define x-wire-examples`
+  )
+
+  return wireExamples
+}
+
 function runGuard(source) {
   const directory = mkdtempSync(join(tmpdir(), 'verified-endpoints-'))
   const candidatePath = join(directory, 'openapi.yaml')
@@ -45,8 +69,9 @@ test('accepts the repository contract', () => {
 
 test('defines organizational-unit filters as booleans', () => {
   for (const name of ['is_active', 'is_assignable']) {
-    const parameter = organizationalUnitListParameters.find(
-      (candidate) => candidate.name === name && candidate.in === 'query'
+    const parameter = organizationalUnitListParameter(
+      organizationalUnitListParameters,
+      name
     )
 
     assert.deepEqual(parameter.schema, {
@@ -57,14 +82,31 @@ test('defines organizational-unit filters as booleans', () => {
 
 test('documents empty organizational-unit boolean filters as omitted', () => {
   for (const name of ['is_active', 'is_assignable']) {
-    const parameter = organizationalUnitListParameters.find(
-      (candidate) => candidate.name === name && candidate.in === 'query'
+    const parameter = organizationalUnitListParameter(
+      organizationalUnitListParameters,
+      name
     )
 
+    assert.equal(parameter.allowEmptyValue, true)
     assert.match(
       parameter.description,
       /Omitted or empty values do not apply the filter\./
     )
+  }
+})
+
+test('rejects organizational-unit boolean filters without empty wire allowance', () => {
+  for (const name of ['is_active', 'is_assignable']) {
+    const candidate = structuredClone(parsedContract)
+    const parameter = organizationalUnitListParameter(
+      candidate.paths['/organizational-units'].get.parameters,
+      name
+    )
+    delete parameter.allowEmptyValue
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${name}: ${result.stdout}`)
   }
 })
 
@@ -106,12 +148,15 @@ test('accepts additional organizational-unit wire examples with allowed values',
   const candidate = structuredClone(parsedContract)
 
   for (const name of ['is_active', 'is_assignable']) {
-    const parameter = candidate.paths[
-      '/organizational-units'
-    ].get.parameters.find(
-      (entry) => entry.name === name && entry.in === 'query'
+    const parameter = organizationalUnitListParameter(
+      candidate.paths['/organizational-units'].get.parameters,
+      name
     )
-    parameter['x-wire-examples'].additional_text_true = { value: 'true' }
+    const wireExamples = organizationalUnitWireExamples(
+      parameter,
+      name
+    )
+    wireExamples.additional_text_true = { value: 'true' }
   }
 
   const result = runGuard(yaml.dump(candidate))
@@ -122,12 +167,15 @@ test('accepts additional organizational-unit wire examples with allowed values',
 test('rejects organizational-unit boolean filters with unrelated wire values', () => {
   for (const name of ['is_active', 'is_assignable']) {
     const candidate = structuredClone(parsedContract)
-    const parameter = candidate.paths[
-      '/organizational-units'
-    ].get.parameters.find(
-      (entry) => entry.name === name && entry.in === 'query'
+    const parameter = organizationalUnitListParameter(
+      candidate.paths['/organizational-units'].get.parameters,
+      name
     )
-    parameter['x-wire-examples'].unsupported = { value: 'yes' }
+    const wireExamples = organizationalUnitWireExamples(
+      parameter,
+      name
+    )
+    wireExamples.unsupported = { value: 'yes' }
 
     const result = runGuard(yaml.dump(candidate))
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -55,9 +55,22 @@ test('defines organizational-unit filters as booleans', () => {
   }
 })
 
+test('documents empty organizational-unit boolean filters as omitted', () => {
+  for (const name of ['is_active', 'is_assignable']) {
+    const parameter = organizationalUnitListParameters.find(
+      (candidate) => candidate.name === name && candidate.in === 'query'
+    )
+
+    assert.match(
+      parameter.description,
+      /Omitted or empty values do not apply the filter\./
+    )
+  }
+})
+
 test('rejects organizational-unit boolean filters without dual wire encoding', () => {
   const candidate = contract.replaceAll(
-    'Query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other values are accepted.',
+    'Omitted or empty values do not apply the filter. Non-empty query-string values may be `1` or `true` for `true`, and `0` or `false` for `false`. No other non-empty values are accepted.',
     'Filter by independent administrative status.'
   )
   const result = runGuard(candidate)


### PR DESCRIPTION
# Document dual boolean query encoding

## Contract-first evidence

Before the contract update, the focused organizational-unit guard failed because
the published filters documented only numeric wire encodings and rejected
textual boolean values.

## Summary

- Document both numeric and textual encodings for `is_active` and
  `is_assignable` on `GET /organizational-units` while retaining boolean
  generated-client types.
- Require guards and tests to cover `1`, `0`, `true`, and `false` for both
  filters, allow additional examples only when they reuse those encodings, and
  reject unrelated values independently for each filter.
- Model omitted and empty values as not applying either filter, including
  machine-readable `allowEmptyValue` coverage while retaining boolean schemas.
- Record the interoperability behavior in the changelog.

Closes #358

## Validation

- `node --test scripts/check-openapi-verified-endpoints.test.mjs`
- `npm run lint`
- `npx prettier --check '**/*.{md,yml,yaml,json}'`
- `npm run validate`

## Follow-up

Runtime delivery was completed by SecPal/api#1305 and merged PR
SecPal/api#1313. Keep this PR in draft until its refreshed CI checks pass and a
final PR-view review finds no issues.
