### PR TITLE
fix: make pre-commit formatting baseline clean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,13 @@ repos:
       - id: reuse
 
   # Code formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: node_modules/.bin/prettier
+        args: [--write]
+        language: system
         types_or: [markdown, yaml, json]
         exclude: 'package-lock\.json|composer\.lock|yarn\.lock|pnpm-lock\.yaml'
 
@@ -27,11 +30,9 @@ repos:
     hooks:
       - id: markdownlint
         name: markdownlint
-        entry: markdownlint
+        entry: node_modules/.bin/markdownlint
         args: ['--config', '.markdownlint.json']
-        language: node
-        additional_dependencies:
-          - markdownlint-cli@0.49.0
+        language: system
         types: [markdown]
 
   # YAML linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: node_modules/.bin/prettier
+        entry: node node_modules/prettier/bin/prettier.cjs
         args: [--write]
         language: system
         types_or: [markdown, yaml, json]
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: markdownlint
         name: markdownlint
-        entry: node_modules/.bin/markdownlint
+        entry: node node_modules/markdownlint-cli/markdownlint.js
         args: ['--config', '.markdownlint.json']
         language: system
         types: [markdown]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Switched the Prettier and markdownlint pre-commit hooks to the pinned
+  repository-local toolchain so `pre-commit run --all-files` runs cleanly with
+  npm 12; removed trailing whitespace from the conflict-marker script
+  documentation so the formatting baseline is clean (closes #364, #366).
 - Strengthened the customer Legal Entity validation-example guard to reject
   malformed tenant metadata, request-schema violations, non-UUID assignment
   values, and contradictory accepted/rejected examples that reuse the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Switched the Prettier and markdownlint pre-commit hooks to the pinned
-  repository-local toolchain so `pre-commit run --all-files` runs cleanly with
-  npm 12; removed trailing whitespace from the conflict-marker script
-  documentation so the formatting baseline is clean (closes #364, #366).
+  repository-local toolchain, made their entrypoints portable across operating
+  systems, and bootstrapped dependencies during hook setup so
+  `pre-commit run --all-files` runs cleanly with npm 12; removed trailing
+  whitespace from the conflict-marker script documentation while preserving
+  its blockquote rendering (closes #364, #366).
 - Strengthened the customer Legal Entity validation-example guard to reject
   malformed tenant metadata, request-schema violations, non-UUID assignment
   values, and contradictory accepted/rejected examples that reuse the same

--- a/docs/scripts/CHECK_CONFLICT_MARKERS.md
+++ b/docs/scripts/CHECK_CONFLICT_MARKERS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 

--- a/docs/scripts/CHECK_CONFLICT_MARKERS.md
+++ b/docs/scripts/CHECK_CONFLICT_MARKERS.md
@@ -45,8 +45,8 @@ The script runs automatically in CI via GitHub Actions on every PR and push to `
 
 ### Pre-commit Hook
 
-> **Performance Note:**  
-> By default, `check-conflict-markers.sh` scans **all tracked files** in the repository.  
+> **Performance Note:**
+> By default, `check-conflict-markers.sh` scans **all tracked files** in the repository.
 > For large repositories, this can be slow when used as a pre-commit hook.
 
 You have two options for pre-commit integration:
@@ -78,7 +78,7 @@ if [ -f scripts/check-conflict-markers.sh ]; then
 fi
 ```
 
-> **Tip:**  
+> **Tip:**
 > The staged-files approach is much faster, but will only catch conflict markers in files you are about to commit.
 
 ## Detected Patterns

--- a/docs/scripts/CHECK_CONFLICT_MARKERS.md
+++ b/docs/scripts/CHECK_CONFLICT_MARKERS.md
@@ -46,6 +46,7 @@ The script runs automatically in CI via GitHub Actions on every PR and push to `
 ### Pre-commit Hook
 
 > **Performance Note:**
+>
 > By default, `check-conflict-markers.sh` scans **all tracked files** in the repository.
 > For large repositories, this can be slow when used as a pre-commit hook.
 
@@ -79,6 +80,7 @@ fi
 ```
 
 > **Tip:**
+>
 > The staged-files approach is much faster, but will only catch conflict markers in files you are about to commit.
 
 ## Detected Patterns

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@redocly/cli": "^2.39.0",
         "js-yaml": "^5.2.1",
-        "markdownlint-cli": "0.49.1",
+        "markdownlint-cli": "0.49.0",
         "prettier": "^3.9.5"
       }
     },
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
       "funding": [
         {
@@ -428,8 +428,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.5.0",
-        "linkify-it": "^5.0.2",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -463,23 +463,23 @@
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.1.tgz",
-      "integrity": "sha512-qpYqJbSYf3jv57bdnFmCaZ/Wlu6IYHp2b6SOKrKBJ7OnPrDHIKmx4NERWH49QH9viTI6yO6raVDDn5nrf60VQQ==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.0.tgz",
+      "integrity": "sha512-vS5tWq5W91Gg33LD4pyAaXPclnz/sRvo6/RGOyDQjQ3eds2DkK6H4szUuE0M9TiRB/u/VBx1gtd9Ktrtx5WlSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "~15.0.0",
         "deep-extend": "~0.6.0",
-        "ignore": "~7.0.6",
-        "js-yaml": "~5.2.1",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.2.0",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.3.0",
-        "markdownlint": "~0.41.1",
+        "markdown-it": "~14.2.0",
+        "markdownlint": "~0.41.0",
         "minimatch": "~10.2.5",
-        "run-con": "~1.3.3",
-        "smol-toml": "~1.7.0",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.1",
         "tinyglobby": "~0.2.17"
       },
       "bin": {
@@ -487,6 +487,29 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mdurl": {
@@ -1141,9 +1164,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@redocly/cli": "^2.39.0",
     "js-yaml": "^5.2.1",
-    "markdownlint-cli": "0.49.1",
+    "markdownlint-cli": "0.49.0",
     "prettier": "^3.9.5"
   },
   "overrides": {

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -53,26 +53,16 @@ if (!hookMatch?.groups?.hook) {
 
 const hook = hookMatch.groups.hook;
 
-if (!hook.includes("entry: markdownlint")) {
-  fail("the markdownlint pre-commit hook must invoke the markdownlint entrypoint directly.");
+if (!hook.includes("entry: node_modules/.bin/markdownlint")) {
+  fail("the markdownlint pre-commit hook must invoke the locked local markdownlint binary.");
 }
 
-if (!hook.includes("language: node")) {
-  fail("the markdownlint pre-commit hook must use language: node.");
+if (!hook.includes("language: system")) {
+  fail("the markdownlint pre-commit hook must use the repository-local toolchain.");
 }
 
-if (!hook.includes("additional_dependencies:")) {
-  fail("the markdownlint pre-commit hook must declare additional_dependencies.");
-}
-
-if (!hook.includes(`- markdownlint-cli@${EXPECTED_VERSION}`)) {
-  fail(
-    `the markdownlint pre-commit hook must pin additional_dependencies to markdownlint-cli@${EXPECTED_VERSION}.`,
-  );
-}
-
-if (hook.includes("language: system")) {
-  fail("the markdownlint pre-commit hook must not use language: system.");
+if (hook.includes("additional_dependencies:")) {
+  fail("the markdownlint pre-commit hook must not install a separate dependency tree.");
 }
 
 if (hook.includes("npx ")) {

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -20,6 +20,10 @@ const preCommitConfig = readFileSync(
   "utf8",
 );
 const preflightScript = readFileSync(new URL("../scripts/preflight.sh", import.meta.url), "utf8");
+const setupScript = readFileSync(
+  new URL("../scripts/setup-pre-commit.sh", import.meta.url),
+  "utf8",
+);
 
 const declaredVersion = packageJson.devDependencies?.["markdownlint-cli"] ?? "";
 if (declaredVersion !== EXPECTED_VERSION) {
@@ -53,8 +57,8 @@ if (!hookMatch?.groups?.hook) {
 
 const hook = hookMatch.groups.hook;
 
-if (!hook.includes("entry: node_modules/.bin/markdownlint")) {
-  fail("the markdownlint pre-commit hook must invoke the locked local markdownlint binary.");
+if (!hook.includes("entry: node node_modules/markdownlint-cli/markdownlint.js")) {
+  fail("the markdownlint pre-commit hook must invoke its locked JavaScript entrypoint.");
 }
 
 if (!hook.includes("language: system")) {
@@ -67,6 +71,20 @@ if (hook.includes("additional_dependencies:")) {
 
 if (hook.includes("npx ")) {
   fail("the markdownlint pre-commit hook must not shell out through npx.");
+}
+
+if (!preCommitConfig.includes("entry: node node_modules/prettier/bin/prettier.cjs")) {
+  fail("the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.");
+}
+
+if (!setupScript.includes('cd "$ROOT_DIR"')) {
+  fail("scripts/setup-pre-commit.sh must run from the repository root.");
+}
+
+const npmCiIndex = setupScript.search(/^npm ci$/m);
+const installHooksIndex = setupScript.search(/^pre-commit install --install-hooks$/m);
+if (npmCiIndex === -1 || installHooksIndex === -1 || npmCiIndex > installHooksIndex) {
+  fail("scripts/setup-pre-commit.sh must run npm ci before installing hooks.");
 }
 
 if (!preflightScript.includes("node_modules/.bin/markdownlint")) {

--- a/scripts/setup-pre-commit.sh
+++ b/scripts/setup-pre-commit.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
 
 echo "🔧 Setting up pre-commit hooks for SecPal..."
 
@@ -23,6 +26,15 @@ if ! command -v pre-commit &>/dev/null; then
 	echo ""
 	exit 1
 fi
+
+# Install the locked Node toolchain used by local formatter hooks.
+if ! command -v npm &>/dev/null; then
+	echo "❌ npm is not installed. Install Node.js and npm before setting up hooks."
+	exit 1
+fi
+
+echo "📦 Installing locked Node dependencies..."
+npm ci
 
 # Install pre-commit hooks
 echo "📦 Installing pre-commit hooks..."


### PR DESCRIPTION
## Reproduced failure

`pre-commit run --all-files` modified trailing whitespace in `docs/scripts/CHECK_CONFLICT_MARKERS.md` and could not initialize Node-based formatter hooks with npm 12.

## Summary

- remove the three trailing-whitespace violations in the conflict-marker documentation;
- run formatter and Markdown lint hooks from the locked repository toolchain;
- align the Markdown lint package pin and lockfile with the validation guard;
- update the guard and changelog for the restored hook baseline.

Closes #364 and #366.

## Validation

- `npm run validate`
- `pre-commit run --all-files`
- signed commit hooks and push preflight

## Follow-up

No linked workspaces or unresolved checks.
