### PR TITLE
fix: exclude documented conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Indented the documented merge-conflict marker example so the pre-commit
+  conflict check continues to catch real unindented markers during a merge
+  without failing on its own documentation (closes #369).
 - Switched the Prettier and markdownlint pre-commit hooks to the pinned
   repository-local toolchain, made their entrypoints portable across operating
   systems, and bootstrapped dependencies during hook setup so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Indented the documented merge-conflict marker example so the pre-commit
   conflict check continues to catch real unindented markers during a merge
-  without failing on its own documentation (closes #369).
+  without failing on its own documentation, and added regression coverage for
+  both documented and real markers (closes #369).
 - Switched the Prettier and markdownlint pre-commit hooks to the pinned
   repository-local toolchain, made their entrypoints portable across operating
   systems, and bootstrapped dependencies during hook setup so

--- a/docs/scripts/CHECK_CONFLICT_MARKERS.md
+++ b/docs/scripts/CHECK_CONFLICT_MARKERS.md
@@ -12,11 +12,11 @@ The `check-conflict-markers.sh` script detects unresolved Git merge conflict mar
 When resolving merge conflicts, developers sometimes forget to remove conflict markers:
 
 ```bash
-<<<<<<< HEAD
-code from current branch
-=======
-code from incoming branch
->>>>>>> feature-branch
+    <<<<<<< HEAD
+    code from current branch
+    =======
+    code from incoming branch
+    >>>>>>> feature-branch
 ```
 
 These markers cause:

--- a/scripts/check-conflict-marker-documentation.test.mjs
+++ b/scripts/check-conflict-marker-documentation.test.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const documentationPath = fileURLToPath(
+  new URL("../docs/scripts/CHECK_CONFLICT_MARKERS.md", import.meta.url),
+);
+const conflictPatterns = [
+  "<<<<<<< ",
+  "======= ",
+  "=======\n",
+  "=======\r\n",
+  ">>>>>>> ",
+];
+
+function conflictMarkerLines(source) {
+  return source
+    .match(/.*(?:\r?\n|$)/gu)
+    .flatMap((line, index) =>
+      conflictPatterns.some((pattern) => line.startsWith(pattern))
+        ? [index + 1]
+        : [],
+    );
+}
+
+test("accepts the documented conflict-marker example", () => {
+  const documentation = readFileSync(documentationPath, "utf8");
+
+  assert.deepEqual(conflictMarkerLines(documentation), []);
+});
+
+test("detects real unindented conflict markers", () => {
+  const unresolvedConflict =
+    [
+      ["<<<<<<<", "HEAD"].join(" "),
+      "current branch",
+      "=======",
+      "incoming branch",
+      [">>>>>>>", "feature-branch"].join(" "),
+    ].join("\n") + "\n";
+
+  assert.deepEqual(conflictMarkerLines(unresolvedConflict), [1, 3, 5]);
+});

--- a/scripts/check-conflict-marker-documentation.test.mjs
+++ b/scripts/check-conflict-marker-documentation.test.mjs
@@ -10,22 +10,12 @@ import { fileURLToPath } from "node:url";
 const documentationPath = fileURLToPath(
   new URL("../docs/scripts/CHECK_CONFLICT_MARKERS.md", import.meta.url),
 );
-const conflictPatterns = [
-  "<<<<<<< ",
-  "======= ",
-  "=======\n",
-  "=======\r\n",
-  ">>>>>>> ",
-];
+const conflictMarkerPattern = /^(?:<<<<<<< |=======(?: |$)|>>>>>>> )/u;
 
 function conflictMarkerLines(source) {
-  return source
-    .match(/.*(?:\r?\n|$)/gu)
-    .flatMap((line, index) =>
-      conflictPatterns.some((pattern) => line.startsWith(pattern))
-        ? [index + 1]
-        : [],
-    );
+  return source.split(/\r?\n/u).flatMap((line, index) =>
+    conflictMarkerPattern.test(line) ? [index + 1] : [],
+  );
 }
 
 test("accepts the documented conflict-marker example", () => {
@@ -45,4 +35,8 @@ test("detects real unindented conflict markers", () => {
     ].join("\n") + "\n";
 
   assert.deepEqual(conflictMarkerLines(unresolvedConflict), [1, 3, 5]);
+});
+
+test("detects an unterminated separator marker", () => {
+  assert.deepEqual(conflictMarkerLines("======="), [1]);
 });


### PR DESCRIPTION
## Reproduced defect

Before this change, the `check-merge-conflict` hook in merge mode reported the
intentional marker example in `docs/scripts/CHECK_CONFLICT_MARKERS.md` at lines
15, 17, and 19. This is the failure described in #369.

## Change

- Indent the documented marker example so it is not interpreted as an
  unresolved conflict.
- Record the correction in `CHANGELOG.md`.

Real conflict markers remain detectable because the hook continues to reject
unindented marker lines.

## Validation

- Confirmed the documented example passes the merge-mode conflict check.
- Confirmed a temporary file containing real, unindented conflict markers is
  rejected by the same hook.
- `pre-commit run --all-files`
- `npm run validate`
- Repository preflight on push

No linked workspace changes or unresolved checks remain. This PR is intentionally
opened as a draft for review.

Closes #369.
