### PR TITLE
test: guard Prettier pre-commit toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   systems, and bootstrapped dependencies during hook setup so
   `pre-commit run --all-files` runs cleanly with npm 12; removed trailing
   whitespace from the conflict-marker script documentation while preserving
-  its blockquote rendering (closes #364, #366).
+  its blockquote rendering (#364, #366).
 - Strengthened the customer Legal Entity validation-example guard to reject
   malformed tenant metadata, request-schema violations, non-UUID assignment
   values, and contradictory accepted/rejected examples that reuse the same

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -4,6 +4,8 @@
 
 import { readFileSync } from "node:fs";
 
+import { load as loadYaml } from "js-yaml";
+
 const EXPECTED_MARKDOWNLINT_VERSION = "0.49.0";
 const EXPECTED_PRETTIER_RANGE = "^3.9.5";
 const EXPECTED_PRETTIER_VERSION = "3.9.5";
@@ -11,6 +13,81 @@ const EXPECTED_PRETTIER_VERSION = "3.9.5";
 function fail(message) {
   console.error(`Error: ${message}`);
   process.exit(1);
+}
+
+function requireInvariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function validatePrettierToolchain({ packageJson, packageLock, preCommitConfig }) {
+  const declaredPrettierRange = packageJson.devDependencies?.prettier ?? "";
+  requireInvariant(
+    declaredPrettierRange === EXPECTED_PRETTIER_RANGE,
+    `package.json must declare Prettier as ${EXPECTED_PRETTIER_RANGE}, found ${declaredPrettierRange || "missing"}.`,
+  );
+
+  const lockfileDeclaredPrettierRange = packageLock.packages?.[""]?.devDependencies?.prettier ?? "";
+  requireInvariant(
+    lockfileDeclaredPrettierRange === EXPECTED_PRETTIER_RANGE,
+    `package-lock.json root package must declare Prettier as ${EXPECTED_PRETTIER_RANGE}, found ${lockfileDeclaredPrettierRange || "missing"}.`,
+  );
+
+  const lockedPrettierVersion = packageLock.packages?.["node_modules/prettier"]?.version ?? "";
+  requireInvariant(
+    lockedPrettierVersion === EXPECTED_PRETTIER_VERSION,
+    `package-lock.json must resolve node_modules/prettier to ${EXPECTED_PRETTIER_VERSION}, found ${lockedPrettierVersion || "missing"}.`,
+  );
+
+  let config;
+  try {
+    config = loadYaml(preCommitConfig);
+  } catch (error) {
+    throw new Error(`could not parse .pre-commit-config.yaml: ${error.message}`, { cause: error });
+  }
+
+  const repositories = Array.isArray(config?.repos) ? config.repos : [];
+  requireInvariant(
+    !repositories.some((repository) =>
+      String(repository?.repo ?? "").includes("github.com/pre-commit/mirrors-prettier"),
+    ),
+    ".pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.",
+  );
+
+  const prettierHooks = repositories.flatMap((repository) =>
+    (Array.isArray(repository?.hooks) ? repository.hooks : [])
+      .filter((hook) => hook?.id === "prettier")
+      .map((hook) => ({ hook, repository: repository.repo })),
+  );
+
+  requireInvariant(
+    prettierHooks.length > 0,
+    "could not locate the Prettier hook in .pre-commit-config.yaml.",
+  );
+  requireInvariant(
+    prettierHooks.length === 1,
+    ".pre-commit-config.yaml must define exactly one Prettier hook.",
+  );
+
+  const [{ hook: prettierHook, repository }] = prettierHooks;
+  requireInvariant(
+    repository === "local",
+    "the Prettier pre-commit hook must use the repository-local toolchain.",
+  );
+  requireInvariant(
+    prettierHook.entry === "node node_modules/prettier/bin/prettier.cjs",
+    "the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.",
+  );
+  requireInvariant(
+    prettierHook.language === "system",
+    "the Prettier pre-commit hook must use the repository-local toolchain.",
+  );
+  requireInvariant(
+    !Object.hasOwn(prettierHook, "additional_dependencies") &&
+      !JSON.stringify(prettierHook).includes("--ignore-prepublish"),
+    "the Prettier pre-commit hook must not configure a separate npm environment.",
+  );
 }
 
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
@@ -34,33 +111,25 @@ if (declaredVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   );
 }
 
-const lockfileDeclaredVersion = packageLock.packages?.[""]?.devDependencies?.["markdownlint-cli"] ?? "";
+const lockfileDeclaredVersion =
+  packageLock.packages?.[""]?.devDependencies?.["markdownlint-cli"] ?? "";
 if (lockfileDeclaredVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   fail(
     `package-lock.json root package must pin markdownlint-cli to ${EXPECTED_MARKDOWNLINT_VERSION}, found ${lockfileDeclaredVersion || "missing"}.`,
   );
 }
 
-const lockedPackageVersion =
-  packageLock.packages?.["node_modules/markdownlint-cli"]?.version ?? "";
+const lockedPackageVersion = packageLock.packages?.["node_modules/markdownlint-cli"]?.version ?? "";
 if (lockedPackageVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   fail(
     `package-lock.json must resolve node_modules/markdownlint-cli to ${EXPECTED_MARKDOWNLINT_VERSION}, found ${lockedPackageVersion || "missing"}.`,
   );
 }
 
-const declaredPrettierRange = packageJson.devDependencies?.prettier ?? "";
-if (declaredPrettierRange !== EXPECTED_PRETTIER_RANGE) {
-  fail(
-    `package.json must declare Prettier as ${EXPECTED_PRETTIER_RANGE}, found ${declaredPrettierRange || "missing"}.`,
-  );
-}
-
-const lockedPrettierVersion = packageLock.packages?.["node_modules/prettier"]?.version ?? "";
-if (lockedPrettierVersion !== EXPECTED_PRETTIER_VERSION) {
-  fail(
-    `package-lock.json must resolve node_modules/prettier to ${EXPECTED_PRETTIER_VERSION}, found ${lockedPrettierVersion || "missing"}.`,
-  );
+try {
+  validatePrettierToolchain({ packageJson, packageLock, preCommitConfig });
+} catch (error) {
+  fail(error.message);
 }
 
 const markdownlintHookPattern =
@@ -87,32 +156,6 @@ if (hook.includes("additional_dependencies:")) {
 
 if (hook.includes("npx ")) {
   fail("the markdownlint pre-commit hook must not shell out through npx.");
-}
-
-const prettierHookPattern =
-  /- id: prettier\b(?<hook>.*?)(?=\n\s*-\s+id:|\n\s*#\s|\n\s*-\s+repo:|\z)/s;
-const prettierHookMatch = preCommitConfig.match(prettierHookPattern);
-
-if (!prettierHookMatch?.groups?.hook) {
-  fail("could not locate the Prettier hook in .pre-commit-config.yaml.");
-}
-
-const prettierHook = prettierHookMatch.groups.hook;
-
-if (!prettierHook.includes("entry: node node_modules/prettier/bin/prettier.cjs")) {
-  fail("the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.");
-}
-
-if (!prettierHook.includes("language: system")) {
-  fail("the Prettier pre-commit hook must use the repository-local toolchain.");
-}
-
-if (prettierHook.includes("additional_dependencies:") || prettierHook.includes("--ignore-prepublish")) {
-  fail("the Prettier pre-commit hook must not configure a separate npm environment.");
-}
-
-if (preCommitConfig.includes("github.com/pre-commit/mirrors-prettier")) {
-  fail(".pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.");
 }
 
 if (!setupScript.includes('cd "$ROOT_DIR"')) {

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -4,7 +4,9 @@
 
 import { readFileSync } from "node:fs";
 
-const EXPECTED_VERSION = "0.49.0";
+const EXPECTED_MARKDOWNLINT_VERSION = "0.49.0";
+const EXPECTED_PRETTIER_RANGE = "^3.9.5";
+const EXPECTED_PRETTIER_VERSION = "3.9.5";
 
 function fail(message) {
   console.error(`Error: ${message}`);
@@ -26,24 +28,38 @@ const setupScript = readFileSync(
 );
 
 const declaredVersion = packageJson.devDependencies?.["markdownlint-cli"] ?? "";
-if (declaredVersion !== EXPECTED_VERSION) {
+if (declaredVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   fail(
-    `package.json must pin markdownlint-cli to ${EXPECTED_VERSION}, found ${declaredVersion || "missing"}.`,
+    `package.json must pin markdownlint-cli to ${EXPECTED_MARKDOWNLINT_VERSION}, found ${declaredVersion || "missing"}.`,
   );
 }
 
 const lockfileDeclaredVersion = packageLock.packages?.[""]?.devDependencies?.["markdownlint-cli"] ?? "";
-if (lockfileDeclaredVersion !== EXPECTED_VERSION) {
+if (lockfileDeclaredVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   fail(
-    `package-lock.json root package must pin markdownlint-cli to ${EXPECTED_VERSION}, found ${lockfileDeclaredVersion || "missing"}.`,
+    `package-lock.json root package must pin markdownlint-cli to ${EXPECTED_MARKDOWNLINT_VERSION}, found ${lockfileDeclaredVersion || "missing"}.`,
   );
 }
 
 const lockedPackageVersion =
   packageLock.packages?.["node_modules/markdownlint-cli"]?.version ?? "";
-if (lockedPackageVersion !== EXPECTED_VERSION) {
+if (lockedPackageVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
   fail(
-    `package-lock.json must resolve node_modules/markdownlint-cli to ${EXPECTED_VERSION}, found ${lockedPackageVersion || "missing"}.`,
+    `package-lock.json must resolve node_modules/markdownlint-cli to ${EXPECTED_MARKDOWNLINT_VERSION}, found ${lockedPackageVersion || "missing"}.`,
+  );
+}
+
+const declaredPrettierRange = packageJson.devDependencies?.prettier ?? "";
+if (declaredPrettierRange !== EXPECTED_PRETTIER_RANGE) {
+  fail(
+    `package.json must declare Prettier as ${EXPECTED_PRETTIER_RANGE}, found ${declaredPrettierRange || "missing"}.`,
+  );
+}
+
+const lockedPrettierVersion = packageLock.packages?.["node_modules/prettier"]?.version ?? "";
+if (lockedPrettierVersion !== EXPECTED_PRETTIER_VERSION) {
+  fail(
+    `package-lock.json must resolve node_modules/prettier to ${EXPECTED_PRETTIER_VERSION}, found ${lockedPrettierVersion || "missing"}.`,
   );
 }
 
@@ -73,8 +89,30 @@ if (hook.includes("npx ")) {
   fail("the markdownlint pre-commit hook must not shell out through npx.");
 }
 
-if (!preCommitConfig.includes("entry: node node_modules/prettier/bin/prettier.cjs")) {
+const prettierHookPattern =
+  /- id: prettier\b(?<hook>.*?)(?=\n\s*-\s+id:|\n\s*#\s|\n\s*-\s+repo:|\z)/s;
+const prettierHookMatch = preCommitConfig.match(prettierHookPattern);
+
+if (!prettierHookMatch?.groups?.hook) {
+  fail("could not locate the Prettier hook in .pre-commit-config.yaml.");
+}
+
+const prettierHook = prettierHookMatch.groups.hook;
+
+if (!prettierHook.includes("entry: node node_modules/prettier/bin/prettier.cjs")) {
   fail("the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.");
+}
+
+if (!prettierHook.includes("language: system")) {
+  fail("the Prettier pre-commit hook must use the repository-local toolchain.");
+}
+
+if (prettierHook.includes("additional_dependencies:") || prettierHook.includes("--ignore-prepublish")) {
+  fail("the Prettier pre-commit hook must not configure a separate npm environment.");
+}
+
+if (preCommitConfig.includes("github.com/pre-commit/mirrors-prettier")) {
+  fail(".pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.");
 }
 
 if (!setupScript.includes('cd "$ROOT_DIR"')) {

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -21,6 +21,24 @@ function requireInvariant(condition, message) {
   }
 }
 
+function parsePreCommitConfig(preCommitConfig) {
+  try {
+    return loadYaml(preCommitConfig);
+  } catch (error) {
+    throw new Error(`could not parse .pre-commit-config.yaml: ${error.message}`, { cause: error });
+  }
+}
+
+function findHooks(config, hookId) {
+  const repositories = Array.isArray(config?.repos) ? config.repos : [];
+
+  return repositories.flatMap((repository) =>
+    (Array.isArray(repository?.hooks) ? repository.hooks : [])
+      .filter((hook) => hook?.id === hookId)
+      .map((hook) => ({ hook, repository: repository.repo })),
+  );
+}
+
 export function validatePrettierToolchain({ packageJson, packageLock, preCommitConfig }) {
   const declaredPrettierRange = packageJson.devDependencies?.prettier ?? "";
   requireInvariant(
@@ -40,13 +58,7 @@ export function validatePrettierToolchain({ packageJson, packageLock, preCommitC
     `package-lock.json must resolve node_modules/prettier to ${EXPECTED_PRETTIER_VERSION}, found ${lockedPrettierVersion || "missing"}.`,
   );
 
-  let config;
-  try {
-    config = loadYaml(preCommitConfig);
-  } catch (error) {
-    throw new Error(`could not parse .pre-commit-config.yaml: ${error.message}`, { cause: error });
-  }
-
+  const config = parsePreCommitConfig(preCommitConfig);
   const repositories = Array.isArray(config?.repos) ? config.repos : [];
   requireInvariant(
     !repositories.some((repository) =>
@@ -55,11 +67,7 @@ export function validatePrettierToolchain({ packageJson, packageLock, preCommitC
     ".pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.",
   );
 
-  const prettierHooks = repositories.flatMap((repository) =>
-    (Array.isArray(repository?.hooks) ? repository.hooks : [])
-      .filter((hook) => hook?.id === "prettier")
-      .map((hook) => ({ hook, repository: repository.repo })),
-  );
+  const prettierHooks = findHooks(config, "prettier");
 
   requireInvariant(
     prettierHooks.length > 0,
@@ -87,6 +95,41 @@ export function validatePrettierToolchain({ packageJson, packageLock, preCommitC
     !Object.hasOwn(prettierHook, "additional_dependencies") &&
       !JSON.stringify(prettierHook).includes("--ignore-prepublish"),
     "the Prettier pre-commit hook must not configure a separate npm environment.",
+  );
+}
+
+export function validateMarkdownlintToolchain(preCommitConfig) {
+  const markdownlintHooks = findHooks(parsePreCommitConfig(preCommitConfig), "markdownlint");
+
+  requireInvariant(
+    markdownlintHooks.length > 0,
+    "could not locate the markdownlint hook in .pre-commit-config.yaml.",
+  );
+  requireInvariant(
+    markdownlintHooks.length === 1,
+    ".pre-commit-config.yaml must define exactly one markdownlint hook.",
+  );
+
+  const [{ hook: markdownlintHook, repository }] = markdownlintHooks;
+  requireInvariant(
+    repository === "local",
+    "the markdownlint pre-commit hook must use the repository-local toolchain.",
+  );
+  requireInvariant(
+    markdownlintHook.entry === "node node_modules/markdownlint-cli/markdownlint.js",
+    "the markdownlint pre-commit hook must invoke its locked JavaScript entrypoint.",
+  );
+  requireInvariant(
+    markdownlintHook.language === "system",
+    "the markdownlint pre-commit hook must use the repository-local toolchain.",
+  );
+  requireInvariant(
+    !Object.hasOwn(markdownlintHook, "additional_dependencies"),
+    "the markdownlint pre-commit hook must not install a separate dependency tree.",
+  );
+  requireInvariant(
+    !JSON.stringify(markdownlintHook).includes("npx "),
+    "the markdownlint pre-commit hook must not shell out through npx.",
   );
 }
 
@@ -128,34 +171,9 @@ if (lockedPackageVersion !== EXPECTED_MARKDOWNLINT_VERSION) {
 
 try {
   validatePrettierToolchain({ packageJson, packageLock, preCommitConfig });
+  validateMarkdownlintToolchain(preCommitConfig);
 } catch (error) {
   fail(error.message);
-}
-
-const markdownlintHookPattern =
-  /- id: markdownlint\b(?<hook>.*?)(?=\n\s*-\s+id:|\n\s*#\s|\n\s*-\s+repo:|\z)/s;
-const hookMatch = preCommitConfig.match(markdownlintHookPattern);
-
-if (!hookMatch?.groups?.hook) {
-  fail("could not locate the markdownlint hook in .pre-commit-config.yaml.");
-}
-
-const hook = hookMatch.groups.hook;
-
-if (!hook.includes("entry: node node_modules/markdownlint-cli/markdownlint.js")) {
-  fail("the markdownlint pre-commit hook must invoke its locked JavaScript entrypoint.");
-}
-
-if (!hook.includes("language: system")) {
-  fail("the markdownlint pre-commit hook must use the repository-local toolchain.");
-}
-
-if (hook.includes("additional_dependencies:")) {
-  fail("the markdownlint pre-commit hook must not install a separate dependency tree.");
-}
-
-if (hook.includes("npx ")) {
-  fail("the markdownlint pre-commit hook must not shell out through npx.");
 }
 
 if (!setupScript.includes('cd "$ROOT_DIR"')) {

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -5,7 +5,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { validatePrettierToolchain } from "./check-markdownlint-toolchain.mjs";
+import {
+  validateMarkdownlintToolchain,
+  validatePrettierToolchain,
+} from "./check-markdownlint-toolchain.mjs";
 
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const packageLock = JSON.parse(
@@ -75,4 +78,33 @@ repos:
       - id: prettier`;
 
   assert.throws(() => validate(config), /must not use the obsolete mirrors-prettier hook/);
+});
+
+test("accepts the repository-local markdownlint hook at end of file", () => {
+  const config = `---
+repos:
+  - repo: local
+    hooks:
+      - id: markdownlint
+        entry: node node_modules/markdownlint-cli/markdownlint.js
+        language: system`;
+
+  assert.doesNotThrow(() => validateMarkdownlintToolchain(config));
+});
+
+test("rejects a markdownlint hook with a separate dependency tree", () => {
+  const config = `---
+repos:
+  - repo: local
+    hooks:
+      - id: markdownlint
+        entry: node node_modules/markdownlint-cli/markdownlint.js
+        language: system
+        additional_dependencies:
+          - markdownlint-cli@0.49.0`;
+
+  assert.throws(
+    () => validateMarkdownlintToolchain(config),
+    /must not install a separate dependency tree/,
+  );
 });

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { validatePrettierToolchain } from "./check-markdownlint-toolchain.mjs";
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const packageLock = JSON.parse(
+  readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
+);
+
+const validHook = `---
+repos:
+  - repo: local
+    hooks:
+      - id: prettier
+        entry: node node_modules/prettier/bin/prettier.cjs
+        language: system`;
+
+function validate(preCommitConfig, lockfile = packageLock) {
+  validatePrettierToolchain({
+    packageJson,
+    packageLock: lockfile,
+    preCommitConfig,
+  });
+}
+
+test("accepts the locked repository-local Prettier hook at end of file", () => {
+  assert.doesNotThrow(() => validate(validHook));
+});
+
+test("rejects additional dependencies after an explanatory comment", () => {
+  const config = `${validHook}
+        # This dependency would create a separate toolchain.
+        additional_dependencies:
+          - prettier@3.9.5`;
+
+  assert.throws(() => validate(config), /must not configure a separate npm environment/);
+});
+
+test("rejects an unlocked entry even when a comment contains the expected command", () => {
+  const config = validHook.replace(
+    "entry: node node_modules/prettier/bin/prettier.cjs",
+    "entry: npx prettier # entry: node node_modules/prettier/bin/prettier.cjs",
+  );
+
+  assert.throws(() => validate(config), /must invoke its locked JavaScript entrypoint/);
+});
+
+test("rejects a prefixed hook id", () => {
+  const config = validHook.replace("id: prettier", "id: prettier-extra");
+
+  assert.throws(() => validate(config), /could not locate the Prettier hook/);
+});
+
+test("rejects a mismatched root lockfile declaration", () => {
+  const mismatchedLockfile = structuredClone(packageLock);
+  mismatchedLockfile.packages[""].devDependencies.prettier = "^3.9.4";
+
+  assert.throws(
+    () => validate(validHook, mismatchedLockfile),
+    /package-lock.json root package must declare Prettier as \^3\.9\.5/,
+  );
+});
+
+test("rejects the obsolete Prettier mirror", () => {
+  const config = `---
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier`;
+
+  assert.throws(() => validate(config), /must not use the obsolete mirrors-prettier hook/);
+});


### PR DESCRIPTION
## Reproduction

With Node.js 22 and npm 12, the former `mirrors-prettier` hook environment passed the unsupported `--ignore-prepublish` npm option. npm stopped with `EUNKNOWNCONFIG`, preventing `pre-commit run --all-files` from running the full hook suite.

## Summary

- add a regression guard for the repository-local Prettier hook, its locked dependency resolution, and the absence of the obsolete mirror or separate npm environment;
- keep the changelog reference to #366 neutral while this draft PR is awaiting review.

## Validation

- `node scripts/check-markdownlint-toolchain.mjs`
- `npm run lint`
- `npm run format:check`
- `npm run validate`
- `pre-commit run --all-files` with Node.js 22.23.1 and npm 12.0.0
- local pre-push validation, including REUSE compliance and domain-policy checks

## Follow-up before ready for review

- Linked workspaces: none used.
- No unresolved local checks. Keep this PR as a draft until the final PR-view self-review and required CI checks complete.

Closes #366.
