### PR TITLE
docs: remove DDEV contributor workflow guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,10 +341,10 @@ SecPal uses [Codecov](https://codecov.io) for automated code coverage tracking a
 
 ```bash
 # Run tests with coverage
-ddev exec php artisan test --coverage-clover coverage.xml
+php artisan test --coverage-clover coverage.xml
 
 # View HTML report
-ddev exec php artisan test --coverage-html coverage-html/
+php artisan test --coverage-html coverage-html/
 open coverage-html/index.html
 ```
 


### PR DESCRIPTION
## Reproduction

Before this change, `CONTRIBUTING.md` instructed contributors to run the Laravel coverage commands through `ddev exec`. That workflow no longer exists, so the documented commands could not run in the native API environment.

## Summary

- Replace the two DDEV-wrapped Laravel coverage commands with direct `php artisan test` commands.
- Keep the generated coverage artifact paths and report-viewing instructions unchanged.

## Tracking

- Epic: SecPal/frontend#1424
- Closes #374

## Validation

- `npm run validate`
- `git diff --check origin/main...HEAD`
- Commit signature verified as valid.
- CI is green, including REUSE compliance, Markdown linting, formatting, OpenAPI validation, and CodeQL.

## Related work

- [API](https://github.com/SecPal/api/pull/1324)
- [Frontend](https://github.com/SecPal/frontend/pull/1423)
- [Android](https://github.com/SecPal/android/pull/397)

No unresolved checks remain for this contracts PR. The coordinated rollout remains tracked by the epic and linked sub-issues.
