### PR TITLE
feat: [US-001] Breaking OpenAPI domain contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing link; dependent links and sites block incompatible reassignment or
   deletion. Site and employee updates validate the complete resulting domain
   assignment, and referenced Legal Entities or establishments cannot be
-  role-downgraded or deleted. Added separate minimal lookups for customers
-  already linked to an establishment and eligible unlinked link candidates,
-  plus authorized Legal Entity and establishment lookups covering both create
-  and reassignment permissions. Dependency-blocked customer reassignment uses
-  an explicit conflict response, and one atomic, information-poor duplicate-conflict
-  response is shared by all domain create operations. Existing
-  organizational-unit and scope administration contracts remain unchanged
+  role-downgraded or deleted; these dependency conflicts add explicit `409`
+  responses to organizational-unit administration. Added separate minimal
+  lookups for customers already linked to an establishment and eligible
+  unlinked link candidates, plus authorized Legal Entity and establishment
+  lookups covering both create and reassignment permissions. Dependency-blocked
+  customer reassignment uses an explicit conflict response, and one atomic,
+  information-poor duplicate-conflict response is shared by all domain create
+  operations. Local customer-establishment contact data remains reusable and
+  only the tenant-scoped customer/establishment pair is unique
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   customer/establishment link plus local contact data. Site and employee
   requests and responses now require explicit `legal_entity_id` and
   `establishment_id` relationships; customer, site, and employee contracts and
-  list filters no longer expose OU fields or relations. Added minimal authorized
-  Legal Entity, establishment, and customer lookups plus one atomic,
-  information-poor duplicate-conflict response shared by all domain create
-  operations. Existing organizational-unit and scope administration contracts
-  remain unchanged (US-001; supersedes the unreleased customer-only US-002
-  lookup surface).
+  list filters no longer expose OU fields or relations. Single-customer
+  responses no longer advertise undeclared relationship includes; dedicated
+  relationship endpoints remain available, with complete pagination metadata
+  for customer/establishment links. Added minimal authorized Legal Entity,
+  establishment, and customer lookups plus one atomic, information-poor
+  duplicate-conflict response shared by all domain create operations. Existing
+  organizational-unit and scope administration contracts remain unchanged
+  (US-001; supersedes the unreleased customer-only US-002 lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.
 - Added `npm test` as the standard contract-test entry point; it runs the repository's canonical lint and formatting validation pipeline (closes #339).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while customer and site create schemas retain the API-supported nullable
   business identifiers, activation defaults, and contact input. Customer and
   Site record reads now distinguish assignment access from OU scopes that can
-  open an empty collection but grant no record visibility, and their domain
-  writes explicitly reject OU-scoped callers. Employee create, update, and
+  open an empty collection but grant no record visibility. All create, update,
+  and delete operations for Customer, CustomerEstablishment, and Site
+  explicitly reject OU-scoped callers. Employee create, update, and
   lookup contracts name the effective `employee.write`, `employee.create`, and
   `employee.update` permissions
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing link; dependent links and sites block incompatible reassignment or
   deletion. Site and employee updates validate the complete resulting domain
   assignment, and referenced Legal Entities or establishments cannot be
-  deleted. Added minimal authorized Legal Entity,
-  establishment, and customer lookups plus one atomic, information-poor
+  role-downgraded or deleted. Added separate minimal lookups for customers
+  already linked to an establishment and eligible unlinked link candidates,
+  plus authorized Legal Entity and establishment lookups and one atomic, information-poor
   duplicate-conflict response shared by all domain create operations. Existing
   organizational-unit and scope administration contracts remain unchanged
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list filters no longer expose OU fields or relations. Single-customer
   responses no longer advertise undeclared relationship includes; dedicated
   relationship endpoints remain available, with complete pagination metadata
-  for customer/establishment links. Added minimal authorized Legal Entity,
+  for customer/establishment links. Customer-establishment links now require
+  tenant- and Legal-Entity-consistent assignments, and sites require an
+  existing link; dependent links and sites block incompatible reassignment or
+  link deletion. Added minimal authorized Legal Entity,
   establishment, and customer lookups plus one atomic, information-poor
   duplicate-conflict response shared by all domain create operations. Existing
   organizational-unit and scope administration contracts remain unchanged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,21 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Defined the customer Legal Entity assignment contract: customer responses and
-  customer create/update payloads carry the explicit same-tenant
-  `legal_entity_id` relationship, while the contract explicitly prohibits a
-  default assignment for existing customers. Any backfill remains blocked until
-  a product-approved deterministic tenant-consistent rule is available.
-  Create and reassignment schemas include accepted same-tenant and rejected
-  cross-tenant validation examples (closes #351; parent epic
-  `SecPal/frontend#1391`).
-- Added the optional nullable customer `vat_id` field to customer responses and
-  create/update request contracts.
-- **Breaking:** Required `legal_entity_id` on customer responses and
-  `POST /customers` request payloads, documented optional authorized
-  Legal Entity reassignment through `PATCH /customers/{customer}`, and documented the narrow
-  `GET /customers/legal-entities` lookup for same-tenant, active,
-  non-deleted Legal Entity options with organizational write access (US-002).
+- **Breaking:** Defined OU-free domain contracts for Legal Entities,
+  establishments, customers, sites, and employees. Customer now contains only
+  Legal-Entity-wide master data (including billing address, optional VAT ID,
+  and status), while `CustomerEstablishment` owns the unique
+  customer/establishment link plus local contact data. Site and employee
+  requests and responses now require explicit `legal_entity_id` and
+  `establishment_id` relationships; customer, site, and employee contracts and
+  list filters no longer expose OU fields or relations. Added minimal authorized
+  Legal Entity, establishment, and customer lookups plus one atomic,
+  information-poor duplicate-conflict response shared by all domain create
+  operations. Existing organizational-unit and scope administration contracts
+  remain unchanged (US-001; supersedes the unreleased customer-only US-002
+  lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.
 - Added `npm test` as the standard contract-test entry point; it runs the repository's canonical lint and formatting validation pipeline (closes #339).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assignment, and referenced Legal Entities or establishments cannot be
   role-downgraded or deleted. Added separate minimal lookups for customers
   already linked to an establishment and eligible unlinked link candidates,
-  plus authorized Legal Entity and establishment lookups and one atomic, information-poor
-  duplicate-conflict response shared by all domain create operations. Existing
+  plus authorized Legal Entity and establishment lookups covering both create
+  and reassignment permissions. Dependency-blocked customer reassignment uses
+  an explicit conflict response, and one atomic, information-poor duplicate-conflict
+  response is shared by all domain create operations. Existing
   organizational-unit and scope administration contracts remain unchanged
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for customer/establishment links. Customer-establishment links now require
   tenant- and Legal-Entity-consistent assignments, and sites require an
   existing link; dependent links and sites block incompatible reassignment or
-  link deletion. Added minimal authorized Legal Entity,
+  deletion. Site and employee updates validate the complete resulting domain
+  assignment, and referenced Legal Entities or establishments cannot be
+  deleted. Added minimal authorized Legal Entity,
   establishment, and customer lookups plus one atomic, information-poor
   duplicate-conflict response shared by all domain create operations. Existing
   organizational-unit and scope administration contracts remain unchanged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tenant- and Legal-Entity-consistent assignments, and sites require an
   existing link; dependent links and sites block incompatible reassignment or
   deletion. Site and employee updates validate the complete resulting domain
-  assignment, and referenced Legal Entities or establishments cannot be
-  role-downgraded or deleted; these dependency conflicts add explicit `409`
-  responses to organizational-unit administration. Added separate minimal
+  assignment. Tenant-local Legal Entities and establishments use active and
+  soft-deleted lifecycle state without inheriting OU `is_assignable` or role
+  flags, so organizational-unit administration remains lifecycle-independent.
+  Added separate minimal
   lookups for customers already linked to an establishment and eligible
   unlinked link candidates, plus authorized Legal Entity and establishment
   lookups covering both create and reassignment permissions. Dependency-blocked
@@ -40,8 +41,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only the tenant-scoped customer/establishment pair is unique. Employee
   creation audit examples now use the runtime `employee_changes` category,
   carry Legal Entity and establishment IDs, and omit obsolete OU and personal
-  name fields. Employee-qualification listing now documents that OU scopes do
-  not grant access to domain employees and cause the runtime `403` boundary
+  name values across attributes and subject embeds. All Employee Qualification
+  and Employee Document operations now document that OU scopes do not grant
+  access to domain employees, including explicit self-service exceptions and
+  fail-closed `403` behavior for scoped non-self access. Migrated customer,
+  site, and employee collection filters now match the domain API identifiers
+  and search fields, and the unsupported site `currently_valid` filter was
+  removed. Closed customer responses retain the caller-visible `sites_count`,
+  while customer and site create schemas retain the API-supported nullable
+  business identifiers, activation defaults, and contact input. Customer and
+  Site record reads now distinguish assignment access from OU scopes that can
+  open an empty collection but grant no record visibility, and their domain
+  writes explicitly reject OU-scoped callers. Employee create, update, and
+  lookup contracts name the effective `employee.write`, `employee.create`, and
+  `employee.update` permissions
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   customer reassignment uses an explicit conflict response, and one atomic,
   information-poor duplicate-conflict response is shared by all domain create
   operations. Local customer-establishment contact data remains reusable and
-  only the tenant-scoped customer/establishment pair is unique
+  only the tenant-scoped customer/establishment pair is unique. Employee
+  creation audit examples now use the runtime `employee_changes` category,
+  carry Legal Entity and establishment IDs, and omit obsolete OU and personal
+  name fields. Employee-qualification listing now documents that OU scopes do
+  not grant access to domain employees and cause the runtime `403` boundary
   (US-001; supersedes the unreleased customer-only US-002 lookup surface).
 - Defined independent organizational-unit `is_active` (administrative status) and `is_assignable` (eligibility for new operational assignments, scopes, and related workflows) flags across response, create, update, and list-filter contracts (closes #338). Both response fields are required booleans and neither is derived from hierarchy, soft deletion, parent status, unit type, or the other flag; create requests default both omitted status fields to `true`, and deletion remains blocked by every non-deleted direct child regardless of its `is_active` value. This is an additive response change: clients generated from older contracts should regenerate types before relying on the fields, while clients that may deserialize cached or staged older responses must tolerate either newly documented field being absent until their deployment is fully aligned.
 - Documented the organizational-unit OpenAPI surface in `docs/openapi.yaml`, including all nine verified OU operations, reusable response/request/permissions/collection/pagination/conflict schemas, full-resource relationship shapes, PATCH-safe independent `is_legal_entity` and `is_establishment` boolean flags, the conditional custom type-name requirement, exact root-or-UUID filtering, tenant isolation, need-to-know parent filtering, policy behavior, type hierarchy validation, and semantic verified-endpoint guard coverage for the OU routes.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8061,8 +8061,8 @@ paths:
                     data:
                       - id: 550e8400-e29b-41d4-a716-446655440001
                         tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                        log_name: employee
-                        description: Created Employee "John Doe"
+                        log_name: employee_changes
+                        description: created
                         subject_type: App\Models\Employee
                         subject_id: 550e8400-e29b-41d4-a716-446655440010
                         causer_type: App\Models\User
@@ -8070,8 +8070,10 @@ paths:
                         event: created
                         properties:
                           attributes:
-                            name: John Doe
+                            employee_number: EMP-2026-0001
                             status: active
+                            legal_entity_id: 770e8400-e29b-41d4-a716-446655440000
+                            establishment_id: 780e8400-e29b-41d4-a716-446655440000
                         ip_address: 192.0.2.1
                         user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
                         batch_uuid: 550e8400-e29b-41d4-a716-446655440100
@@ -8250,8 +8252,8 @@ paths:
                     data:
                       id: 550e8400-e29b-41d4-a716-446655440001
                       tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                      log_name: employee
-                      description: Created Employee "John Doe"
+                      log_name: employee_changes
+                      description: created
                       subject_type: App\Models\Employee
                       subject_id: 550e8400-e29b-41d4-a716-446655440010
                       causer_type: App\Models\User
@@ -8259,9 +8261,10 @@ paths:
                       event: created
                       properties:
                         attributes:
-                          name: John Doe
+                          employee_number: EMP-2026-0001
                           status: active
-                          organizational_unit_id: 550e8400-e29b-41d4-a716-446655440030
+                          legal_entity_id: 770e8400-e29b-41d4-a716-446655440000
+                          establishment_id: 780e8400-e29b-41d4-a716-446655440000
                         ip: 192.0.2.1
                         user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
                       ip_address: 192.0.2.1
@@ -8977,8 +8980,8 @@ paths:
 
         **Relations:** `employee` and `qualification` are eager-loaded; each `data[]` item includes both embeds.
 
-        **Organizational scope:** users with `User::organizationalScopes` only see employees in their allowed units; otherwise the controller
-        returns HTTP **403** (with an English message such as “You do not have access to this employee's organizational unit”).
+        **Authorization boundary:** OU scopes do not grant access to domain employees. A caller with any organizational scopes
+        (`User::organizationalScopes`) receives HTTP **403** with “No organizational entitlement exists for this employee.” Unscoped callers still require the permission below.
 
         **Authorization:** `employee_qualification.read` via `EmployeeQualificationPolicy::viewAny`.
       operationId: listEmployeeQualifications

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8600,7 +8600,7 @@ paths:
 
     patch:
       summary: Update Employee
-      description: Update employee details with partial-update semantics. If either domain relationship is supplied, the resulting stored Legal Entity and establishment pair must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and remain within the caller's organizational write access.
+      description: Requires `employees.update` and updates employee details with partial-update semantics. If either domain relationship is supplied, the resulting stored Legal Entity and establishment pair must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and remain within the caller's organizational write access.
       operationId: updateEmployee
       tags:
         - Employees
@@ -9947,7 +9947,7 @@ paths:
   /lookups/legal-entities:
     get:
       summary: List Authorized Legal Entities
-      description: Requires at least one of `customers.create`, `customers.update`, `sites.create`, or `employees.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
+      description: Requires at least one of `customers.create`, `customers.update`, `sites.create`, `sites.update`, `employees.create`, or `employees.update` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
       operationId: listLegalEntityLookups
       tags:
         - Lookups
@@ -9970,7 +9970,7 @@ paths:
   /lookups/legal-entities/{legal_entity}/establishments:
     get:
       summary: List Authorized Establishments
-      description: Requires at least one of `customers.update`, `sites.create`, or `employees.create` and returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
+      description: Requires at least one of `customers.update`, `sites.create`, `sites.update`, `employees.create`, or `employees.update` and returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
       operationId: listEstablishmentLookups
       tags:
         - Lookups
@@ -10003,7 +10003,7 @@ paths:
   /lookups/establishments/{establishment}/customers:
     get:
       summary: List Authorized Customers
-      description: Requires `sites.create` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers available through an existing customer-establishment link for that establishment. Each item contains only its UUID and display name.
+      description: Requires at least one of `sites.create` or `sites.update` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers available through an existing customer-establishment link for that establishment. Each item contains only its UUID and display name.
       operationId: listCustomerLookups
       tags:
         - Lookups
@@ -10315,6 +10315,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -10604,7 +10606,7 @@ paths:
       summary: Update Site
       description: |
         Update site fields (PATCH semantics - all fields optional).
-        Requires sites.update permission and view access to site.
+        Requires `sites.update` and view access to the site.
       operationId: updateSite
       tags:
         - Sites

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2596,6 +2596,22 @@ components:
         establishment_id:
           type: string
           format: uuid
+      x-validation-examples:
+        accepted:
+          - name: Reassign the establishment within the stored Legal Entity
+            value:
+              establishment_id: '780e8400-e29b-41d4-a716-446655440001'
+            resulting:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440001'
+        rejected:
+          - name: Reassign the establishment to another Legal Entity
+            value:
+              establishment_id: '780e8400-e29b-41d4-a716-446655440002'
+            resulting:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440002'
+            status: 422
 
     EmployeeResponse:
       type: object
@@ -5532,6 +5548,9 @@ components:
       type: object
       additionalProperties: false
       description: Customer-to-establishment assignment with local contact data. A unique tenant-scoped pair of `customer_id` and `establishment_id` links each customer and establishment once.
+      x-unique-by:
+        - customer_id
+        - establishment_id
       required:
         - id
         - customer_id
@@ -5619,6 +5638,28 @@ components:
             value:
               customer_id: '550e8400-e29b-41d4-a716-446655440000'
               establishment_id: '780e8400-e29b-41d4-a716-446655440002'
+      x-uniqueness-examples:
+        accepted:
+          - name: Local contact data may be reused for another relationship pair
+            existing:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              email: 'shared.contact@secpal.dev'
+            value:
+              customer_id: '550e8400-e29b-41d4-a716-446655440001'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              email: 'shared.contact@secpal.dev'
+        rejected:
+          - name: The relationship pair remains duplicate when local contact data differs
+            existing:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              email: 'first.contact@secpal.dev'
+            value:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              email: 'replacement.contact@secpal.dev'
+            status: 409
 
     CustomerEstablishmentUpdateRequest:
       type: object
@@ -5747,12 +5788,16 @@ components:
             legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
             value:
               legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            resulting:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
         rejected:
           - name: Reassign to a Legal Entity from another tenant
             customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
             legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440002'
             status: 422
             value:
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
+            resulting:
               legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
 
     Site:
@@ -5997,6 +6042,24 @@ components:
         valid_until:
           type: [string, 'null']
           format: date
+      x-validation-examples:
+        accepted:
+          - name: Reassign the establishment within the resulting domain combination
+            value:
+              establishment_id: '780e8400-e29b-41d4-a716-446655440001'
+            resulting:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440001'
+        rejected:
+          - name: Reassign the customer outside the resulting Legal Entity
+            value:
+              customer_id: '550e8400-e29b-41d4-a716-446655440002'
+            resulting:
+              customer_id: '550e8400-e29b-41d4-a716-446655440002'
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+            status: 422
 
     CustomerAssignment:
       type: object
@@ -10069,7 +10132,7 @@ paths:
   /customer-establishments:
     get:
       summary: List Customer Establishments
-      description: Lists authorized customer-to-establishment assignments without exposing organizational-unit relationships.
+      description: Requires view access via customer assignment or organizational scope and lists only authorized customer-to-establishment assignments without exposing organizational-unit relationships.
       operationId: listCustomerEstablishments
       tags:
         - Customers
@@ -10118,7 +10181,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Link Customer to Establishment
-      description: Requires `customers.update` and creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
+      description: Requires `customers.update` and creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification for the tenant-scoped `customer_id` and `establishment_id` pair is evaluated atomically in the same transaction as creation. Every duplicate pair returns the neutral `DuplicateConflict` response without treating local contact data as a duplicate identifier.
       operationId: createCustomerEstablishment
       tags:
         - Customers
@@ -10158,6 +10221,7 @@ paths:
           format: uuid
     get:
       summary: Get Customer Establishment
+      description: Requires view access via customer assignment or organizational scope and returns one authorized customer-to-establishment assignment without exposing organizational-unit relationships.
       operationId: getCustomerEstablishment
       tags:
         - Customers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5597,6 +5597,26 @@ components:
         comments:
           type: [string, 'null']
           maxLength: 2000
+      x-validation-examples:
+        accepted:
+          - name: Customer and establishment belong to one tenant and Legal Entity
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            value:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+        rejected:
+          - name: Establishment belongs to another Legal Entity
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
+            status: 422
+            value:
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440002'
 
     CustomerEstablishmentUpdateRequest:
       type: object
@@ -9918,7 +9938,7 @@ paths:
   /lookups/legal-entities:
     get:
       summary: List Authorized Legal Entities
-      description: Requires `customers.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
+      description: Requires at least one of `customers.create`, `sites.create`, or `employees.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
       operationId: listLegalEntityLookups
       tags:
         - Lookups
@@ -9941,7 +9961,7 @@ paths:
   /lookups/legal-entities/{legal_entity}/establishments:
     get:
       summary: List Authorized Establishments
-      description: Returns only establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
+      description: Returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
       operationId: listEstablishmentLookups
       tags:
         - Lookups
@@ -9974,7 +9994,7 @@ paths:
   /lookups/establishments/{establishment}/customers:
     get:
       summary: List Authorized Customers
-      description: Returns only customers the caller is authorized to use through the selected authorized establishment. Each item contains only its UUID and display name.
+      description: Returns only customers the caller is authorized to use through an existing customer-establishment link for the selected authorized establishment. Each item contains only its UUID and display name.
       operationId: listCustomerLookups
       tags:
         - Lookups
@@ -10056,7 +10076,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Link Customer to Establishment
-      description: Creates a unique customer-to-establishment link with optional local contact data. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
+      description: Creates a unique customer-to-establishment link with optional local contact data. The customer and establishment must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
       operationId: createCustomerEstablishment
       tags:
         - Customers
@@ -10148,6 +10168,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Delete Customer Establishment
+      description: Deletion is blocked while one or more sites use this customer-establishment link, preserving the relationship required by each site.
       operationId: deleteCustomerEstablishment
       tags:
         - Customers
@@ -10162,6 +10183,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -10209,7 +10232,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity.
+        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
       operationId: updateCustomer
       tags:
         - Customers
@@ -10454,7 +10477,7 @@ paths:
       summary: Create Site
       description: |
         Create a new site. Site number is auto-generated (OBJ-YYYY-####).
-        Requires sites.create permission and an authorized, tenant-consistent customer, Legal Entity, and establishment combination. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
+        Requires sites.create permission and an authorized, tenant-consistent customer, Legal Entity, and establishment combination with an existing customer-establishment link for the selected customer and establishment. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createSite
       tags:
         - Sites

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9591,6 +9591,8 @@ paths:
         Update organizational-unit fields with PATCH semantics.
 
         `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; changing it to `custom` requires a `custom_type_name` containing a non-whitespace character in the same payload. The API returns `422` if the name is absent, `null`, empty, or whitespace-only when changing to `custom`, or if a caller clears the name of an existing custom unit. Status flags remain independent and are never inferred from `type`.
+
+        Clearing `is_legal_entity` or `is_establishment` is rejected with `409` while that role is referenced by customers, customer-establishment links, sites, or employees; callers must migrate or remove dependent domain records first.
       operationId: updateOrganizationalUnit
       tags:
         - Organizational Units
@@ -9625,6 +9627,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -9943,7 +9947,7 @@ paths:
   /lookups/legal-entities:
     get:
       summary: List Authorized Legal Entities
-      description: Requires at least one of `customers.create`, `sites.create`, or `employees.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
+      description: Requires at least one of `customers.create`, `customers.update`, `sites.create`, or `employees.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
       operationId: listLegalEntityLookups
       tags:
         - Lookups
@@ -9966,7 +9970,7 @@ paths:
   /lookups/legal-entities/{legal_entity}/establishments:
     get:
       summary: List Authorized Establishments
-      description: Returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
+      description: Requires at least one of `customers.update`, `sites.create`, or `employees.create` and returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
       operationId: listEstablishmentLookups
       tags:
         - Lookups
@@ -9999,7 +10003,7 @@ paths:
   /lookups/establishments/{establishment}/customers:
     get:
       summary: List Authorized Customers
-      description: Returns only customers the caller is authorized to use through an existing customer-establishment link for the selected authorized establishment. Each item contains only its UUID and display name.
+      description: Requires `sites.create` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers available through an existing customer-establishment link for that establishment. Each item contains only its UUID and display name.
       operationId: listCustomerLookups
       tags:
         - Lookups
@@ -10016,6 +10020,39 @@ paths:
       responses:
         '200':
           description: Authorized customer lookup options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerLookupCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /lookups/establishments/{establishment}/customer-candidates:
+    get:
+      summary: List Customer Link Candidates
+      description: Requires `customers.update` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers from the same tenant and Legal Entity that are not yet linked to that establishment. Each item contains only its UUID and display name.
+      operationId: listCustomerLinkCandidateLookups
+      tags:
+        - Lookups
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: establishment
+          in: path
+          required: true
+          description: Authorized establishment UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Authorized customer link candidates
           content:
             application/json:
               schema:
@@ -10081,7 +10118,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Link Customer to Establishment
-      description: Creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
+      description: Requires `customers.update` and creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
       operationId: createCustomerEstablishment
       tags:
         - Customers
@@ -10143,6 +10180,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     patch:
       summary: Update Customer Establishment Contact Data
+      description: Requires `customers.update` and updates only the link's local contact data.
       operationId: updateCustomerEstablishment
       tags:
         - Customers
@@ -10173,7 +10211,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Delete Customer Establishment
-      description: Deletion is blocked while one or more sites use this customer-establishment link, preserving the relationship required by each site.
+      description: Requires `customers.update`. Deletion is blocked while one or more sites use this customer-establishment link, preserving the relationship required by each site.
       operationId: deleteCustomerEstablishment
       tags:
         - Customers

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2356,9 +2356,47 @@ components:
         legal_entity_id:
           type: string
           format: uuid
+          description: Same-tenant Legal Entity assigned to the employee.
         establishment_id:
           type: string
           format: uuid
+          description: Establishment assigned to the employee; it must belong to the selected Legal Entity and tenant.
+      x-validation-examples:
+        accepted:
+          - name: Employee assigned within one tenant and Legal Entity
+            employee_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            value:
+              first_name: Max
+              last_name: Mustermann
+              date_of_birth: '1990-05-15'
+              email: max.mustermann@secpal.dev
+              status: active
+              position: Security Guard
+              contract_start_date: '2026-08-01'
+              contract_type: full_time
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+        rejected:
+          - name: Establishment belongs to another Legal Entity
+            employee_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
+            status: 422
+            value:
+              first_name: Max
+              last_name: Mustermann
+              date_of_birth: '1990-05-15'
+              email: max.mustermann@secpal.dev
+              status: active
+              position: Security Guard
+              contract_start_date: '2026-08-01'
+              contract_type: full_time
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440002'
 
     EmployeeUpdateRequest:
       type: object
@@ -5523,7 +5561,7 @@ components:
           type: [string, 'null']
           format: email
           maxLength: 255
-          example: 'max.mustermann@example.com'
+          example: 'max.mustermann@secpal.dev'
         comments:
           type: [string, 'null']
           maxLength: 2000
@@ -5593,12 +5631,15 @@ components:
       additionalProperties: false
       required:
         - data
+        - links
         - meta
       properties:
         data:
           type: array
           items:
             $ref: '#/components/schemas/CustomerEstablishment'
+        links:
+          $ref: '#/components/schemas/PaginationLinks'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
 
@@ -5824,10 +5865,12 @@ components:
         legal_entity_id:
           type: string
           format: uuid
+          description: Same-tenant Legal Entity responsible for the site.
           example: '770e8400-e29b-41d4-a716-446655440000'
         establishment_id:
           type: string
           format: uuid
+          description: Establishment responsible for the site; it must belong to the selected Legal Entity and tenant.
           example: '780e8400-e29b-41d4-a716-446655440000'
         type:
           type: string
@@ -5850,6 +5893,46 @@ components:
         valid_until:
           type: [string, 'null']
           format: date
+      x-validation-examples:
+        accepted:
+          - name: Site relationships belong to one tenant and Legal Entity
+            site_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            value:
+              name: Airport Terminal 1
+              customer_id: '550e8400-e29b-41d4-a716-446655440000'
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              type: permanent
+              address:
+                street: Flughafenstraße 1
+                city: Berlin
+                postal_code: '10115'
+                country: DE
+        rejected:
+          - name: Customer belongs to another Legal Entity
+            site_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            customer_legal_entity_id: '770e8400-e29b-41d4-a716-446655440002'
+            legal_entity_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_tenant_id: '660e8400-e29b-41d4-a716-446655440001'
+            establishment_legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+            status: 422
+            value:
+              name: Airport Terminal 1
+              customer_id: '550e8400-e29b-41d4-a716-446655440002'
+              legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+              establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+              type: permanent
+              address:
+                street: Flughafenstraße 1
+                city: Berlin
+                postal_code: '10115'
+                country: DE
 
     SiteUpdateRequest:
       type: object
@@ -10004,6 +10087,13 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   /customer-establishments/{customer_establishment}:
+    parameters:
+      - name: customer_establishment
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
     get:
       summary: Get Customer Establishment
       operationId: getCustomerEstablishment
@@ -10011,13 +10101,6 @@ paths:
         - Customers
       security:
         - BearerAuth: []
-      parameters:
-        - name: customer_establishment
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         '200':
           description: Customer establishment retrieved successfully
@@ -10040,13 +10123,6 @@ paths:
         - Customers
       security:
         - BearerAuth: []
-      parameters:
-        - name: customer_establishment
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
       requestBody:
         required: true
         content:
@@ -10077,13 +10153,6 @@ paths:
         - Customers
       security:
         - BearerAuth: []
-      parameters:
-        - name: customer_establishment
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         '204':
           description: Customer establishment deleted successfully
@@ -10100,7 +10169,7 @@ paths:
     get:
       summary: Get Customer
       description: |
-        Retrieve a single customer by ID with optional relationships.
+        Retrieve a single customer's Legal-Entity-wide master data.
         Requires view access via assignment or organizational scope.
       operationId: getCustomer
       tags:
@@ -10115,13 +10184,6 @@ paths:
             type: string
             format: uuid
           description: Customer UUID
-        - name: include
-          in: query
-          required: false
-          schema:
-            type: string
-            enum: [sites, assignments, sites.assignments]
-          description: Comma-separated list of relationships to include
       responses:
         '200':
           description: Customer retrieved successfully

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -55,6 +55,8 @@ tags:
     description: Qualification catalog and per-employee qualification assignments.
   - name: Customers
     description: Customer management and related customer-scoped resources.
+  - name: Lookups
+    description: Minimal authorized domain-assignment lookup endpoints.
   - name: Sites
     description: Site management endpoints and site-related nested resources.
   - name: Organizational Units
@@ -2034,55 +2036,6 @@ components:
               type: string
               example: 'department'
 
-    EmployeeOrganizationalUnitSummary:
-      type: object
-      description: Minimal embedded organizational unit information for an employee
-      required:
-        - id
-        - type
-        - name
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          format: uuid
-          example: '550e8400-e29b-41d4-a716-446655440200'
-        type:
-          type: string
-          example: 'department'
-        name:
-          type: string
-          example: 'Operations'
-        custom_type_name:
-          type: [string, 'null']
-        description:
-          type: [string, 'null']
-        metadata:
-          type: [object, 'null']
-        parent:
-          type: ['null', object]
-          additionalProperties: true
-        children:
-          type: array
-          items:
-            type: object
-            additionalProperties: true
-        ancestors:
-          type: array
-          items:
-            type: object
-            additionalProperties: true
-        descendants:
-          type: array
-          items:
-            type: object
-            additionalProperties: true
-        created_at:
-          $ref: '#/components/schemas/ApiTimestamp'
-        updated_at:
-          $ref: '#/components/schemas/ApiTimestamp'
-
     EmployeeAddress:
       type: object
       description: |
@@ -2210,7 +2163,8 @@ components:
         - position
         - contract_start_date
         - contract_type
-        - organizational_unit_id
+        - legal_entity_id
+        - establishment_id
       properties:
         first_name:
           type: string
@@ -2399,7 +2353,10 @@ components:
         criminal_record_check_date:
           type: [string, 'null']
           format: date
-        organizational_unit_id:
+        legal_entity_id:
+          type: string
+          format: uuid
+        establishment_id:
           type: string
           format: uuid
 
@@ -2593,8 +2550,11 @@ components:
         criminal_record_check_date:
           type: [string, 'null']
           format: date
-        organizational_unit_id:
-          type: [string, 'null']
+        legal_entity_id:
+          type: string
+          format: uuid
+        establishment_id:
+          type: string
           format: uuid
 
     EmployeeResponse:
@@ -2671,6 +2631,8 @@ components:
         - onboarding_completed
         - onboarding_workflow
         - onboarding_invitation
+        - legal_entity_id
+        - establishment_id
         - created_at
         - updated_at
       properties:
@@ -2881,16 +2843,15 @@ components:
             `onboarding_workflow.status = ready_for_activation` signals activation readiness.
         onboarding_invitation:
           $ref: '#/components/schemas/EmployeeOnboardingInvitation'
-        organizational_unit_id:
-          type: [string, 'null']
+        legal_entity_id:
+          type: string
+          format: uuid
+        establishment_id:
+          type: string
           format: uuid
         user:
           anyOf:
             - $ref: '#/components/schemas/EmployeeUserSummary'
-            - type: 'null'
-        organizational_unit:
-          anyOf:
-            - $ref: '#/components/schemas/EmployeeOrganizationalUnitSummary'
             - type: 'null'
         created_at:
           $ref: '#/components/schemas/ApiTimestamp'
@@ -5376,6 +5337,7 @@ components:
 
     Customer:
       type: object
+      additionalProperties: false
       description: |
         Customer (client organization) entity with an explicit Legal Entity assignment.
 
@@ -5406,7 +5368,7 @@ components:
           type: string
           format: uuid
           description: |
-            Same-tenant Legal Entity organizational unit explicitly assigned to this customer.
+            Same-tenant Legal Entity explicitly assigned to this customer.
             No default Legal Entity assignment is permitted for existing customers; backfill
             requires a product-approved deterministic tenant-consistent rule.
           example: '770e8400-e29b-41d4-a716-446655440000'
@@ -5422,27 +5384,10 @@ components:
           example: 'ACME Corporation GmbH'
         billing_address:
           $ref: '#/components/schemas/Address'
-        contact:
-          anyOf:
-            - $ref: '#/components/schemas/Contact'
-            - type: 'null'
         is_active:
           type: boolean
           description: Whether customer is active
           example: true
-        notes:
-          type: [string, 'null']
-          description: Internal notes (conditionally visible)
-          example: 'VIP customer - handle with priority'
-        metadata:
-          type: [object, 'null']
-          description: Custom metadata as JSON
-          additionalProperties: true
-          example: { 'industry': 'retail', 'employee_count': 500 }
-        sites_count:
-          type: integer
-          description: Number of sites (when counted)
-          example: 5
         created_at:
           allOf:
             - $ref: '#/components/schemas/ApiTimestamp'
@@ -5459,10 +5404,10 @@ components:
           description: Soft deletion timestamp
           example: null
 
-    CustomerLegalEntityLookup:
+    LegalEntityLookup:
       type: object
       additionalProperties: false
-      description: Minimal Legal Entity option for creating customers. This intentionally does not expose the general organizational-unit resource.
+      description: Minimal authorized Legal Entity option for domain assignment workflows.
       required:
         - id
         - name
@@ -5470,16 +5415,196 @@ components:
         id:
           type: string
           format: uuid
-          description: Legal Entity organizational unit UUID
           example: '770e8400-e29b-41d4-a716-446655440000'
         name:
           type: string
           maxLength: 255
-          description: Display name for the Legal Entity option
           example: 'SecPal GmbH'
+
+    EstablishmentLookup:
+      type: object
+      additionalProperties: false
+      description: Minimal authorized establishment option belonging to the selected Legal Entity.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: '780e8400-e29b-41d4-a716-446655440000'
+        name:
+          type: string
+          maxLength: 255
+          example: 'Berlin Establishment'
+
+    CustomerLookup:
+      type: object
+      additionalProperties: false
+      description: Minimal authorized customer option linked to the selected establishment.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: '550e8400-e29b-41d4-a716-446655440000'
+        name:
+          type: string
+          maxLength: 255
+          example: 'ACME Corporation GmbH'
+
+    LegalEntityLookupCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/LegalEntityLookup'
+
+    EstablishmentLookupCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/EstablishmentLookup'
+
+    CustomerLookupCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomerLookup'
+
+    CustomerEstablishment:
+      type: object
+      additionalProperties: false
+      description: Customer-to-establishment assignment with local contact data. A unique tenant-scoped pair of `customer_id` and `establishment_id` links each customer and establishment once.
+      required:
+        - id
+        - customer_id
+        - establishment_id
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: '790e8400-e29b-41d4-a716-446655440000'
+        customer_id:
+          type: string
+          format: uuid
+          example: '550e8400-e29b-41d4-a716-446655440000'
+        establishment_id:
+          type: string
+          format: uuid
+          example: '780e8400-e29b-41d4-a716-446655440000'
+        contact_name:
+          type: [string, 'null']
+          maxLength: 255
+          example: 'Max Mustermann'
+        phone:
+          type: [string, 'null']
+          maxLength: 50
+          example: '+49 30 12345678'
+        email:
+          type: [string, 'null']
+          format: email
+          maxLength: 255
+          example: 'max.mustermann@example.com'
+        comments:
+          type: [string, 'null']
+          maxLength: 2000
+          example: 'Use the service entrance after 18:00.'
+        created_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+        updated_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+
+    CustomerEstablishmentCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - customer_id
+        - establishment_id
+      properties:
+        customer_id:
+          type: string
+          format: uuid
+        establishment_id:
+          type: string
+          format: uuid
+        contact_name:
+          type: [string, 'null']
+          maxLength: 255
+        phone:
+          type: [string, 'null']
+          maxLength: 50
+        email:
+          type: [string, 'null']
+          format: email
+          maxLength: 255
+        comments:
+          type: [string, 'null']
+          maxLength: 2000
+
+    CustomerEstablishmentUpdateRequest:
+      type: object
+      additionalProperties: false
+      description: Partial update of local contact data; the customer-to-establishment pair is immutable.
+      properties:
+        contact_name:
+          type: [string, 'null']
+          maxLength: 255
+        phone:
+          type: [string, 'null']
+          maxLength: 50
+        email:
+          type: [string, 'null']
+          format: email
+          maxLength: 255
+        comments:
+          type: [string, 'null']
+          maxLength: 2000
+
+    CustomerEstablishmentResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/CustomerEstablishment'
+
+    CustomerEstablishmentCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomerEstablishment'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
 
     CustomerCreateRequest:
       type: object
+      additionalProperties: false
       required:
         - legal_entity_id
         - name
@@ -5488,7 +5613,7 @@ components:
         legal_entity_id:
           type: string
           format: uuid
-          description: Same-tenant active, assignable, non-deleted Legal Entity organizational unit for the new customer
+          description: Same-tenant active, assignable, non-deleted Legal Entity for the new customer
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -5501,20 +5626,9 @@ components:
           example: 'ACME Corporation GmbH'
         billing_address:
           $ref: '#/components/schemas/Address'
-        contact:
-          anyOf:
-            - $ref: '#/components/schemas/Contact'
-            - type: 'null'
         is_active:
           type: boolean
           default: true
-        notes:
-          type: [string, 'null']
-          example: 'VIP customer'
-        metadata:
-          type: [object, 'null']
-          additionalProperties: true
-          example: { 'industry': 'retail' }
       x-validation-examples:
         accepted:
           - name: Explicit Legal Entity from the customer's tenant
@@ -5544,6 +5658,7 @@ components:
 
     CustomerUpdateRequest:
       type: object
+      additionalProperties: false
       properties:
         legal_entity_id:
           type: string
@@ -5560,17 +5675,8 @@ components:
           maxLength: 255
         billing_address:
           $ref: '#/components/schemas/Address'
-        contact:
-          anyOf:
-            - $ref: '#/components/schemas/Contact'
-            - type: 'null'
         is_active:
           type: boolean
-        notes:
-          type: [string, 'null']
-        metadata:
-          type: [object, 'null']
-          additionalProperties: true
       x-validation-examples:
         accepted:
           - name: Reassign to a Legal Entity from the customer's tenant
@@ -5592,7 +5698,8 @@ components:
       required:
         - id
         - customer_id
-        - organizational_unit_id
+        - legal_entity_id
+        - establishment_id
         - site_number
         - name
         - type
@@ -5613,11 +5720,16 @@ components:
           format: uuid
           description: Customer that owns this site
           example: '550e8400-e29b-41d4-a716-446655440000'
-        organizational_unit_id:
+        legal_entity_id:
           type: string
           format: uuid
-          description: Internal organizational unit responsible for this site
+          description: Legal Entity responsible for this site
           example: '770e8400-e29b-41d4-a716-446655440000'
+        establishment_id:
+          type: string
+          format: uuid
+          description: Establishment responsible for this site
+          example: '780e8400-e29b-41d4-a716-446655440000'
         site_number:
           type: string
           maxLength: 50
@@ -5689,6 +5801,97 @@ components:
             - $ref: '#/components/schemas/NullableApiTimestamp'
           description: Soft deletion timestamp
           example: null
+
+    SiteCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - customer_id
+        - legal_entity_id
+        - establishment_id
+        - type
+        - address
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          example: 'Airport Terminal 1'
+        customer_id:
+          type: string
+          format: uuid
+          example: '550e8400-e29b-41d4-a716-446655440000'
+        legal_entity_id:
+          type: string
+          format: uuid
+          example: '770e8400-e29b-41d4-a716-446655440000'
+        establishment_id:
+          type: string
+          format: uuid
+          example: '780e8400-e29b-41d4-a716-446655440000'
+        type:
+          type: string
+          enum: [permanent, temporary]
+          example: 'permanent'
+        address:
+          $ref: '#/components/schemas/Address'
+        contact:
+          $ref: '#/components/schemas/Contact'
+        access_instructions:
+          type: [string, 'null']
+        notes:
+          type: [string, 'null']
+        metadata:
+          type: [object, 'null']
+          additionalProperties: true
+        valid_from:
+          type: [string, 'null']
+          format: date
+        valid_until:
+          type: [string, 'null']
+          format: date
+
+    SiteUpdateRequest:
+      type: object
+      additionalProperties: false
+      description: Partial site update. Domain relationships may be reassigned only to an authorized, tenant-consistent customer, Legal Entity, and establishment combination.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        customer_id:
+          type: string
+          format: uuid
+        legal_entity_id:
+          type: string
+          format: uuid
+        establishment_id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: [permanent, temporary]
+        address:
+          $ref: '#/components/schemas/Address'
+        contact:
+          anyOf:
+            - $ref: '#/components/schemas/Contact'
+            - type: 'null'
+        access_instructions:
+          type: [string, 'null']
+        notes:
+          type: [string, 'null']
+        metadata:
+          type: [object, 'null']
+          additionalProperties: true
+        is_active:
+          type: boolean
+        valid_from:
+          type: [string, 'null']
+          format: date
+        valid_until:
+          type: [string, 'null']
+          format: date
 
     CustomerAssignment:
       type: object
@@ -5868,6 +6071,23 @@ components:
           description: Soft deletion timestamp
           example: null
 
+    DuplicateResourceError:
+      type: object
+      additionalProperties: false
+      description: Neutral duplicate response shared by all domain create operations so callers cannot infer which identifying value matched.
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+          enum:
+            - A matching record already exists.
+        code:
+          type: string
+          enum:
+            - DUPLICATE_RESOURCE
+
   responses:
     BadRequest:
       description: Bad Request - Invalid input parameters
@@ -5888,6 +6108,16 @@ components:
           example:
             message: The request cannot be completed in the current resource state.
             code: CONFLICT
+
+    DuplicateConflict:
+      description: Duplicate identification is evaluated atomically in the same transaction as the write. Every duplicate case returns this identical neutral payload.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DuplicateResourceError'
+          example:
+            message: A matching record already exists.
+            code: DUPLICATE_RESOURCE
 
     OrganizationalUnitHasChildrenConflict:
       description: Conflict - Non-deleted direct child units must be moved or deleted first, regardless of their `is_active` values
@@ -8177,13 +8407,6 @@ paths:
           schema:
             type: string
             maxLength: 255
-        - name: organizational_unit_id
-          in: query
-          required: false
-          description: Filter employees by organizational unit.
-          schema:
-            type: string
-            format: uuid
       responses:
         '200':
           description: List of employees
@@ -8200,7 +8423,9 @@ paths:
 
     post:
       summary: Create Employee
-      description: Create a new employee record. Onboarding invitations may only be requested during the `pre_contract` phase.
+      description: |
+        Create a new employee record. Onboarding invitations may only be requested during the `pre_contract` phase.
+        Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createEmployee
       tags:
         - Employees
@@ -8225,6 +8450,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/DuplicateConflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -9567,7 +9794,8 @@ paths:
       summary: Create Customer
       description: |
         Create a new customer. Customer number is auto-generated (KD-YYYY-####).
-        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, assignable, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
+        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity.
+        Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createCustomer
       tags:
         - Customers
@@ -9597,42 +9825,274 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/DuplicateConflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /customers/legal-entities:
+  /lookups/legal-entities:
     get:
-      summary: List Customer Legal Entity Options
-      description: |
-        Return only the Legal Entity options allowed for customer creation.
-
-        Requires `customers.create`. Results are limited to same tenant, active, assignable, non-deleted Legal Entity organizational units for which the caller has organizational write access. The response is intentionally minimal and does not expose the general organizational-unit resource or hierarchy metadata.
-      operationId: listCustomerLegalEntities
+      summary: List Authorized Legal Entities
+      description: Requires `customers.create` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
+      operationId: listLegalEntityLookups
       tags:
-        - Customers
+        - Lookups
       security:
         - BearerAuth: []
       responses:
         '200':
-          description: Legal Entity options retrieved successfully
+          description: Authorized Legal Entity lookup options
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: false
-                required:
-                  - data
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/CustomerLegalEntityLookup'
+                $ref: '#/components/schemas/LegalEntityLookupCollectionResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /lookups/legal-entities/{legal_entity}/establishments:
+    get:
+      summary: List Authorized Establishments
+      description: Returns only establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
+      operationId: listEstablishmentLookups
+      tags:
+        - Lookups
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: legal_entity
+          in: path
+          required: true
+          description: Authorized Legal Entity UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Authorized establishment lookup options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EstablishmentLookupCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /lookups/establishments/{establishment}/customers:
+    get:
+      summary: List Authorized Customers
+      description: Returns only customers the caller is authorized to use through the selected authorized establishment. Each item contains only its UUID and display name.
+      operationId: listCustomerLookups
+      tags:
+        - Lookups
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: establishment
+          in: path
+          required: true
+          description: Authorized establishment UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Authorized customer lookup options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerLookupCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /customer-establishments:
+    get:
+      summary: List Customer Establishments
+      description: Lists authorized customer-to-establishment assignments without exposing organizational-unit relationships.
+      operationId: listCustomerEstablishments
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 15
+        - name: customer_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: establishment_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Customer establishments retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerEstablishmentCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Link Customer to Establishment
+      description: Creates a unique customer-to-establishment link with optional local contact data. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
+      operationId: createCustomerEstablishment
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerEstablishmentCreateRequest'
+      responses:
+        '201':
+          description: Customer establishment created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerEstablishmentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/DuplicateConflict'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /customer-establishments/{customer_establishment}:
+    get:
+      summary: Get Customer Establishment
+      operationId: getCustomerEstablishment
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: customer_establishment
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Customer establishment retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerEstablishmentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      summary: Update Customer Establishment Contact Data
+      operationId: updateCustomerEstablishment
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: customer_establishment
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerEstablishmentUpdateRequest'
+      responses:
+        '200':
+          description: Customer establishment updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerEstablishmentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete Customer Establishment
+      operationId: deleteCustomerEstablishment
+      tags:
+        - Customers
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: customer_establishment
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Customer establishment deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -9687,7 +10147,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity organizational unit, and the caller must have organizational write access for that Legal Entity.
+        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity.
       operationId: updateCustomer
       tags:
         - Customers
@@ -9851,7 +10311,7 @@ paths:
       summary: List Sites
       description: |
         Retrieve a paginated list of sites with comprehensive filtering.
-        Users see sites via organizational unit access, direct assignment, or customer assignment.
+        Users see sites through their authorized domain relationships or direct assignments.
       operationId: listSites
       tags:
         - Sites
@@ -9887,13 +10347,6 @@ paths:
             type: string
             format: uuid
           description: Filter by customer
-        - name: organizational_unit_id
-          in: query
-          required: false
-          schema:
-            type: string
-            format: uuid
-          description: Filter by organizational unit
         - name: type
           in: query
           required: false
@@ -9939,7 +10392,7 @@ paths:
       summary: Create Site
       description: |
         Create a new site. Site number is auto-generated (OBJ-YYYY-####).
-        Requires sites.create permission and access to organizational unit.
+        Requires sites.create permission and an authorized, tenant-consistent customer, Legal Entity, and establishment combination. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createSite
       tags:
         - Sites
@@ -9950,51 +10403,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - name
-                - customer_id
-                - organizational_unit_id
-                - type
-                - address
-              properties:
-                name:
-                  type: string
-                  maxLength: 255
-                  example: 'Airport Terminal 1'
-                customer_id:
-                  type: string
-                  format: uuid
-                  example: '550e8400-e29b-41d4-a716-446655440000'
-                organizational_unit_id:
-                  type: string
-                  format: uuid
-                  example: '770e8400-e29b-41d4-a716-446655440000'
-                type:
-                  type: string
-                  enum: [permanent, temporary]
-                  example: 'permanent'
-                address:
-                  $ref: '#/components/schemas/Address'
-                contact:
-                  $ref: '#/components/schemas/Contact'
-                access_instructions:
-                  type: string
-                  example: 'Gate 5, Security Check'
-                notes:
-                  type: string
-                  example: 'High security area'
-                metadata:
-                  type: object
-                  additionalProperties: true
-                valid_from:
-                  type: string
-                  format: date
-                  example: '2025-01-01'
-                valid_until:
-                  type: string
-                  format: date
-                  example: '2025-12-31'
+              $ref: '#/components/schemas/SiteCreateRequest'
       responses:
         '201':
           description: Site created successfully
@@ -10013,6 +10422,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/DuplicateConflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -10023,7 +10434,7 @@ paths:
       summary: Get Site
       description: |
         Retrieve a single site by ID with optional relationships.
-        Requires view access via assignment, organizational unit, or customer assignment.
+        Requires view access via assignment or authorized domain relationships.
       operationId: getSite
       tags:
         - Sites
@@ -10042,14 +10453,7 @@ paths:
           required: false
           schema:
             type: string
-            enum:
-              [
-                customer,
-                organizationalUnit,
-                assignments,
-                costCenters,
-                customer.assignments,
-              ]
+            enum: [customer, assignments, costCenters, customer.assignments]
           description: Comma-separated list of relationships to include
       responses:
         '200':
@@ -10095,36 +10499,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  maxLength: 255
-                organizational_unit_id:
-                  type: string
-                  format: uuid
-                type:
-                  type: string
-                  enum: [permanent, temporary]
-                address:
-                  $ref: '#/components/schemas/Address'
-                contact:
-                  $ref: '#/components/schemas/Contact'
-                access_instructions:
-                  type: string
-                notes:
-                  type: string
-                metadata:
-                  type: object
-                  additionalProperties: true
-                is_active:
-                  type: boolean
-                valid_from:
-                  type: string
-                  format: date
-                valid_until:
-                  type: string
-                  format: date
+              $ref: '#/components/schemas/SiteUpdateRequest'
       responses:
         '200':
           description: Site updated successfully

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -825,7 +825,7 @@ components:
 
         **Date rules:** `obtained_date` is required and cannot be after today; when `expiry_date` is sent it must be strictly after `obtained_date`.
 
-        **Authorization:** `EmployeeQualificationPolicy::create` requires `employee_qualification.write`; organizational scope is enforced in the controller for scoped managers.
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_qualification.write`.
       required:
         - qualification_id
         - obtained_date
@@ -864,7 +864,7 @@ components:
 
         **Date rules:** Same as attach when `obtained_date` / `expiry_date` are present (`obtained_date` not in the future; `expiry_date` after `obtained_date` when set).
 
-        **Authorization:** `employee_qualification.write` plus organizational scope via `EmployeeQualificationPolicy::update`.
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_qualification.write` through `EmployeeQualificationPolicy::update`.
       properties:
         obtained_date:
           type: string
@@ -2402,7 +2402,7 @@ components:
     EmployeeUpdateRequest:
       type: object
       additionalProperties: false
-      description: Partial employee update request. All properties are optional. If either domain relationship changes, validation uses the resulting Legal Entity and establishment pair after applying supplied values to the stored employee; the result must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and stay within the caller's organizational write access.
+      description: Partial employee update request. All properties are optional. If either domain relationship changes, validation uses the resulting Legal Entity and establishment pair after applying supplied values to the stored employee; the result must remain same tenant and same Legal Entity, use active, non-deleted targets, and stay within the caller's organizational write access.
       properties:
         employee_number:
           type: [string, 'null']
@@ -5444,6 +5444,10 @@ components:
           type: boolean
           description: Whether customer is active
           example: true
+        sites_count:
+          type: integer
+          minimum: 0
+          description: Number of the customer's sites visible to the current caller. Present on customer list and detail responses.
         created_at:
           allOf:
             - $ref: '#/components/schemas/ApiTimestamp'
@@ -5714,10 +5718,15 @@ components:
         - name
         - billing_address
       properties:
+        customer_number:
+          type: [string, 'null']
+          maxLength: 50
+          description: Optional caller-supplied customer number. When omitted or null, the API generates a KD-YYYY-#### value.
+          example: 'CUSTOM-001'
         legal_entity_id:
           type: string
           format: uuid
-          description: Same-tenant active, assignable, non-deleted Legal Entity for the new customer
+          description: Same-tenant active, non-deleted Legal Entity for the new customer
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -5731,7 +5740,7 @@ components:
         billing_address:
           $ref: '#/components/schemas/Address'
         is_active:
-          type: boolean
+          type: [boolean, 'null']
           default: true
       x-validation-examples:
         accepted:
@@ -5767,7 +5776,7 @@ components:
         legal_entity_id:
           type: string
           format: uuid
-          description: Target Legal Entity for reassignment. When different from the customer's current value, it must be same-tenant, active, assignable, and non-deleted.
+          description: Target Legal Entity for reassignment. When different from the customer's current value, it must be same-tenant, active, and non-deleted.
           example: '770e8400-e29b-41d4-a716-446655440000'
         vat_id:
           type: [string, 'null']
@@ -5925,6 +5934,11 @@ components:
           type: string
           maxLength: 255
           example: 'Airport Terminal 1'
+        site_number:
+          type: [string, 'null']
+          maxLength: 50
+          description: Optional caller-supplied site number. When omitted or null, the API generates an OBJ-YYYY-#### value.
+          example: 'CUSTOM-SITE-001'
         customer_id:
           type: string
           format: uuid
@@ -5946,7 +5960,9 @@ components:
         address:
           $ref: '#/components/schemas/Address'
         contact:
-          $ref: '#/components/schemas/Contact'
+          anyOf:
+            - $ref: '#/components/schemas/Contact'
+            - type: 'null'
         access_instructions:
           type: [string, 'null']
         notes:
@@ -5954,6 +5970,9 @@ components:
         metadata:
           type: [object, 'null']
           additionalProperties: true
+        is_active:
+          type: [boolean, 'null']
+          default: true
         valid_from:
           type: [string, 'null']
           format: date
@@ -6004,11 +6023,14 @@ components:
     SiteUpdateRequest:
       type: object
       additionalProperties: false
-      description: Partial site update. If any domain relationship changes, validation uses the resulting customer, Legal Entity, and establishment combination after applying supplied values to the stored site; the result must use an active, non-deleted customer, active, assignable, non-deleted Legal Entity and establishment within the caller's organizational write access, remain tenant- and Legal-Entity-consistent, and reference an existing customer-establishment link.
+      description: Partial site update. If any domain relationship changes, validation uses the resulting customer, Legal Entity, and establishment combination after applying supplied values to the stored site; the result must use an active, non-deleted customer plus an active, non-deleted Legal Entity and establishment, remain tenant- and Legal-Entity-consistent, and reference an existing customer-establishment link. Changing any domain relationship requires `sites.update`; callers with any organizational scopes receive HTTP **403** for such reassignment.
       properties:
         name:
           type: string
           maxLength: 255
+        site_number:
+          type: string
+          maxLength: 50
         customer_id:
           type: string
           format: uuid
@@ -6287,14 +6309,12 @@ components:
             message: A matching record already exists.
             code: DUPLICATE_RESOURCE
 
-    OrganizationalUnitDeletionConflict:
-      description: Conflict - Non-deleted direct child units or domain records still reference the organizational unit
+    OrganizationalUnitHasChildrenConflict:
+      description: Conflict - Non-deleted direct child units must be moved or deleted first, regardless of their `is_active` values
       content:
         application/json:
           schema:
-            oneOf:
-              - $ref: '#/components/schemas/OrganizationalUnitHasChildrenConflict'
-              - $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/OrganizationalUnitHasChildrenConflict'
 
     Unauthorized:
       description: Unauthorized - Authentication required
@@ -8292,7 +8312,7 @@ paths:
                       subject:
                         type: Employee
                         id: 550e8400-e29b-41d4-a716-446655440010
-                        name: John Doe
+                        name: null
                 systemActivity:
                   summary: System-initiated activity (no causer)
                   value:
@@ -8576,10 +8596,24 @@ paths:
         - name: search
           in: query
           required: false
-          description: Search employees by name or email.
+          description: Search employees by email and employee_number.
           schema:
             type: string
             maxLength: 255
+        - name: legal_entity_id
+          in: query
+          required: false
+          description: Filter employees by Legal Entity.
+          schema:
+            type: string
+            format: uuid
+        - name: establishment_id
+          in: query
+          required: false
+          description: Filter employees by establishment.
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: List of employees
@@ -8598,7 +8632,7 @@ paths:
       summary: Create Employee
       description: |
         Create a new employee record. Onboarding invitations may only be requested during the `pre_contract` phase.
-        Requires `employees.create`. The supplied Legal Entity and establishment must be same tenant and belong to the same Legal Entity, both targets must be active, assignable, non-deleted, and the caller must have organizational write access for them.
+        Requires `employee.write` or `employee.create`. The supplied Legal Entity and establishment must be same tenant and belong to the same Legal Entity, both targets must be active and non-deleted, and the caller must have organizational write access for them.
         Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createEmployee
       tags:
@@ -8666,7 +8700,7 @@ paths:
 
     patch:
       summary: Update Employee
-      description: Requires `employees.update` and updates employee details with partial-update semantics. If either domain relationship is supplied, the resulting stored Legal Entity and establishment pair must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and remain within the caller's organizational write access.
+      description: Requires `employee.write` or `employee.update` and updates employee details with partial-update semantics. If either domain relationship is supplied, the resulting stored Legal Entity and establishment pair must remain same tenant and same Legal Entity, use active, non-deleted targets, and remain within the caller's organizational write access.
       operationId: updateEmployee
       tags:
         - Employees
@@ -8980,8 +9014,10 @@ paths:
 
         **Relations:** `employee` and `qualification` are eager-loaded; each `data[]` item includes both embeds.
 
-        **Authorization boundary:** OU scopes do not grant access to domain employees. A caller with any organizational scopes
-        (`User::organizationalScopes`) receives HTTP **403** with “No organizational entitlement exists for this employee.” Unscoped callers still require the permission below.
+        **Self-service:** the employee may list their own qualification assignments.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Non-self callers with any organizational scopes
+        (`User::organizationalScopes`) receive HTTP **403** with “No organizational entitlement exists for this employee.” Unscoped non-self callers still require the permission below.
 
         **Authorization:** `employee_qualification.read` via `EmployeeQualificationPolicy::viewAny`.
       operationId: listEmployeeQualifications
@@ -9028,7 +9064,7 @@ paths:
 
         **Conflict:** attaching the same `qualification_id` twice for one employee yields HTTP **409** with a message-only JSON body.
 
-        **Authorization:** `employee_qualification.write`; scoped managers must pass controller organizational checks (otherwise **403**).
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_qualification.write`.
       operationId: attachEmployeeQualification
       tags:
         - Employees
@@ -9093,7 +9129,9 @@ paths:
         **Route binding:** `EmployeeQualification` is tenant-scoped via its employee (`TenantScopedRouteBindingTest`). Unknown UUID / wrong tenant → **404**
         `Resource not found.`
 
-        **Authorization:** `EmployeeQualificationPolicy::view` (self-service employee, `employee_qualification.read` with scope rules, etc.).
+        **Self-service:** the employee may view their own assignment.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Non-self callers with any organizational scopes receive HTTP **403**; unscoped non-self callers require `employee_qualification.read` through `EmployeeQualificationPolicy::view`.
       operationId: getEmployeeQualification
       tags:
         - Qualifications
@@ -9138,7 +9176,7 @@ paths:
 
         Response reloads `qualification`; `employee` is not guaranteed on success payloads.
 
-        **Authorization:** `employee_qualification.write` plus `EmployeeQualificationPolicy::update` scope checks.
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_qualification.write` through `EmployeeQualificationPolicy::update`.
       operationId: updateEmployeeQualification
       tags:
         - Qualifications
@@ -9189,7 +9227,7 @@ paths:
       description: |
         Hard-delete the pivot (`EmployeeQualificationController::destroy`). Success is HTTP **204** with an empty body.
 
-        **Authorization:** `employee_qualification.write` plus `EmployeeQualificationPolicy::delete` scope checks.
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_qualification.write` through `EmployeeQualificationPolicy::delete`.
       operationId: deleteEmployeeQualification
       tags:
         - Qualifications
@@ -9227,9 +9265,11 @@ paths:
     get:
       summary: List Employee Documents
       description: |
-        Returns metadata for documents belonging to the employee (`EmployeeDocumentPolicy::viewAny` + organizational scope).
+        Returns metadata for documents belonging to the employee (`EmployeeDocumentPolicy::viewAny`).
 
-        When the authenticated user is the employee (`User` matches `employee.user_id`), the list is filtered to rows with `visible_to_employee` **true**. HR and scoped managers see all documents permitted by policy.
+        **Self-service:** when the authenticated user is the employee (`User` matches `employee.user_id`), the list is filtered to rows with `visible_to_employee` **true**.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Non-self callers with any organizational scopes receive HTTP **403**; unscoped non-self callers require `employee_document.read`.
 
         **Routing:** Lives under the authenticated `verified` middleware group alongside other `/v1` HR APIs; callers need a verified email address when that middleware applies.
       operationId: listEmployeeDocuments
@@ -9266,7 +9306,9 @@ paths:
       description: |
         Multipart upload validated by `UploadEmployeeDocumentRequest` (`EmployeeDocumentController::store`).
 
-        Requires `employee_document.write` (via policy). Files are encrypted at rest; responses mirror `EmployeeDocumentResource` and never expose `file_path`.
+        Files are encrypted at rest; responses mirror `EmployeeDocumentResource` and never expose `file_path`.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_document.write` through `EmployeeDocumentPolicy::create`.
       operationId: createEmployeeDocument
       tags:
         - Employees
@@ -9322,6 +9364,10 @@ paths:
       summary: Get Employee Document Metadata
       description: |
         Returns a single document row (`EmployeeDocumentPolicy::view`). Route-model binding is scoped: a `{document}` UUID that does not belong to `{employee}` yields **404**.
+
+        **Self-service:** the employee may view their own document only when `visible_to_employee` is **true**.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Non-self callers with any organizational scopes receive HTTP **403**; unscoped non-self callers require `employee_document.read`.
       operationId: getEmployeeDocument
       tags:
         - Employees
@@ -9362,6 +9408,8 @@ paths:
       summary: Delete Employee Document
       description: |
         Soft-deletes the record and removes ciphertext from storage (`EmployeeDocumentPolicy::delete`).
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `employee_document.write`.
       operationId: deleteEmployeeDocument
       tags:
         - Employees
@@ -9399,6 +9447,10 @@ paths:
       summary: Download Employee Document File
       description: |
         Streams decrypted bytes with `Content-Type` set to the stored MIME type and `Content-Disposition: attachment` using a sanitized filename.
+
+        **Self-service:** the employee may download their own document only when `visible_to_employee` is **true**.
+
+        **Authorization boundary:** OU scopes do not grant access to domain employees. Non-self callers with any organizational scopes receive HTTP **403**; unscoped non-self callers require `employee_document.read`.
 
         **404:** Returned when the ciphertext blob is missing from disk (`EmployeeDocumentFileNotFoundException` maps to *File not found*) — see feature tests.
 
@@ -9658,7 +9710,6 @@ paths:
 
         `OrganizationalUnitPolicy::update` enforces same-tenant access plus write scope. If `type` is changed, the API validates the structural type enum; changing it to `custom` requires a `custom_type_name` containing a non-whitespace character in the same payload. The API returns `422` if the name is absent, `null`, empty, or whitespace-only when changing to `custom`, or if a caller clears the name of an existing custom unit. Status flags remain independent and are never inferred from `type`.
 
-        Clearing `is_legal_entity` or `is_establishment` is rejected with `409` while that role is referenced by customers, customer-establishment links, sites, or employees; callers must migrate or remove dependent domain records first.
       operationId: updateOrganizationalUnit
       tags:
         - Organizational Units
@@ -9693,8 +9744,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -9705,7 +9754,7 @@ paths:
       description: |
         Soft-delete an organizational unit.
 
-        `OrganizationalUnitPolicy::delete` requires same-tenant manage access. The API rejects deletion while non-deleted direct child units exist, regardless of each child's `is_active` value, or while the unit is referenced by customers, customer-establishment links, sites, or employees; callers must move or delete dependents first.
+        `OrganizationalUnitPolicy::delete` requires same-tenant manage access. The API rejects deletion while non-deleted direct child units exist, regardless of each child's `is_active` value; callers must move or delete children first.
       operationId: deleteOrganizationalUnit
       tags:
         - Organizational Units
@@ -9731,7 +9780,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/OrganizationalUnitDeletionConflict'
+          $ref: '#/components/responses/OrganizationalUnitHasChildrenConflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -9909,7 +9958,7 @@ paths:
       summary: List Customers
       description: |
         Retrieve a paginated list of customers with optional filtering.
-        Users only see customers they have access to (via assignments or organizational scope).
+        Full collection access requires `customers.read` without organizational scopes. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no customer-record access, so it yields an empty authorized collection.
       operationId: listCustomers
       tags:
         - Customers
@@ -9965,14 +10014,16 @@ paths:
                     $ref: '#/components/schemas/PaginationMeta'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
     post:
       summary: Create Customer
       description: |
-        Create a new customer. Customer number is auto-generated (KD-YYYY-####).
-        Requires `customers.create`. The supplied `legal_entity_id` must be a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity.
+        Create a new customer. The optional `customer_number` is accepted as supplied; when omitted or null, the API generates a KD-YYYY-#### value.
+        Requires `customers.create` and a same-tenant, active, non-deleted Legal Entity. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.create`.
         Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createCustomer
       tags:
@@ -10013,7 +10064,7 @@ paths:
   /lookups/legal-entities:
     get:
       summary: List Authorized Legal Entities
-      description: Requires at least one of `customers.create`, `customers.update`, `sites.create`, `sites.update`, `employees.create`, or `employees.update` and returns only authorized, same tenant, active, assignable, non-deleted Legal Entity options for which the caller has organizational write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
+      description: Requires at least one of `customers.create`, `customers.update`, `sites.create`, `sites.update`, `employee.write`, `employee.create`, or `employee.update` and returns only authorized, same tenant, active, non-deleted Legal Entity options within the caller's authorized domain write access. Each item contains only its UUID and display name; no hierarchy, RBAC, tenant, or status metadata is exposed.
       operationId: listLegalEntityLookups
       tags:
         - Lookups
@@ -10036,7 +10087,7 @@ paths:
   /lookups/legal-entities/{legal_entity}/establishments:
     get:
       summary: List Authorized Establishments
-      description: Requires at least one of `customers.update`, `sites.create`, `sites.update`, `employees.create`, or `employees.update` and returns only same tenant, active, assignable, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
+      description: Requires at least one of `customers.update`, `sites.create`, `sites.update`, `employee.write`, `employee.create`, or `employee.update` and returns only same tenant, active, non-deleted establishments the caller is authorized to use under the selected authorized Legal Entity. Each item contains only its UUID and display name.
       operationId: listEstablishmentLookups
       tags:
         - Lookups
@@ -10069,7 +10120,7 @@ paths:
   /lookups/establishments/{establishment}/customers:
     get:
       summary: List Authorized Customers
-      description: Requires at least one of `sites.create` or `sites.update` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers available through an existing customer-establishment link for that establishment. Each item contains only its UUID and display name.
+      description: Requires at least one of `sites.create` or `sites.update` and an active, non-deleted establishment within the caller's authorized domain write access. Returns only authorized, active, non-deleted customers available through an existing customer-establishment link for that establishment. Each item contains only its UUID and display name.
       operationId: listCustomerLookups
       tags:
         - Lookups
@@ -10102,7 +10153,7 @@ paths:
   /lookups/establishments/{establishment}/customer-candidates:
     get:
       summary: List Customer Link Candidates
-      description: Requires `customers.update` and an active, assignable, non-deleted establishment within the caller's organizational write access. Returns only authorized, active, non-deleted customers from the same tenant and Legal Entity that are not yet linked to that establishment. Each item contains only its UUID and display name.
+      description: Requires `customers.update` and an active, non-deleted establishment within the caller's authorized domain write access. Returns only authorized, active, non-deleted customers from the same tenant and Legal Entity that are not yet linked to that establishment. Each item contains only its UUID and display name.
       operationId: listCustomerLinkCandidateLookups
       tags:
         - Lookups
@@ -10135,7 +10186,7 @@ paths:
   /customer-establishments:
     get:
       summary: List Customer Establishments
-      description: Requires view access via customer assignment or organizational scope and lists only authorized customer-to-establishment assignments without exposing organizational-unit relationships.
+      description: Full collection access requires `customers.read` without organizational scopes. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no customer-record access, so it yields an empty authorized collection. The response exposes no organizational-unit relationships.
       operationId: listCustomerEstablishments
       tags:
         - Customers
@@ -10184,7 +10235,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Link Customer to Establishment
-      description: Requires `customers.update` and creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification for the tenant-scoped `customer_id` and `establishment_id` pair is evaluated atomically in the same transaction as creation. Every duplicate pair returns the neutral `DuplicateConflict` response without treating local contact data as a duplicate identifier.
+      description: Requires `customers.update` and creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, non-deleted establishment; both must belong to the same tenant and Legal Entity. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.update`. Duplicate identification for the tenant-scoped `customer_id` and `establishment_id` pair is evaluated atomically in the same transaction as creation. Every duplicate pair returns the neutral `DuplicateConflict` response without treating local contact data as a duplicate identifier.
       operationId: createCustomerEstablishment
       tags:
         - Customers
@@ -10224,7 +10275,7 @@ paths:
           format: uuid
     get:
       summary: Get Customer Establishment
-      description: Requires view access via customer assignment or organizational scope and returns one authorized customer-to-establishment assignment without exposing organizational-unit relationships.
+      description: Requires an active customer or site assignment, or `customers.read` without organizational scopes. OU scopes alone do not grant record access. The response exposes no organizational-unit relationships.
       operationId: getCustomerEstablishment
       tags:
         - Customers
@@ -10303,7 +10354,7 @@ paths:
       summary: Get Customer
       description: |
         Retrieve a single customer's Legal-Entity-wide master data.
-        Requires view access via assignment or organizational scope.
+        Requires an active customer or site assignment, or `customers.read` without organizational scopes. OU scopes alone do not grant record access.
       operationId: getCustomer
       tags:
         - Customers
@@ -10342,7 +10393,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same tenant, active, assignable, non-deleted Legal Entity, and the caller must have organizational write access for that Legal Entity. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
+        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same-tenant, active, non-deleted Legal Entity. Legal Entity reassignment requires `customers.update`; callers with any organizational scopes receive HTTP **403** for reassignment. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
       operationId: updateCustomer
       tags:
         - Customers
@@ -10504,7 +10555,7 @@ paths:
       summary: List Sites
       description: |
         Retrieve a paginated list of sites with comprehensive filtering.
-        Users see sites through their authorized domain relationships or direct assignments.
+        `sites.read` grants tenant-wide access. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no site-record access, so it yields an empty authorized collection.
       operationId: listSites
       tags:
         - Sites
@@ -10532,7 +10583,7 @@ paths:
           schema:
             type: string
             maxLength: 255
-          description: Search in name, site_number, customer name
+          description: Search in name and site_number
         - name: customer_id
           in: query
           required: false
@@ -10540,6 +10591,13 @@ paths:
             type: string
             format: uuid
           description: Filter by customer
+        - name: establishment_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Filter by establishment
         - name: type
           in: query
           required: false
@@ -10553,12 +10611,6 @@ paths:
           schema:
             type: boolean
           description: Filter by active status
-        - name: currently_valid
-          in: query
-          required: false
-          schema:
-            type: boolean
-          description: Filter by current validity (for temporary sites)
       responses:
         '200':
           description: Sites retrieved successfully
@@ -10578,14 +10630,16 @@ paths:
                     $ref: '#/components/schemas/PaginationMeta'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
     post:
       summary: Create Site
       description: |
-        Create a new site. Site number is auto-generated (OBJ-YYYY-####).
-        Requires `sites.create`, an active, non-deleted customer, active, assignable, non-deleted Legal Entity and establishment within the caller's organizational write access, and a tenant- and Legal-Entity-consistent combination with an existing customer-establishment link for the selected customer and establishment. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
+        Create a new site. The optional `site_number` is accepted as supplied; when omitted or null, the API generates an OBJ-YYYY-#### value.
+        Requires `sites.create`, an active, non-deleted customer, an active, non-deleted Legal Entity and establishment, and a tenant- and Legal-Entity-consistent combination with an existing customer-establishment link for the selected customer and establishment. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `sites.create`. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createSite
       tags:
         - Sites
@@ -10627,7 +10681,7 @@ paths:
       summary: Get Site
       description: |
         Retrieve a single site by ID with optional relationships.
-        Requires view access via assignment or authorized domain relationships.
+        Requires `sites.read` or an active customer or site assignment. OU scopes alone do not grant record access.
       operationId: getSite
       tags:
         - Sites
@@ -10673,7 +10727,7 @@ paths:
       summary: Update Site
       description: |
         Update site fields (PATCH semantics - all fields optional).
-        Requires `sites.update` and view access to the site.
+        Requires `sites.update` and view access to the site. Changing any domain relationship (`customer_id`, `legal_entity_id`, or `establishment_id`) requires `sites.update`; callers with any organizational scopes receive HTTP **403** for such reassignment.
       operationId: updateSite
       tags:
         - Sites

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6023,7 +6023,7 @@ components:
     SiteUpdateRequest:
       type: object
       additionalProperties: false
-      description: Partial site update. If any domain relationship changes, validation uses the resulting customer, Legal Entity, and establishment combination after applying supplied values to the stored site; the result must use an active, non-deleted customer plus an active, non-deleted Legal Entity and establishment, remain tenant- and Legal-Entity-consistent, and reference an existing customer-establishment link. Changing any domain relationship requires `sites.update`; callers with any organizational scopes receive HTTP **403** for such reassignment.
+      description: Partial site update. If any domain relationship changes, validation uses the resulting customer, Legal Entity, and establishment combination after applying supplied values to the stored site; the result must use an active, non-deleted customer plus an active, non-deleted Legal Entity and establishment, remain tenant- and Legal-Entity-consistent, and reference an existing customer-establishment link.
       properties:
         name:
           type: string
@@ -10298,7 +10298,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     patch:
       summary: Update Customer Establishment Contact Data
-      description: Requires `customers.update` and updates only the link's local contact data.
+      description: Requires `customers.update` and updates only the link's local contact data. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.update`.
       operationId: updateCustomerEstablishment
       tags:
         - Customers
@@ -10329,7 +10329,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Delete Customer Establishment
-      description: Requires `customers.update`. Deletion is blocked while one or more sites use this customer-establishment link, preserving the relationship required by each site.
+      description: Requires `customers.update`. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.update`. Deletion is blocked while one or more sites use this customer-establishment link, preserving the relationship required by each site.
       operationId: deleteCustomerEstablishment
       tags:
         - Customers
@@ -10393,7 +10393,7 @@ paths:
       summary: Update Customer
       description: |
         Update customer fields (PATCH semantics - all fields optional).
-        Requires `customers.update` and view access to the customer. If `legal_entity_id` differs from the customer's current value, it must identify a same-tenant, active, non-deleted Legal Entity. Legal Entity reassignment requires `customers.update`; callers with any organizational scopes receive HTTP **403** for reassignment. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
+        Requires `customers.update` and view access to the customer. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.update` and view access. If `legal_entity_id` differs from the customer's current value, it must identify a same-tenant, active, non-deleted Legal Entity. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
       operationId: updateCustomer
       tags:
         - Customers
@@ -10443,7 +10443,7 @@ paths:
     delete:
       summary: Delete Customer
       description: |
-        Soft delete a customer. Requires customers.delete permission.
+        Soft delete a customer. Requires `customers.delete`. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.delete`.
         Deletion is blocked while customer-establishment links or sites reference the customer; callers must move or delete dependents first.
       operationId: deleteCustomer
       tags:
@@ -10727,7 +10727,7 @@ paths:
       summary: Update Site
       description: |
         Update site fields (PATCH semantics - all fields optional).
-        Requires `sites.update` and view access to the site. Changing any domain relationship (`customer_id`, `legal_entity_id`, or `establishment_id`) requires `sites.update`; callers with any organizational scopes receive HTTP **403** for such reassignment.
+        Requires `sites.update` and view access to the site. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `sites.update` and view access.
       operationId: updateSite
       tags:
         - Sites
@@ -10775,7 +10775,7 @@ paths:
     delete:
       summary: Delete Site
       description: |
-        Soft delete a site. Requires sites.delete permission.
+        Soft delete a site. Requires `sites.delete`. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `sites.delete`.
         Will fail if site has active cost centers.
       operationId: deleteSite
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2154,6 +2154,7 @@ components:
 
     EmployeeCreateRequest:
       type: object
+      additionalProperties: false
       required:
         - first_name
         - last_name
@@ -2400,7 +2401,8 @@ components:
 
     EmployeeUpdateRequest:
       type: object
-      description: Partial employee update request. All properties are optional.
+      additionalProperties: false
+      description: Partial employee update request. All properties are optional. If either domain relationship changes, validation uses the resulting Legal Entity and establishment pair after applying supplied values to the stored employee; the result must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and stay within the caller's organizational write access.
       properties:
         employee_number:
           type: [string, 'null']
@@ -5957,7 +5959,7 @@ components:
     SiteUpdateRequest:
       type: object
       additionalProperties: false
-      description: Partial site update. Domain relationships may be reassigned only to an authorized, tenant-consistent customer, Legal Entity, and establishment combination.
+      description: Partial site update. If any domain relationship changes, validation uses the resulting customer, Legal Entity, and establishment combination after applying supplied values to the stored site; the result must use an active, non-deleted customer, active, assignable, non-deleted Legal Entity and establishment within the caller's organizational write access, remain tenant- and Legal-Entity-consistent, and reference an existing customer-establishment link.
       properties:
         name:
           type: string
@@ -6222,12 +6224,14 @@ components:
             message: A matching record already exists.
             code: DUPLICATE_RESOURCE
 
-    OrganizationalUnitHasChildrenConflict:
-      description: Conflict - Non-deleted direct child units must be moved or deleted first, regardless of their `is_active` values
+    OrganizationalUnitDeletionConflict:
+      description: Conflict - Non-deleted direct child units or domain records still reference the organizational unit
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganizationalUnitHasChildrenConflict'
+            oneOf:
+              - $ref: '#/components/schemas/OrganizationalUnitHasChildrenConflict'
+              - $ref: '#/components/schemas/Error'
 
     Unauthorized:
       description: Unauthorized - Authentication required
@@ -8528,6 +8532,7 @@ paths:
       summary: Create Employee
       description: |
         Create a new employee record. Onboarding invitations may only be requested during the `pre_contract` phase.
+        Requires `employees.create`. The supplied Legal Entity and establishment must be same tenant and belong to the same Legal Entity, both targets must be active, assignable, non-deleted, and the caller must have organizational write access for them.
         Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createEmployee
       tags:
@@ -8595,7 +8600,7 @@ paths:
 
     patch:
       summary: Update Employee
-      description: Update employee details (partial update)
+      description: Update employee details with partial-update semantics. If either domain relationship is supplied, the resulting stored Legal Entity and establishment pair must remain same tenant and same Legal Entity, use active, assignable, non-deleted targets, and remain within the caller's organizational write access.
       operationId: updateEmployee
       tags:
         - Employees
@@ -9630,7 +9635,7 @@ paths:
       description: |
         Soft-delete an organizational unit.
 
-        `OrganizationalUnitPolicy::delete` requires same-tenant manage access. The API rejects deletion while non-deleted direct child units exist, regardless of each child's `is_active` value; callers must move or delete children first.
+        `OrganizationalUnitPolicy::delete` requires same-tenant manage access. The API rejects deletion while non-deleted direct child units exist, regardless of each child's `is_active` value, or while the unit is referenced by customers, customer-establishment links, sites, or employees; callers must move or delete dependents first.
       operationId: deleteOrganizationalUnit
       tags:
         - Organizational Units
@@ -9656,7 +9661,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/OrganizationalUnitHasChildrenConflict'
+          $ref: '#/components/responses/OrganizationalUnitDeletionConflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -10076,7 +10081,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Link Customer to Establishment
-      description: Creates a unique customer-to-establishment link with optional local contact data. The customer and establishment must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
+      description: Creates a unique customer-to-establishment link with optional local contact data. The request must use an active, non-deleted customer and an active, assignable, non-deleted establishment within the caller's organizational write access; both must belong to the same tenant and Legal Entity. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing whether the pair or local identifying data matched.
       operationId: createCustomerEstablishment
       tags:
         - Customers
@@ -10281,7 +10286,7 @@ paths:
       summary: Delete Customer
       description: |
         Soft delete a customer. Requires customers.delete permission.
-        Will fail if customer has active sites.
+        Deletion is blocked while customer-establishment links or sites reference the customer; callers must move or delete dependents first.
       operationId: deleteCustomer
       tags:
         - Customers
@@ -10304,12 +10309,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '422':
-          description: Cannot delete customer with active sites
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -10477,7 +10478,7 @@ paths:
       summary: Create Site
       description: |
         Create a new site. Site number is auto-generated (OBJ-YYYY-####).
-        Requires sites.create permission and an authorized, tenant-consistent customer, Legal Entity, and establishment combination with an existing customer-establishment link for the selected customer and establishment. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
+        Requires `sites.create`, an active, non-deleted customer, active, assignable, non-deleted Legal Entity and establishment within the caller's organizational write access, and a tenant- and Legal-Entity-consistent combination with an existing customer-establishment link for the selected customer and establishment. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createSite
       tags:
         - Sites

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
-    "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml",
+    "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml && node scripts/check-domain-contracts.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
     "test": "npm run validate",

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import * as yaml from 'js-yaml'
+
+const contractPath = resolve(process.argv[2] ?? 'docs/openapi.yaml')
+const contract = yaml.load(readFileSync(contractPath, 'utf8'))
+const schemas = contract?.components?.schemas ?? {}
+const responses = contract?.components?.responses ?? {}
+const paths = contract?.paths ?? {}
+const errors = []
+
+const uuidProperty = (property) =>
+  property?.type === 'string' && property?.format === 'uuid'
+
+function requireUuid(schemaName, propertyName, required) {
+  const schema = schemas[schemaName]
+  if (
+    !uuidProperty(schema?.properties?.[propertyName]) ||
+    Boolean(schema?.required?.includes(propertyName)) !== required
+  ) {
+    errors.push(
+      `${schemaName}.${propertyName} must be ${required ? 'a required' : 'an optional'} UUID.`
+    )
+  }
+}
+
+function rejectOuFields(schemaName) {
+  const properties = schemas[schemaName]?.properties ?? {}
+  for (const propertyName of ['organizational_unit_id', 'organizational_unit']) {
+    if (Object.hasOwn(properties, propertyName)) {
+      errors.push(`${schemaName} must not expose ${propertyName}.`)
+    }
+  }
+}
+
+const customerAllowedProperties = new Set([
+  'id',
+  'customer_number',
+  'legal_entity_id',
+  'vat_id',
+  'name',
+  'billing_address',
+  'is_active',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+])
+for (const propertyName of Object.keys(schemas.Customer?.properties ?? {})) {
+  if (!customerAllowedProperties.has(propertyName)) {
+    errors.push(`Customer must not expose non-master-data field ${propertyName}.`)
+  }
+}
+
+for (const schemaName of [
+  'Customer',
+  'CustomerCreateRequest',
+  'CustomerUpdateRequest',
+  'Site',
+  'SiteCreateRequest',
+  'SiteUpdateRequest',
+  'Employee',
+  'EmployeeCreateRequest',
+  'EmployeeUpdateRequest',
+]) {
+  rejectOuFields(schemaName)
+}
+
+requireUuid('Customer', 'legal_entity_id', true)
+requireUuid('CustomerCreateRequest', 'legal_entity_id', true)
+requireUuid('CustomerUpdateRequest', 'legal_entity_id', false)
+for (const schemaName of ['Site', 'SiteCreateRequest']) {
+  requireUuid(schemaName, 'customer_id', true)
+  requireUuid(schemaName, 'legal_entity_id', true)
+  requireUuid(schemaName, 'establishment_id', true)
+}
+for (const propertyName of [
+  'customer_id',
+  'legal_entity_id',
+  'establishment_id',
+]) {
+  requireUuid('SiteUpdateRequest', propertyName, false)
+}
+for (const schemaName of ['Employee', 'EmployeeCreateRequest']) {
+  requireUuid(schemaName, 'legal_entity_id', true)
+  requireUuid(schemaName, 'establishment_id', true)
+}
+for (const propertyName of ['legal_entity_id', 'establishment_id']) {
+  requireUuid('EmployeeUpdateRequest', propertyName, false)
+}
+
+for (const [pathName, operation] of [
+  ['/sites', paths['/sites']?.get],
+  ['/employees', paths['/employees']?.get],
+]) {
+  const parameters = operation?.parameters ?? []
+  if (parameters.some((parameter) => parameter?.name === 'organizational_unit_id')) {
+    errors.push(`GET ${pathName} must not expose an organizational_unit_id filter.`)
+  }
+}
+const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
+  (parameter) => parameter?.name === 'include'
+)?.schema?.enum
+if (siteIncludes?.some((value) => /organizational/i.test(value))) {
+  errors.push('GET /sites/{site} must not expose an organizational-unit include.')
+}
+
+const customerEstablishment = schemas.CustomerEstablishment ?? {}
+const expectedCustomerEstablishmentRequired = [
+  'id',
+  'customer_id',
+  'establishment_id',
+  'created_at',
+  'updated_at',
+]
+if (
+  JSON.stringify(customerEstablishment.required) !==
+    JSON.stringify(expectedCustomerEstablishmentRequired) ||
+  !/unique.*customer_id.*establishment_id/i.test(
+    customerEstablishment.description ?? ''
+  )
+) {
+  errors.push(
+    'CustomerEstablishment must define the unique customer_id and establishment_id pair and required response fields.'
+  )
+}
+for (const propertyName of [
+  'customer_id',
+  'establishment_id',
+  'contact_name',
+  'phone',
+  'email',
+  'comments',
+]) {
+  if (!customerEstablishment.properties?.[propertyName]) {
+    errors.push(`CustomerEstablishment must expose ${propertyName}.`)
+  }
+}
+
+for (const schemaName of [
+  'LegalEntityLookup',
+  'EstablishmentLookup',
+  'CustomerLookup',
+]) {
+  const schema = schemas[schemaName] ?? {}
+  if (
+    schema.type !== 'object' ||
+    schema.additionalProperties !== false ||
+    JSON.stringify(schema.required) !== JSON.stringify(['id', 'name']) ||
+    JSON.stringify(Object.keys(schema.properties ?? {})) !==
+      JSON.stringify(['id', 'name']) ||
+    !uuidProperty(schema.properties?.id) ||
+    schema.properties?.name?.type !== 'string'
+  ) {
+    errors.push(`${schemaName} must expose only required id and name fields.`)
+  }
+}
+
+for (const [pathName, responseRef] of [
+  [
+    '/lookups/legal-entities',
+    '#/components/schemas/LegalEntityLookupCollectionResponse',
+  ],
+  [
+    '/lookups/legal-entities/{legal_entity}/establishments',
+    '#/components/schemas/EstablishmentLookupCollectionResponse',
+  ],
+  [
+    '/lookups/establishments/{establishment}/customers',
+    '#/components/schemas/CustomerLookupCollectionResponse',
+  ],
+]) {
+  const operation = paths[pathName]?.get
+  const actualRef =
+    operation?.responses?.['200']?.content?.['application/json']?.schema?.$ref
+  if (
+    actualRef !== responseRef ||
+    !/only/i.test(operation?.description ?? '') ||
+    !/authorized/i.test(operation?.description ?? '')
+  ) {
+    errors.push(
+      `GET ${pathName} must return the minimal authorized lookup response.`
+    )
+  }
+}
+
+const duplicateError = schemas.DuplicateResourceError ?? {}
+if (
+  duplicateError.additionalProperties !== false ||
+  JSON.stringify(duplicateError.required) !==
+    JSON.stringify(['message', 'code']) ||
+  JSON.stringify(duplicateError.properties?.code?.enum) !==
+    JSON.stringify(['DUPLICATE_RESOURCE']) ||
+  JSON.stringify(duplicateError.properties?.message?.enum) !==
+    JSON.stringify(['A matching record already exists.'])
+) {
+  errors.push('DuplicateResourceError must retain its neutral fixed shape.')
+}
+if (
+  responses.DuplicateConflict?.content?.['application/json']?.schema?.$ref !==
+    '#/components/schemas/DuplicateResourceError' ||
+  !/atomically.*same transaction/i.test(
+    responses.DuplicateConflict?.description ?? ''
+  )
+) {
+  errors.push(
+    'DuplicateConflict must document atomic checking and use DuplicateResourceError.'
+  )
+}
+for (const pathName of [
+  '/customers',
+  '/customer-establishments',
+  '/sites',
+  '/employees',
+]) {
+  if (
+    paths[pathName]?.post?.responses?.['409']?.$ref !==
+    '#/components/responses/DuplicateConflict'
+  ) {
+    errors.push(`POST ${pathName} must use DuplicateConflict for duplicates.`)
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Domain contract guard failed:')
+  for (const error of errors) console.error(`  - ${error}`)
+  process.exit(1)
+}
+
+console.log('Domain contract guard passed.')

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -229,6 +229,74 @@ for (const schemaName of ['SiteCreateRequest', 'EmployeeCreateRequest']) {
     )
   }
 }
+
+function hasTenantConsistentCustomerEstablishmentExamples() {
+  const schema = schemas.CustomerEstablishmentCreateRequest ?? {}
+  const examples = schema['x-validation-examples'] ?? {}
+  const accepted = examples.accepted?.[0]
+  const rejected = examples.rejected?.[0]
+  const payloadIsPresent = (example) =>
+    ['customer_id', 'establishment_id'].every((property) =>
+      Object.hasOwn(example?.value ?? {}, property)
+    )
+  const tenantIds = (example) =>
+    [example?.customer_tenant_id, example?.establishment_tenant_id]
+  const legalEntityIds = (example) =>
+    [example?.customer_legal_entity_id, example?.establishment_legal_entity_id]
+  const isValid = (example) =>
+    payloadIsPresent(example) &&
+    [...tenantIds(example), ...legalEntityIds(example), example?.value?.customer_id, example?.value?.establishment_id].every(uuidValue)
+
+  return (
+    isValid(accepted) &&
+    isValid(rejected) &&
+    tenantIds(accepted)[0] === tenantIds(accepted)[1] &&
+    legalEntityIds(accepted)[0] === legalEntityIds(accepted)[1] &&
+    rejected?.status === 422 &&
+    (tenantIds(rejected)[0] !== tenantIds(rejected)[1] ||
+      legalEntityIds(rejected)[0] !== legalEntityIds(rejected)[1])
+  )
+}
+
+if (!hasTenantConsistentCustomerEstablishmentExamples()) {
+  errors.push(
+    'CustomerEstablishmentCreateRequest must retain accepted and rejected tenant-consistent link examples.'
+  )
+}
+
+const legalEntityLookupDescription =
+  paths['/lookups/legal-entities']?.get?.description ?? ''
+if (!/customers\.create.*sites\.create.*employees\.create/i.test(legalEntityLookupDescription)) {
+  errors.push(
+    'GET /lookups/legal-entities must authorize every domain-assignment creation workflow.'
+  )
+}
+const establishmentLookupDescription =
+  paths['/lookups/legal-entities/{legal_entity}/establishments']?.get
+    ?.description ?? ''
+if (!/same tenant, active, assignable, non-deleted/i.test(establishmentLookupDescription)) {
+  errors.push(
+    'GET establishment lookups must return only eligible establishments.'
+  )
+}
+if (!/existing customer-establishment link/i.test(paths['/sites']?.post?.description ?? '')) {
+  errors.push('POST /sites must require an existing customer-establishment link.')
+}
+if (
+  !/no customer-establishment links or sites/i.test(
+    paths['/customers/{customer}']?.patch?.description ?? ''
+  )
+) {
+  errors.push('PATCH /customers/{customer} must protect dependent links and sites during Legal Entity reassignment.')
+}
+const customerEstablishmentDelete = customerEstablishmentPath.delete
+if (
+  !/blocked.*sites/i.test(customerEstablishmentDelete?.description ?? '') ||
+  customerEstablishmentDelete?.responses?.['409']?.$ref !==
+    '#/components/responses/Conflict'
+) {
+  errors.push('DELETE customer establishments must block deletion while dependent sites exist.')
+}
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum
@@ -312,6 +380,16 @@ for (const [pathName, responseRef] of [
       `GET ${pathName} must return the minimal authorized lookup response.`
     )
   }
+}
+if (
+  !/existing customer-establishment link/i.test(
+    paths['/lookups/establishments/{establishment}/customers']?.get
+      ?.description ?? ''
+  )
+) {
+  errors.push(
+    'GET customer lookups must return only customers with an existing customer-establishment link.'
+  )
 }
 
 const duplicateError = schemas.DuplicateResourceError ?? {}

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -21,6 +21,22 @@ const uuidValue = (value) =>
     value
   )
 
+function requireTextRules(rules) {
+  for (const { label, text: value, patterns } of rules) {
+    if (patterns.some((pattern) => !pattern.test(value ?? ''))) {
+      errors.push(`${label} must document its complete domain invariant.`)
+    }
+  }
+}
+
+function requireResponseRefs(rules) {
+  for (const { label, operation, status, ref } of rules) {
+    if (operation?.responses?.[status]?.$ref !== ref) {
+      errors.push(`${label} must use ${ref} for HTTP ${status}.`)
+    }
+  }
+}
+
 function requireUuid(schemaName, propertyName, required) {
   const schema = schemas[schemaName]
   if (
@@ -236,65 +252,6 @@ for (const schemaName of ['EmployeeCreateRequest', 'EmployeeUpdateRequest']) {
   }
 }
 
-if (
-  !/active, assignable, non-deleted.*organizational write access/i.test(
-    paths['/employees']?.post?.description ?? ''
-  )
-) {
-  errors.push('POST /employees must require eligible authorized assignment targets.')
-}
-if (
-  !/resulting.*same tenant.*Legal Entity.*active, assignable, non-deleted/i.test(
-    paths['/employees/{employee}']?.patch?.description ?? ''
-  )
-) {
-  errors.push('PATCH employee assignments must validate the resulting domain pair.')
-}
-if (
-  !/resulting.*existing customer-establishment link/i.test(
-    schemas.SiteUpdateRequest?.description ?? ''
-  )
-) {
-  errors.push('PATCH site assignments must require a valid resulting customer-establishment link.')
-}
-
-for (const [label, description] of [
-  [
-    'POST customer-establishment links',
-    paths['/customer-establishments']?.post?.description,
-  ],
-  ['POST site assignments', paths['/sites']?.post?.description],
-  ['PATCH site assignments', schemas.SiteUpdateRequest?.description],
-]) {
-  if (
-    !/active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i.test(
-      description ?? ''
-    )
-  ) {
-    errors.push(`${label} must enforce eligible authorized assignment targets.`)
-  }
-}
-
-const customerDelete = paths['/customers/{customer}']?.delete
-if (
-  !/customer-establishment links or sites/i.test(customerDelete?.description ?? '') ||
-  customerDelete?.responses?.['409']?.$ref !==
-    '#/components/responses/Conflict'
-) {
-  errors.push('DELETE customers must block remaining domain dependents with Conflict.')
-}
-const organizationalUnitDelete =
-  paths['/organizational-units/{organizational_unit}']?.delete
-if (
-  !/customers, customer-establishment links, sites, or employees/i.test(
-    organizationalUnitDelete?.description ?? ''
-  ) ||
-  organizationalUnitDelete?.responses?.['409']?.$ref !==
-    '#/components/responses/OrganizationalUnitDeletionConflict'
-) {
-  errors.push('DELETE organizational units must block remaining domain dependents with Conflict.')
-}
-
 function hasTenantConsistentCustomerEstablishmentExamples() {
   const schema = schemas.CustomerEstablishmentCreateRequest ?? {}
   const examples = schema['x-validation-examples'] ?? {}
@@ -329,39 +286,164 @@ if (!hasTenantConsistentCustomerEstablishmentExamples()) {
   )
 }
 
-const legalEntityLookupDescription =
-  paths['/lookups/legal-entities']?.get?.description ?? ''
-if (!/customers\.create.*sites\.create.*employees\.create/i.test(legalEntityLookupDescription)) {
-  errors.push(
-    'GET /lookups/legal-entities must authorize every domain-assignment creation workflow.'
-  )
-}
-const establishmentLookupDescription =
-  paths['/lookups/legal-entities/{legal_entity}/establishments']?.get
-    ?.description ?? ''
-if (!/same tenant, active, assignable, non-deleted/i.test(establishmentLookupDescription)) {
-  errors.push(
-    'GET establishment lookups must return only eligible establishments.'
-  )
-}
-if (!/existing customer-establishment link/i.test(paths['/sites']?.post?.description ?? '')) {
-  errors.push('POST /sites must require an existing customer-establishment link.')
-}
-if (
-  !/no customer-establishment links or sites/i.test(
-    paths['/customers/{customer}']?.patch?.description ?? ''
-  )
-) {
-  errors.push('PATCH /customers/{customer} must protect dependent links and sites during Legal Entity reassignment.')
-}
 const customerEstablishmentDelete = customerEstablishmentPath.delete
-if (
-  !/blocked.*sites/i.test(customerEstablishmentDelete?.description ?? '') ||
-  customerEstablishmentDelete?.responses?.['409']?.$ref !==
-    '#/components/responses/Conflict'
-) {
-  errors.push('DELETE customer establishments must block deletion while dependent sites exist.')
-}
+const customerDelete = paths['/customers/{customer}']?.delete
+const organizationalUnitUpdate =
+  paths['/organizational-units/{organizational_unit}']?.patch
+const organizationalUnitDelete =
+  paths['/organizational-units/{organizational_unit}']?.delete
+
+requireTextRules([
+  {
+    label: 'POST employee assignments',
+    text: paths['/employees']?.post?.description,
+    patterns: [
+      /active, assignable, non-deleted/i,
+      /organizational write access/i,
+    ],
+  },
+  {
+    label: 'PATCH employee assignments',
+    text: paths['/employees/{employee}']?.patch?.description,
+    patterns: [
+      /resulting.*same tenant.*Legal Entity/i,
+      /active, assignable, non-deleted/i,
+    ],
+  },
+  {
+    label: 'POST customer-establishment links',
+    text: paths['/customer-establishments']?.post?.description,
+    patterns: [
+      /customers\.update/i,
+      /active, non-deleted customer/i,
+      /active, assignable, non-deleted establishment/i,
+      /organizational write access/i,
+    ],
+  },
+  {
+    label: 'POST site assignments',
+    text: paths['/sites']?.post?.description,
+    patterns: [
+      /active, non-deleted customer/i,
+      /active, assignable, non-deleted/i,
+      /organizational write access/i,
+      /existing customer-establishment link/i,
+    ],
+  },
+  {
+    label: 'PATCH site assignments',
+    text: schemas.SiteUpdateRequest?.description,
+    patterns: [
+      /resulting/i,
+      /active, non-deleted customer/i,
+      /active, assignable, non-deleted/i,
+      /organizational write access/i,
+      /existing customer-establishment link/i,
+    ],
+  },
+  {
+    label: 'PATCH customer Legal Entity reassignment',
+    text: paths['/customers/{customer}']?.patch?.description,
+    patterns: [/no customer-establishment links or sites/i],
+  },
+  {
+    label: 'PATCH customer-establishment links',
+    text: customerEstablishmentPath.patch?.description,
+    patterns: [/customers\.update/i],
+  },
+  {
+    label: 'DELETE customer-establishment links',
+    text: customerEstablishmentDelete?.description,
+    patterns: [/customers\.update/i, /blocked.*sites/i],
+  },
+  {
+    label: 'DELETE customers',
+    text: customerDelete?.description,
+    patterns: [/customer-establishment links or sites/i],
+  },
+  {
+    label: 'PATCH organizational-unit roles',
+    text: organizationalUnitUpdate?.description,
+    patterns: [
+      /is_legal_entity.*is_establishment/i,
+      /referenced.*customers.*customer-establishment links.*sites.*employees/i,
+    ],
+  },
+  {
+    label: 'DELETE organizational units',
+    text: organizationalUnitDelete?.description,
+    patterns: [/customers, customer-establishment links, sites, or employees/i],
+  },
+  {
+    label: 'GET Legal Entity lookups',
+    text: paths['/lookups/legal-entities']?.get?.description,
+    patterns: [
+      /customers\.create.*customers\.update.*sites\.create.*employees\.create/i,
+    ],
+  },
+  {
+    label: 'GET establishment lookups',
+    text: paths['/lookups/legal-entities/{legal_entity}/establishments']?.get
+      ?.description,
+    patterns: [
+      /customers\.update.*sites\.create.*employees\.create/i,
+      /same tenant, active, assignable, non-deleted/i,
+    ],
+  },
+  {
+    label: 'GET linked customer lookups',
+    text: paths['/lookups/establishments/{establishment}/customers']?.get
+      ?.description,
+    patterns: [
+      /sites\.create/i,
+      /active, assignable, non-deleted establishment/i,
+      /organizational write access/i,
+      /active, non-deleted customers/i,
+      /existing customer-establishment link/i,
+    ],
+  },
+  {
+    label: 'GET customer link candidates',
+    text: paths[
+      '/lookups/establishments/{establishment}/customer-candidates'
+    ]?.get?.description,
+    patterns: [
+      /customers\.update/i,
+      /active, assignable, non-deleted establishment/i,
+      /same tenant and Legal Entity/i,
+      /active, non-deleted customers/i,
+      /not yet linked/i,
+      /organizational write access/i,
+    ],
+  },
+])
+
+requireResponseRefs([
+  {
+    label: 'DELETE customer-establishment links',
+    operation: customerEstablishmentDelete,
+    status: '409',
+    ref: '#/components/responses/Conflict',
+  },
+  {
+    label: 'DELETE customers',
+    operation: customerDelete,
+    status: '409',
+    ref: '#/components/responses/Conflict',
+  },
+  {
+    label: 'PATCH organizational-unit roles',
+    operation: organizationalUnitUpdate,
+    status: '409',
+    ref: '#/components/responses/Conflict',
+  },
+  {
+    label: 'DELETE organizational units',
+    operation: organizationalUnitDelete,
+    status: '409',
+    ref: '#/components/responses/OrganizationalUnitDeletionConflict',
+  },
+])
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum
@@ -432,6 +514,10 @@ for (const [pathName, responseRef] of [
     '/lookups/establishments/{establishment}/customers',
     '#/components/schemas/CustomerLookupCollectionResponse',
   ],
+  [
+    '/lookups/establishments/{establishment}/customer-candidates',
+    '#/components/schemas/CustomerLookupCollectionResponse',
+  ],
 ]) {
   const operation = paths[pathName]?.get
   const actualRef =
@@ -445,16 +531,6 @@ for (const [pathName, responseRef] of [
       `GET ${pathName} must return the minimal authorized lookup response.`
     )
   }
-}
-if (
-  !/existing customer-establishment link/i.test(
-    paths['/lookups/establishments/{establishment}/customers']?.get
-      ?.description ?? ''
-  )
-) {
-  errors.push(
-    'GET customer lookups must return only customers with an existing customer-establishment link.'
-  )
 }
 
 const duplicateError = schemas.DuplicateResourceError ?? {}

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -61,6 +61,104 @@ function requireContractRules(rules) {
   }
 }
 
+function requireEmployeeSubresourceAuthorization({
+  familyLabel,
+  pathPrefixes,
+  rules,
+  schemaRules = [],
+}) {
+  const coveredOperations = new Set()
+  const noOuBoundary = /OU scopes do not grant access to domain employees/i
+  const selfServiceMarker = /\*\*Self-service:\*\*/i
+  const selfServiceBoundary = /non-self callers.*organizational scopes.*403/is
+  const nonSelfServiceBoundary = /callers with any organizational scopes.*403/is
+  const stalePatterns = [
+    /allowed units/i,
+    /scoped managers/i,
+    /scope rules/i,
+    /scope checks/i,
+    /organizational checks/i,
+    /organizational scope (?:is enforced|via)/i,
+  ]
+
+  for (const rule of rules) {
+    const description = rule.operation?.description ?? ''
+    if (rule.operation) {
+      coveredOperations.add(rule.operation)
+    }
+    if (
+      !noOuBoundary.test(description) ||
+      !description.includes(rule.permission) ||
+      selfServiceMarker.test(description) !== rule.selfService ||
+      !(rule.selfService
+        ? selfServiceBoundary.test(description)
+        : nonSelfServiceBoundary.test(description)) ||
+      stalePatterns.some((pattern) => pattern.test(description)) ||
+      rule.operation?.responses?.['403']?.$ref !== rule.forbiddenRef
+    ) {
+      errors.push(
+        `${familyLabel} authorization must keep ${rule.label} permission, no-OU boundary, and 403 response aligned.`
+      )
+    }
+  }
+
+  for (const rule of schemaRules) {
+    const description = schemas[rule.schemaName]?.description ?? ''
+    if (
+      !noOuBoundary.test(description) ||
+      !description.includes(rule.permission) ||
+      !nonSelfServiceBoundary.test(description) ||
+      selfServiceMarker.test(description) ||
+      stalePatterns.some((pattern) => pattern.test(description))
+    ) {
+      errors.push(
+        `${familyLabel} authorization must keep ${rule.schemaName} aligned with its operation.`
+      )
+    }
+  }
+
+  for (const [pathName, pathItem] of Object.entries(paths)) {
+    if (
+      !pathPrefixes.some(
+        (prefix) => pathName === prefix || pathName.startsWith(`${prefix}/`)
+      )
+    ) {
+      continue
+    }
+    for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+      const operation = pathItem?.[method]
+      if (operation && !coveredOperations.has(operation)) {
+        errors.push(
+          `unmodeled ${familyLabel} operation: ${method.toUpperCase()} ${pathName}.`
+        )
+      }
+    }
+  }
+}
+
+function requireCollectionFilterRules(rules) {
+  for (const rule of rules) {
+    const parameters = rule.operation?.parameters ?? []
+    const parameterNames = parameters.map(({ name }) => name)
+    const searchDescription =
+      parameters.find(({ name }) => name === 'search')?.description ?? ''
+    const invalidUuidFilter = rule.uuidFields.some((field) => {
+      const parameter = parameters.find(({ name }) => name === field)
+      return !uuidProperty(parameter?.schema)
+    })
+
+    if (
+      JSON.stringify(parameterNames) !== JSON.stringify(rule.parameters) ||
+      invalidUuidFilter ||
+      !rule.searchPattern.test(searchDescription)
+    ) {
+      errors.push(
+        `GET ${rule.path} collection filters must match the validated API parameters and search fields.`
+      )
+    }
+  }
+}
+
 function requireUniquenessRules(rules) {
   const coveredSchemas = new Set(
     rules.map(({ resourceSchema }) => resourceSchema)
@@ -192,10 +290,15 @@ function requireAssignmentWorkflows(workflows, lookups) {
       )
     }
 
-    if (
-      !(workflow.operation?.description ?? '').includes(workflow.permission)
-    ) {
-      errors.push(`${workflow.label} must require ${workflow.permission}.`)
+    const permissions = workflow.permissions ?? [workflow.permission]
+    const missingPermissions = permissions.filter(
+      (permission) =>
+        !(workflow.operation?.description ?? '').includes(permission)
+    )
+    if (missingPermissions.length > 0) {
+      errors.push(
+        `${workflow.label} must require ${missingPermissions.join(', ')}.`
+      )
     }
 
     for (const lookupName of workflow.lookups) {
@@ -206,7 +309,9 @@ function requireAssignmentWorkflows(workflows, lookups) {
         )
         continue
       }
-      permissions.add(workflow.permission)
+      for (const permission of workflow.permissions ?? [workflow.permission]) {
+        permissions.add(permission)
+      }
     }
   }
 
@@ -263,6 +368,26 @@ function rejectOuFields(schemaName) {
   }
 }
 
+function requireOptionalString(
+  schemaName,
+  propertyName,
+  maxLength,
+  nullable = false
+) {
+  const schema = schemas[schemaName] ?? {}
+  const property = schema.properties?.[propertyName]
+  if (
+    JSON.stringify(property?.type) !==
+      JSON.stringify(nullable ? ['string', 'null'] : 'string') ||
+    property.maxLength !== maxLength ||
+    schema.required?.includes(propertyName)
+  ) {
+    errors.push(
+      `${schemaName}.${propertyName} must remain an optional string with maxLength ${maxLength}.`
+    )
+  }
+}
+
 const customerAllowedProperties = new Set([
   'id',
   'customer_number',
@@ -271,6 +396,7 @@ const customerAllowedProperties = new Set([
   'name',
   'billing_address',
   'is_active',
+  'sites_count',
   'created_at',
   'updated_at',
   'deleted_at',
@@ -284,6 +410,16 @@ for (const propertyName of Object.keys(schemas.Customer?.properties ?? {})) {
       `Customer must not expose non-master-data field ${propertyName}.`
     )
   }
+}
+const customerSitesCount = schemas.Customer?.properties?.sites_count
+if (
+  customerSitesCount?.type !== 'integer' ||
+  customerSitesCount.minimum !== 0 ||
+  schemas.Customer?.required?.includes('sites_count')
+) {
+  errors.push(
+    'Customer.sites_count must remain an optional non-negative visible-site count.'
+  )
 }
 
 const customerGet = paths['/customers/{customer}']?.get
@@ -334,6 +470,7 @@ if (
       activity.description !== 'created' ||
       !uuidValue(attributes.legal_entity_id) ||
       !uuidValue(attributes.establishment_id) ||
+      activity.subject?.name != null ||
       forbiddenEmployeeAuditFields.some((field) =>
         Object.hasOwn(attributes, field)
       )
@@ -341,7 +478,7 @@ if (
   })
 ) {
   errors.push(
-    'All employee creation audit examples must use employee_changes, include domain assignment UUIDs, and exclude OU and personal contact fields.'
+    'All employee creation audit examples must use employee_changes, include domain assignment UUIDs, and exclude OU and employee personal-name values.'
   )
 }
 
@@ -368,19 +505,99 @@ for (const propertyName of ['legal_entity_id', 'establishment_id']) {
   requireUuid('EmployeeUpdateRequest', propertyName, false)
 }
 
-for (const [pathName, operation] of [
-  ['/sites', paths['/sites']?.get],
-  ['/employees', paths['/employees']?.get],
+for (const [schemaName, propertyName, nullable] of [
+  ['CustomerCreateRequest', 'customer_number', true],
+  ['SiteCreateRequest', 'site_number', true],
+  ['SiteUpdateRequest', 'site_number', false],
 ]) {
-  const parameters = operation?.parameters ?? []
-  if (
-    parameters.some((parameter) => parameter?.name === 'organizational_unit_id')
-  ) {
-    errors.push(
-      `GET ${pathName} must not expose an organizational_unit_id filter.`
-    )
+  requireOptionalString(schemaName, propertyName, 50, nullable)
+}
+const siteCreateIsActive = schemas.SiteCreateRequest?.properties?.is_active
+if (
+  JSON.stringify(siteCreateIsActive?.type) !==
+    JSON.stringify(['boolean', 'null']) ||
+  siteCreateIsActive.default !== true ||
+  schemas.SiteCreateRequest?.required?.includes('is_active')
+) {
+  errors.push(
+    'SiteCreateRequest.is_active must remain an optional nullable boolean defaulting to true.'
+  )
+}
+const customerCreateIsActive =
+  schemas.CustomerCreateRequest?.properties?.is_active
+if (
+  JSON.stringify(customerCreateIsActive?.type) !==
+    JSON.stringify(['boolean', 'null']) ||
+  customerCreateIsActive.default !== true ||
+  schemas.CustomerCreateRequest?.required?.includes('is_active')
+) {
+  errors.push(
+    'CustomerCreateRequest.is_active must remain an optional nullable boolean defaulting to true.'
+  )
+}
+if (
+  JSON.stringify(schemas.SiteCreateRequest?.properties?.contact?.anyOf) !==
+  JSON.stringify([{ $ref: '#/components/schemas/Contact' }, { type: 'null' }])
+) {
+  errors.push(
+    'SiteCreateRequest.contact must accept either Contact or the API-supported null value.'
+  )
+}
+for (const [label, description, pattern] of [
+  [
+    'CustomerCreateRequest.customer_number',
+    paths['/customers']?.post?.description,
+    /customer_number.*omitted or null.*generat(?:ed|es)/is,
+  ],
+  [
+    'SiteCreateRequest.site_number',
+    paths['/sites']?.post?.description,
+    /site_number.*omitted or null.*generat(?:ed|es)/is,
+  ],
+]) {
+  if (!pattern.test(description ?? '')) {
+    errors.push(`${label} must document its optional generated default.`)
   }
 }
+
+requireCollectionFilterRules([
+  {
+    path: '/customers',
+    operation: paths['/customers']?.get,
+    parameters: ['page', 'per_page', 'search', 'is_active'],
+    uuidFields: [],
+    searchPattern: /name and customer_number/i,
+  },
+  {
+    path: '/sites',
+    operation: paths['/sites']?.get,
+    parameters: [
+      'page',
+      'per_page',
+      'search',
+      'customer_id',
+      'establishment_id',
+      'type',
+      'is_active',
+    ],
+    uuidFields: ['customer_id', 'establishment_id'],
+    searchPattern: /name and site_number/i,
+  },
+  {
+    path: '/employees',
+    operation: paths['/employees']?.get,
+    parameters: [
+      'page',
+      'per_page',
+      'status',
+      'search',
+      'legal_entity_id',
+      'establishment_id',
+    ],
+    uuidFields: ['legal_entity_id', 'establishment_id'],
+    searchPattern: /email and employee_number/i,
+  },
+])
 
 const customerEstablishment = schemas.CustomerEstablishment ?? {}
 const customerEstablishmentEmailExample =
@@ -542,11 +759,6 @@ if (!hasTenantConsistentCustomerEstablishmentExamples()) {
 const customerUpdate = paths['/customers/{customer}']?.patch
 const customerDelete = paths['/customers/{customer}']?.delete
 const customerEstablishmentDelete = customerEstablishmentPath.delete
-const organizationalUnitUpdate =
-  paths['/organizational-units/{organizational_unit}']?.patch
-const organizationalUnitDelete =
-  paths['/organizational-units/{organizational_unit}']?.delete
-
 const assignmentLookups = {
   legalEntities: {
     label: 'GET Legal Entity lookups',
@@ -623,7 +835,7 @@ requireAssignmentWorkflows(
       operation: paths['/employees']?.post,
       requestSchema: 'EmployeeCreateRequest',
       relationshipFields: ['legal_entity_id', 'establishment_id'],
-      permission: 'employees.create',
+      permissions: ['employee.write', 'employee.create'],
       lookups: ['legalEntities', 'establishments'],
     },
     {
@@ -631,29 +843,45 @@ requireAssignmentWorkflows(
       operation: paths['/employees/{employee}']?.patch,
       requestSchema: 'EmployeeUpdateRequest',
       relationshipFields: ['legal_entity_id', 'establishment_id'],
-      permission: 'employees.update',
+      permissions: ['employee.write', 'employee.update'],
       lookups: ['legalEntities', 'establishments'],
     },
   ],
   assignmentLookups
 )
 
+const tenantDomainAssignablePattern =
+  /active, assignable|assignable (?:Legal Entit|establishment)|(?:Legal Entit|establishment)[^.]*assignable/i
+
 requireContractRules([
+  {
+    label: 'POST customer assignments',
+    text: paths['/customers']?.post?.description,
+    patterns: [
+      /active, non-deleted/i,
+      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
+    ],
+    forbiddenPatterns: [
+      /organizational write access/i,
+      tenantDomainAssignablePattern,
+    ],
+    response: {
+      operation: paths['/customers']?.post,
+      status: '403',
+      ref: '#/components/responses/Forbidden',
+    },
+  },
   {
     label: 'POST employee assignments',
     text: paths['/employees']?.post?.description,
-    patterns: [
-      /active, assignable, non-deleted/i,
-      /organizational write access/i,
-    ],
+    patterns: [/active(?:,| and) non-deleted/i, /organizational write access/i],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
   {
     label: 'PATCH employee assignments',
     text: paths['/employees/{employee}']?.patch?.description,
-    patterns: [
-      /resulting.*same tenant.*Legal Entity/i,
-      /active, assignable, non-deleted/i,
-    ],
+    patterns: [/resulting.*same tenant.*Legal Entity/i, /active, non-deleted/i],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
   {
     label: 'POST customer-establishment links',
@@ -661,8 +889,12 @@ requireContractRules([
     patterns: [
       /customers\.update/i,
       /active, non-deleted customer/i,
-      /active, assignable, non-deleted establishment/i,
+      /active, non-deleted establishment/i,
+      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
+    ],
+    forbiddenPatterns: [
       /organizational write access/i,
+      tenantDomainAssignablePattern,
     ],
   },
   {
@@ -670,9 +902,13 @@ requireContractRules([
     text: paths['/sites']?.post?.description,
     patterns: [
       /active, non-deleted customer/i,
-      /active, assignable, non-deleted/i,
-      /organizational write access/i,
+      /active, non-deleted/i,
+      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
       /existing customer-establishment link/i,
+    ],
+    forbiddenPatterns: [
+      /organizational write access/i,
+      tenantDomainAssignablePattern,
     ],
   },
   {
@@ -681,9 +917,24 @@ requireContractRules([
     patterns: [
       /resulting/i,
       /active, non-deleted customer/i,
-      /active, assignable, non-deleted/i,
-      /organizational write access/i,
+      /active, non-deleted/i,
+      /domain relationship.*sites\.update.*organizational scopes.*403/is,
       /existing customer-establishment link/i,
+    ],
+    forbiddenPatterns: [
+      /organizational write access/i,
+      tenantDomainAssignablePattern,
+    ],
+  },
+  {
+    label: 'PATCH site assignment operation',
+    text: paths['/sites/{site}']?.patch?.description,
+    patterns: [
+      /domain relationship.*sites\.update.*organizational scopes.*403/is,
+    ],
+    forbiddenPatterns: [
+      /organizational write access/i,
+      tenantDomainAssignablePattern,
     ],
   },
   {
@@ -692,16 +943,35 @@ requireContractRules([
     patterns: [/customers\.update/i],
   },
   ...[
+    ['GET customer collections', paths['/customers']?.get],
     [
       'GET customer-establishment collections',
       paths['/customer-establishments']?.get,
     ],
+  ].map(([label, operation]) => ({
+    label,
+    text: operation?.description,
+    patterns: [
+      /customers\.read.*without organizational scopes/is,
+      /active customer or site assignment/is,
+      /OU scope alone.*empty authorized collection/is,
+    ],
+    response: {
+      operation,
+      status: '403',
+      ref: '#/components/responses/Forbidden',
+    },
+  })),
+  ...[
+    ['GET customer records', paths['/customers/{customer}']?.get],
     ['GET customer-establishment links', customerEstablishmentPath.get],
   ].map(([label, operation]) => ({
     label,
     text: operation?.description,
     patterns: [
-      /view access.*customer assignment.*organizational scope.*authorized/is,
+      /active customer or site assignment/is,
+      /customers\.read.*without organizational scopes/is,
+      /OU scopes alone do not grant record access/is,
     ],
     response: {
       operation,
@@ -710,59 +980,182 @@ requireContractRules([
     },
   })),
   {
-    label: 'GET employee qualifications',
-    text: paths['/employees/{employee}/qualifications']?.get?.description,
+    label: 'GET site collections',
+    text: paths['/sites']?.get?.description,
     patterns: [
-      /OU scopes do not grant access.*organizational scopes.*403.*No organizational entitlement exists/is,
-    ],
-    forbiddenPatterns: [
-      /organizational scopes.*allowed units/is,
-      /employee's organizational unit/i,
+      /sites\.read/is,
+      /active customer or site assignment/is,
+      /OU scope alone.*empty authorized collection/is,
     ],
     response: {
-      operation: paths['/employees/{employee}/qualifications']?.get,
+      operation: paths['/sites']?.get,
       status: '403',
-      ref: '#/components/responses/SimpleForbidden',
+      ref: '#/components/responses/Forbidden',
+    },
+  },
+  {
+    label: 'GET site records',
+    text: paths['/sites/{site}']?.get?.description,
+    patterns: [
+      /sites\.read/is,
+      /active customer or site assignment/is,
+      /OU scopes alone do not grant record access/is,
+    ],
+    response: {
+      operation: paths['/sites/{site}']?.get,
+      status: '403',
+      ref: '#/components/responses/Forbidden',
     },
   },
   {
     label: 'GET Legal Entity lookups',
     text: assignmentLookups.legalEntities.operation?.description,
-    patterns: [/same tenant, active, assignable, non-deleted/i],
+    patterns: [/same tenant, active, non-deleted/i],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
   {
     label: 'GET establishment lookups',
     text: assignmentLookups.establishments.operation?.description,
-    patterns: [/same tenant, active, assignable, non-deleted/i],
+    patterns: [/same tenant, active, non-deleted/i],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
   {
     label: 'GET linked customer lookups',
     text: assignmentLookups.linkedCustomers.operation?.description,
     patterns: [
-      /active, assignable, non-deleted establishment/i,
-      /organizational write access/i,
+      /active, non-deleted establishment/i,
+      /authorized domain write access/i,
       /active, non-deleted customers/i,
       /existing customer-establishment link/i,
     ],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
   {
     label: 'GET customer link candidates',
     text: assignmentLookups.customerLinkCandidates.operation?.description,
     patterns: [
-      /active, assignable, non-deleted establishment/i,
+      /active, non-deleted establishment/i,
       /same tenant and Legal Entity/i,
       /active, non-deleted customers/i,
       /not yet linked/i,
-      /organizational write access/i,
+      /authorized domain write access/i,
     ],
+    forbiddenPatterns: [tenantDomainAssignablePattern],
   },
 ])
+
+requireEmployeeSubresourceAuthorization({
+  familyLabel: 'employee qualification',
+  pathPrefixes: [
+    '/employees/{employee}/qualifications',
+    '/employee-qualifications',
+  ],
+  rules: [
+    {
+      label: 'list',
+      operation: paths['/employees/{employee}/qualifications']?.get,
+      permission: 'employee_qualification.read',
+      forbiddenRef: '#/components/responses/SimpleForbidden',
+      selfService: true,
+    },
+    {
+      label: 'attach',
+      operation: paths['/employees/{employee}/qualifications']?.post,
+      permission: 'employee_qualification.write',
+      forbiddenRef: '#/components/responses/SimpleForbidden',
+      selfService: false,
+    },
+    {
+      label: 'show',
+      operation: paths['/employee-qualifications/{employeeQualification}']?.get,
+      permission: 'employee_qualification.read',
+      forbiddenRef: '#/components/responses/SimpleForbidden',
+      selfService: true,
+    },
+    {
+      label: 'update',
+      operation:
+        paths['/employee-qualifications/{employeeQualification}']?.patch,
+      permission: 'employee_qualification.write',
+      forbiddenRef: '#/components/responses/SimpleForbidden',
+      selfService: false,
+    },
+    {
+      label: 'delete',
+      operation:
+        paths['/employee-qualifications/{employeeQualification}']?.delete,
+      permission: 'employee_qualification.write',
+      forbiddenRef: '#/components/responses/SimpleForbidden',
+      selfService: false,
+    },
+  ],
+  schemaRules: [
+    {
+      schemaName: 'AttachQualificationRequest',
+      permission: 'employee_qualification.write',
+    },
+    {
+      schemaName: 'UpdateEmployeeQualificationRequest',
+      permission: 'employee_qualification.write',
+    },
+  ],
+})
+
+requireEmployeeSubresourceAuthorization({
+  familyLabel: 'employee document',
+  pathPrefixes: ['/employees/{employee}/documents'],
+  rules: [
+    {
+      label: 'list',
+      operation: paths['/employees/{employee}/documents']?.get,
+      permission: 'employee_document.read',
+      forbiddenRef: '#/components/responses/Forbidden',
+      selfService: true,
+    },
+    {
+      label: 'upload',
+      operation: paths['/employees/{employee}/documents']?.post,
+      permission: 'employee_document.write',
+      forbiddenRef: '#/components/responses/Forbidden',
+      selfService: false,
+    },
+    {
+      label: 'show',
+      operation: paths['/employees/{employee}/documents/{document}']?.get,
+      permission: 'employee_document.read',
+      forbiddenRef: '#/components/responses/Forbidden',
+      selfService: true,
+    },
+    {
+      label: 'delete',
+      operation: paths['/employees/{employee}/documents/{document}']?.delete,
+      permission: 'employee_document.write',
+      forbiddenRef: '#/components/responses/Forbidden',
+      selfService: false,
+    },
+    {
+      label: 'download',
+      operation:
+        paths['/employees/{employee}/documents/{document}/download']?.get,
+      permission: 'employee_document.read',
+      forbiddenRef: '#/components/responses/Forbidden',
+      selfService: true,
+    },
+  ],
+})
 
 requireContractRules([
   {
     label: 'PATCH customer Legal Entity reassignment',
     text: customerUpdate?.description,
-    patterns: [/no customer-establishment links or sites/i],
+    patterns: [
+      /no customer-establishment links or sites/i,
+      /legal_entity_id.*customers\.update.*organizational scopes.*403/is,
+    ],
+    forbiddenPatterns: [
+      /organizational write access/i,
+      tenantDomainAssignablePattern,
+    ],
     response: {
       operation: customerUpdate,
       status: '409',
@@ -789,43 +1182,49 @@ requireContractRules([
       ref: '#/components/responses/Conflict',
     },
   },
-  {
-    label: 'PATCH organizational-unit roles',
-    text: organizationalUnitUpdate?.description,
-    patterns: [
-      /is_legal_entity.*is_establishment/i,
-      /referenced.*customers.*customer-establishment links.*sites.*employees/i,
-    ],
-    response: {
-      operation: organizationalUnitUpdate,
-      status: '409',
-      ref: '#/components/responses/Conflict',
-    },
-  },
-  {
-    label: 'DELETE organizational units',
-    text: organizationalUnitDelete?.description,
-    patterns: [/customers, customer-establishment links, sites, or employees/i],
-    response: {
-      operation: organizationalUnitDelete,
-      status: '409',
-      ref: '#/components/responses/OrganizationalUnitDeletionConflict',
-    },
-  },
 ])
 
-requireContractRules([
-  {
-    label: 'CHANGELOG OU lifecycle notes',
-    text: changelog,
-    patterns: [
-      /role-downgraded or deleted; these dependency conflicts add explicit `409`/is,
-    ],
-    forbiddenPatterns: [
-      /organizational-unit and scope administration contracts remain unchanged/i,
-    ],
-  },
-])
+const tenantLocalDomainDescriptions = [
+  schemas.CustomerCreateRequest?.properties?.legal_entity_id?.description,
+  schemas.CustomerUpdateRequest?.properties?.legal_entity_id?.description,
+  schemas.EmployeeUpdateRequest?.description,
+  schemas.SiteUpdateRequest?.description,
+  paths['/customers']?.post?.description,
+  customerUpdate?.description,
+  paths['/customer-establishments']?.post?.description,
+  paths['/sites']?.post?.description,
+  paths['/employees']?.post?.description,
+  paths['/employees/{employee}']?.patch?.description,
+  ...Object.values(assignmentLookups).map(
+    ({ operation }) => operation?.description
+  ),
+]
+if (
+  tenantLocalDomainDescriptions.some((description) =>
+    tenantDomainAssignablePattern.test(description ?? '')
+  )
+) {
+  errors.push(
+    'The tenant-local domain must not inherit organizational-unit assignability.'
+  )
+}
+const organizationalUnitPath =
+  paths['/organizational-units/{organizational_unit}'] ?? {}
+if (
+  /customers|customer-establishment|sites|employees/i.test(
+    `${organizationalUnitPath.patch?.description ?? ''}\n${organizationalUnitPath.delete?.description ?? ''}`
+  ) ||
+  responses.OrganizationalUnitDeletionConflict != null
+) {
+  errors.push(
+    'Organizational-unit lifecycle must remain independent from tenant-local domain records.'
+  )
+}
+if (/role-downgraded or deleted.*conflict/is.test(changelog)) {
+  errors.push(
+    'CHANGELOG must not couple tenant-local domain lifecycle to organizational-unit roles.'
+  )
+}
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -15,6 +15,11 @@ const errors = []
 
 const uuidProperty = (property) =>
   property?.type === 'string' && property?.format === 'uuid'
+const uuidValue = (value) =>
+  typeof value === 'string' &&
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value
+  )
 
 function requireUuid(schemaName, propertyName, required) {
   const schema = schemas[schemaName]
@@ -49,10 +54,25 @@ const customerAllowedProperties = new Set([
   'updated_at',
   'deleted_at',
 ])
+if (schemas.Customer?.additionalProperties !== false) {
+  errors.push('Customer must remain a closed master-data response schema.')
+}
 for (const propertyName of Object.keys(schemas.Customer?.properties ?? {})) {
   if (!customerAllowedProperties.has(propertyName)) {
     errors.push(`Customer must not expose non-master-data field ${propertyName}.`)
   }
+}
+
+const customerGet = paths['/customers/{customer}']?.get
+if (
+  (customerGet?.parameters ?? []).some(
+    (parameter) => parameter?.name === 'include'
+  ) ||
+  /optional relationships/i.test(customerGet?.description ?? '')
+) {
+  errors.push(
+    'GET /customers/{customer} must not advertise relationships that the closed Customer response cannot represent.'
+  )
 }
 
 for (const schemaName of [
@@ -101,6 +121,114 @@ for (const [pathName, operation] of [
     errors.push(`GET ${pathName} must not expose an organizational_unit_id filter.`)
   }
 }
+
+const customerEstablishment = schemas.CustomerEstablishment ?? {}
+const customerEstablishmentEmailExample =
+  customerEstablishment.properties?.email?.example
+if (
+  typeof customerEstablishmentEmailExample !== 'string' ||
+  !customerEstablishmentEmailExample.endsWith('@secpal.dev')
+) {
+  errors.push(
+    'CustomerEstablishment.email must use the approved secpal.dev example domain.'
+  )
+}
+
+const customerEstablishmentCollection =
+  schemas.CustomerEstablishmentCollectionResponse ?? {}
+if (
+  customerEstablishmentCollection.additionalProperties !== false ||
+  JSON.stringify(customerEstablishmentCollection.required) !==
+    JSON.stringify(['data', 'links', 'meta']) ||
+  customerEstablishmentCollection.properties?.links?.$ref !==
+    '#/components/schemas/PaginationLinks' ||
+  customerEstablishmentCollection.properties?.meta?.$ref !==
+    '#/components/schemas/PaginationMeta'
+) {
+  errors.push(
+    'CustomerEstablishmentCollectionResponse must include pagination links and metadata.'
+  )
+}
+
+const customerEstablishmentPath =
+  paths['/customer-establishments/{customer_establishment}'] ?? {}
+const customerEstablishmentParameter = customerEstablishmentPath.parameters
+if (
+  !Array.isArray(customerEstablishmentParameter) ||
+  customerEstablishmentParameter.length !== 1 ||
+  customerEstablishmentParameter[0]?.name !== 'customer_establishment' ||
+  customerEstablishmentParameter[0]?.in !== 'path' ||
+  customerEstablishmentParameter[0]?.required !== true ||
+  !uuidProperty(customerEstablishmentParameter[0]?.schema) ||
+  ['get', 'patch', 'delete'].some((method) =>
+    (customerEstablishmentPath[method]?.parameters ?? []).some(
+      (parameter) => parameter?.name === 'customer_establishment'
+    )
+  )
+) {
+  errors.push(
+    'Customer establishment operations must share one path-level UUID parameter.'
+  )
+}
+
+function hasTenantConsistentDomainExamples(schemaName) {
+  const schema = schemas[schemaName] ?? {}
+  const examples = schema['x-validation-examples'] ?? {}
+  const accepted = examples.accepted?.[0]
+  const rejected = examples.rejected?.[0]
+  const requiredPayloadIsPresent = (example) =>
+    schema.required?.every((property) =>
+      Object.hasOwn(example?.value ?? {}, property)
+    )
+  const tenantIds = (example) =>
+    Object.entries(example ?? {})
+      .filter(([key, value]) => key.endsWith('_tenant_id') && value)
+      .map(([, value]) => value)
+  const relatedLegalEntityIds = (example) =>
+    Object.entries(example ?? {})
+      .filter(([key, value]) => key.endsWith('_legal_entity_id') && value)
+      .map(([, value]) => value)
+  const assignmentIds = (example) =>
+    ['customer_id', 'legal_entity_id', 'establishment_id']
+      .filter((property) => Object.hasOwn(example?.value ?? {}, property))
+      .map((property) => example.value[property])
+  const identifiersAreUuids = (example) =>
+    [
+      ...tenantIds(example),
+      ...relatedLegalEntityIds(example),
+      ...assignmentIds(example),
+    ].every(uuidValue)
+  const isConsistent = (example) =>
+    new Set(tenantIds(example)).size === 1 &&
+    relatedLegalEntityIds(example).every(
+      (value) => value === example?.value?.legal_entity_id
+    )
+  const isInconsistent = (example) =>
+    new Set(tenantIds(example)).size > 1 ||
+    relatedLegalEntityIds(example).some(
+      (value) => value !== example?.value?.legal_entity_id
+    )
+
+  return (
+    requiredPayloadIsPresent(accepted) &&
+    requiredPayloadIsPresent(rejected) &&
+    uuidProperty(schema.properties?.legal_entity_id) &&
+    uuidProperty(schema.properties?.establishment_id) &&
+    identifiersAreUuids(accepted) &&
+    identifiersAreUuids(rejected) &&
+    isConsistent(accepted) &&
+    rejected?.status === 422 &&
+    isInconsistent(rejected)
+  )
+}
+
+for (const schemaName of ['SiteCreateRequest', 'EmployeeCreateRequest']) {
+  if (!hasTenantConsistentDomainExamples(schemaName)) {
+    errors.push(
+      `${schemaName} must retain accepted and rejected tenant-consistent domain-assignment examples.`
+    )
+  }
+}
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum
@@ -108,7 +236,6 @@ if (siteIncludes?.some((value) => /organizational/i.test(value))) {
   errors.push('GET /sites/{site} must not expose an organizational-unit include.')
 }
 
-const customerEstablishment = schemas.CustomerEstablishment ?? {}
 const expectedCustomerEstablishmentRequired = [
   'id',
   'customer_id',

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -230,6 +230,71 @@ for (const schemaName of ['SiteCreateRequest', 'EmployeeCreateRequest']) {
   }
 }
 
+for (const schemaName of ['EmployeeCreateRequest', 'EmployeeUpdateRequest']) {
+  if (schemas[schemaName]?.additionalProperties !== false) {
+    errors.push(`${schemaName} must remain closed to obsolete OU fields.`)
+  }
+}
+
+if (
+  !/active, assignable, non-deleted.*organizational write access/i.test(
+    paths['/employees']?.post?.description ?? ''
+  )
+) {
+  errors.push('POST /employees must require eligible authorized assignment targets.')
+}
+if (
+  !/resulting.*same tenant.*Legal Entity.*active, assignable, non-deleted/i.test(
+    paths['/employees/{employee}']?.patch?.description ?? ''
+  )
+) {
+  errors.push('PATCH employee assignments must validate the resulting domain pair.')
+}
+if (
+  !/resulting.*existing customer-establishment link/i.test(
+    schemas.SiteUpdateRequest?.description ?? ''
+  )
+) {
+  errors.push('PATCH site assignments must require a valid resulting customer-establishment link.')
+}
+
+for (const [label, description] of [
+  [
+    'POST customer-establishment links',
+    paths['/customer-establishments']?.post?.description,
+  ],
+  ['POST site assignments', paths['/sites']?.post?.description],
+  ['PATCH site assignments', schemas.SiteUpdateRequest?.description],
+]) {
+  if (
+    !/active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i.test(
+      description ?? ''
+    )
+  ) {
+    errors.push(`${label} must enforce eligible authorized assignment targets.`)
+  }
+}
+
+const customerDelete = paths['/customers/{customer}']?.delete
+if (
+  !/customer-establishment links or sites/i.test(customerDelete?.description ?? '') ||
+  customerDelete?.responses?.['409']?.$ref !==
+    '#/components/responses/Conflict'
+) {
+  errors.push('DELETE customers must block remaining domain dependents with Conflict.')
+}
+const organizationalUnitDelete =
+  paths['/organizational-units/{organizational_unit}']?.delete
+if (
+  !/customers, customer-establishment links, sites, or employees/i.test(
+    organizationalUnitDelete?.description ?? ''
+  ) ||
+  organizationalUnitDelete?.responses?.['409']?.$ref !==
+    '#/components/responses/OrganizationalUnitDeletionConflict'
+) {
+  errors.push('DELETE organizational units must block remaining domain dependents with Conflict.')
+}
+
 function hasTenantConsistentCustomerEstablishmentExamples() {
   const schema = schemas.CustomerEstablishmentCreateRequest ?? {}
   const examples = schema['x-validation-examples'] ?? {}

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -61,6 +61,53 @@ function requireContractRules(rules) {
   }
 }
 
+function requireNoOuScopeDomainMutations(rules) {
+  const coveredOperations = new Set()
+  const mutationMethods = new Set(['post', 'put', 'patch', 'delete'])
+  const domainTags = new Set(['Customers', 'Sites'])
+  const noOuBoundary =
+    /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is
+  const contradictoryOuAccess = [
+    /organizational write access/i,
+    /OU scopes? (?:also )?grant access to (?:this|customer|site|the) domain write/i,
+  ]
+
+  for (const { label, operation, permission } of rules) {
+    if (operation) {
+      coveredOperations.add(operation)
+    }
+    const description = operation?.description ?? ''
+    const unscopedPermission = new RegExp(
+      'unscoped callers require `' + permission.replaceAll('.', '\\.') + '`',
+      'i'
+    )
+    if (
+      !noOuBoundary.test(description) ||
+      !unscopedPermission.test(description) ||
+      contradictoryOuAccess.some((pattern) => pattern.test(description)) ||
+      operation?.responses?.['403']?.$ref !== '#/components/responses/Forbidden'
+    ) {
+      errors.push(
+        `${label} must keep its permission, complete no-OU domain-write boundary, and 403 response aligned.`
+      )
+    }
+  }
+
+  for (const [pathName, pathItem] of Object.entries(paths)) {
+    for (const [method, operation] of Object.entries(pathItem ?? {})) {
+      if (
+        mutationMethods.has(method) &&
+        operation?.tags?.some((tag) => domainTags.has(tag)) &&
+        !coveredOperations.has(operation)
+      ) {
+        errors.push(
+          `${method.toUpperCase()} ${pathName} must be covered by the customer/site no-OU domain mutation model.`
+        )
+      }
+    }
+  }
+}
+
 function requireEmployeeSubresourceAuthorization({
   familyLabel,
   pathPrefixes,
@@ -759,6 +806,55 @@ if (!hasTenantConsistentCustomerEstablishmentExamples()) {
 const customerUpdate = paths['/customers/{customer}']?.patch
 const customerDelete = paths['/customers/{customer}']?.delete
 const customerEstablishmentDelete = customerEstablishmentPath.delete
+const customerSiteDomainMutations = [
+  {
+    label: 'POST customers',
+    operation: paths['/customers']?.post,
+    permission: 'customers.create',
+  },
+  {
+    label: 'PATCH customers',
+    operation: customerUpdate,
+    permission: 'customers.update',
+  },
+  {
+    label: 'DELETE customers',
+    operation: customerDelete,
+    permission: 'customers.delete',
+  },
+  {
+    label: 'POST customer-establishment links',
+    operation: paths['/customer-establishments']?.post,
+    permission: 'customers.update',
+  },
+  {
+    label: 'PATCH customer-establishment links',
+    operation: customerEstablishmentPath.patch,
+    permission: 'customers.update',
+  },
+  {
+    label: 'DELETE customer-establishment links',
+    operation: customerEstablishmentDelete,
+    permission: 'customers.update',
+  },
+  {
+    label: 'POST sites',
+    operation: paths['/sites']?.post,
+    permission: 'sites.create',
+  },
+  {
+    label: 'PATCH sites',
+    operation: paths['/sites/{site}']?.patch,
+    permission: 'sites.update',
+  },
+  {
+    label: 'DELETE sites',
+    operation: paths['/sites/{site}']?.delete,
+    permission: 'sites.delete',
+  },
+]
+requireNoOuScopeDomainMutations(customerSiteDomainMutations)
+
 const assignmentLookups = {
   legalEntities: {
     label: 'GET Legal Entity lookups',
@@ -857,19 +953,11 @@ requireContractRules([
   {
     label: 'POST customer assignments',
     text: paths['/customers']?.post?.description,
-    patterns: [
-      /active, non-deleted/i,
-      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
-    ],
+    patterns: [/active, non-deleted/i],
     forbiddenPatterns: [
       /organizational write access/i,
       tenantDomainAssignablePattern,
     ],
-    response: {
-      operation: paths['/customers']?.post,
-      status: '403',
-      ref: '#/components/responses/Forbidden',
-    },
   },
   {
     label: 'POST employee assignments',
@@ -890,7 +978,6 @@ requireContractRules([
       /customers\.update/i,
       /active, non-deleted customer/i,
       /active, non-deleted establishment/i,
-      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
     ],
     forbiddenPatterns: [
       /organizational write access/i,
@@ -903,7 +990,6 @@ requireContractRules([
     patterns: [
       /active, non-deleted customer/i,
       /active, non-deleted/i,
-      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is,
       /existing customer-establishment link/i,
     ],
     forbiddenPatterns: [
@@ -918,29 +1004,12 @@ requireContractRules([
       /resulting/i,
       /active, non-deleted customer/i,
       /active, non-deleted/i,
-      /domain relationship.*sites\.update.*organizational scopes.*403/is,
       /existing customer-establishment link/i,
     ],
     forbiddenPatterns: [
       /organizational write access/i,
       tenantDomainAssignablePattern,
     ],
-  },
-  {
-    label: 'PATCH site assignment operation',
-    text: paths['/sites/{site}']?.patch?.description,
-    patterns: [
-      /domain relationship.*sites\.update.*organizational scopes.*403/is,
-    ],
-    forbiddenPatterns: [
-      /organizational write access/i,
-      tenantDomainAssignablePattern,
-    ],
-  },
-  {
-    label: 'PATCH customer-establishment links',
-    text: customerEstablishmentPath.patch?.description,
-    patterns: [/customers\.update/i],
   },
   ...[
     ['GET customer collections', paths['/customers']?.get],
@@ -1149,8 +1218,8 @@ requireContractRules([
     label: 'PATCH customer Legal Entity reassignment',
     text: customerUpdate?.description,
     patterns: [
+      /legal_entity_id.*same-tenant, active, non-deleted Legal Entity/is,
       /no customer-establishment links or sites/i,
-      /legal_entity_id.*customers\.update.*organizational scopes.*403/is,
     ],
     forbiddenPatterns: [
       /organizational write access/i,

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -23,6 +23,19 @@ const uuidValue = (value) =>
     value
   )
 
+function collectMatchingObjects(value, predicate, matches = []) {
+  if (value === null || typeof value !== 'object') {
+    return matches
+  }
+  if (predicate(value)) {
+    matches.push(value)
+  }
+  for (const child of Object.values(value)) {
+    collectMatchingObjects(child, predicate, matches)
+  }
+  return matches
+}
+
 function requireContractRules(rules) {
   for (const {
     label,
@@ -297,6 +310,39 @@ for (const schemaName of [
   'EmployeeUpdateRequest',
 ]) {
   rejectOuFields(schemaName)
+}
+
+const employeeCreationAuditExamples = collectMatchingObjects(
+  paths,
+  (value) =>
+    value.subject_type === 'App\\Models\\Employee' && value.event === 'created'
+)
+const forbiddenEmployeeAuditFields = [
+  'organizational_unit_id',
+  'name',
+  'first_name',
+  'last_name',
+  'email',
+  'phone',
+]
+if (
+  employeeCreationAuditExamples.length < 2 ||
+  employeeCreationAuditExamples.some((activity) => {
+    const attributes = activity.properties?.attributes ?? {}
+    return (
+      activity.log_name !== 'employee_changes' ||
+      activity.description !== 'created' ||
+      !uuidValue(attributes.legal_entity_id) ||
+      !uuidValue(attributes.establishment_id) ||
+      forbiddenEmployeeAuditFields.some((field) =>
+        Object.hasOwn(attributes, field)
+      )
+    )
+  })
+) {
+  errors.push(
+    'All employee creation audit examples must use employee_changes, include domain assignment UUIDs, and exclude OU and personal contact fields.'
+  )
 }
 
 requireUuid('Customer', 'legal_entity_id', true)
@@ -663,6 +709,22 @@ requireContractRules([
       ref: '#/components/responses/Forbidden',
     },
   })),
+  {
+    label: 'GET employee qualifications',
+    text: paths['/employees/{employee}/qualifications']?.get?.description,
+    patterns: [
+      /OU scopes do not grant access.*organizational scopes.*403.*No organizational entitlement exists/is,
+    ],
+    forbiddenPatterns: [
+      /organizational scopes.*allowed units/is,
+      /employee's organizational unit/i,
+    ],
+    response: {
+      operation: paths['/employees/{employee}/qualifications']?.get,
+      status: '403',
+      ref: '#/components/responses/SimpleForbidden',
+    },
+  },
   {
     label: 'GET Legal Entity lookups',
     text: assignmentLookups.legalEntities.operation?.description,

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -21,18 +21,97 @@ const uuidValue = (value) =>
     value
   )
 
-function requireTextRules(rules) {
-  for (const { label, text: value, patterns } of rules) {
+function requireContractRules(rules) {
+  for (const { label, text: value, patterns = [], response } of rules) {
     if (patterns.some((pattern) => !pattern.test(value ?? ''))) {
       errors.push(`${label} must document its complete domain invariant.`)
+    }
+    if (
+      response &&
+      response.operation?.responses?.[response.status]?.$ref !== response.ref
+    ) {
+      errors.push(
+        `${label} must use ${response.ref} for HTTP ${response.status}.`
+      )
     }
   }
 }
 
-function requireResponseRefs(rules) {
-  for (const { label, operation, status, ref } of rules) {
-    if (operation?.responses?.[status]?.$ref !== ref) {
-      errors.push(`${label} must use ${ref} for HTTP ${status}.`)
+function requireAssignmentWorkflows(workflows, lookups) {
+  const relationshipFields = new Set([
+    'customer_id',
+    'legal_entity_id',
+    'establishment_id',
+  ])
+  const coveredOperations = new Set(workflows.map(({ operation }) => operation))
+  const requiredLookupPermissions = new Map(
+    Object.keys(lookups).map((lookupName) => [lookupName, new Set()])
+  )
+
+  for (const workflow of workflows) {
+    const expectedRequestRef = `#/components/schemas/${workflow.requestSchema}`
+    const actualRequestRef =
+      workflow.operation?.requestBody?.content?.['application/json']?.schema
+        ?.$ref
+    if (actualRequestRef !== expectedRequestRef) {
+      errors.push(
+        `${workflow.label} must use ${expectedRequestRef} as its request contract.`
+      )
+    }
+
+    const properties = schemas[workflow.requestSchema]?.properties ?? {}
+    const missingFields = workflow.relationshipFields.filter(
+      (field) => !Object.hasOwn(properties, field)
+    )
+    if (missingFields.length > 0) {
+      errors.push(
+        `${workflow.label} must expose relationship fields: ${missingFields.join(', ')}.`
+      )
+    }
+
+    if (
+      !(workflow.operation?.description ?? '').includes(workflow.permission)
+    ) {
+      errors.push(`${workflow.label} must require ${workflow.permission}.`)
+    }
+
+    for (const lookupName of workflow.lookups) {
+      const permissions = requiredLookupPermissions.get(lookupName)
+      if (!permissions) {
+        errors.push(
+          `${workflow.label} references unknown lookup ${lookupName}.`
+        )
+        continue
+      }
+      permissions.add(workflow.permission)
+    }
+  }
+
+  for (const [pathName, pathItem] of Object.entries(paths)) {
+    for (const method of ['post', 'put', 'patch']) {
+      const operation = pathItem?.[method]
+      const requestContract =
+        operation?.requestBody?.content?.['application/json']?.schema
+      const requestSchema = requestContract?.$ref
+        ? schemas[requestContract.$ref.split('/').at(-1)]
+        : requestContract
+      const writesRelationship = Object.keys(
+        requestSchema?.properties ?? {}
+      ).some((field) => relationshipFields.has(field))
+      if (writesRelationship && !coveredOperations.has(operation)) {
+        errors.push(
+          `${method.toUpperCase()} ${pathName} writes domain relationships and must be represented in the assignment workflow model.`
+        )
+      }
+    }
+  }
+
+  for (const [lookupName, lookup] of Object.entries(lookups)) {
+    const description = lookup.operation?.description ?? ''
+    for (const permission of requiredLookupPermissions.get(lookupName) ?? []) {
+      if (!description.includes(permission)) {
+        errors.push(`${lookup.label} must authorize ${permission}.`)
+      }
     }
   }
 }
@@ -51,7 +130,10 @@ function requireUuid(schemaName, propertyName, required) {
 
 function rejectOuFields(schemaName) {
   const properties = schemas[schemaName]?.properties ?? {}
-  for (const propertyName of ['organizational_unit_id', 'organizational_unit']) {
+  for (const propertyName of [
+    'organizational_unit_id',
+    'organizational_unit',
+  ]) {
     if (Object.hasOwn(properties, propertyName)) {
       errors.push(`${schemaName} must not expose ${propertyName}.`)
     }
@@ -75,7 +157,9 @@ if (schemas.Customer?.additionalProperties !== false) {
 }
 for (const propertyName of Object.keys(schemas.Customer?.properties ?? {})) {
   if (!customerAllowedProperties.has(propertyName)) {
-    errors.push(`Customer must not expose non-master-data field ${propertyName}.`)
+    errors.push(
+      `Customer must not expose non-master-data field ${propertyName}.`
+    )
   }
 }
 
@@ -133,8 +217,12 @@ for (const [pathName, operation] of [
   ['/employees', paths['/employees']?.get],
 ]) {
   const parameters = operation?.parameters ?? []
-  if (parameters.some((parameter) => parameter?.name === 'organizational_unit_id')) {
-    errors.push(`GET ${pathName} must not expose an organizational_unit_id filter.`)
+  if (
+    parameters.some((parameter) => parameter?.name === 'organizational_unit_id')
+  ) {
+    errors.push(
+      `GET ${pathName} must not expose an organizational_unit_id filter.`
+    )
   }
 }
 
@@ -261,13 +349,22 @@ function hasTenantConsistentCustomerEstablishmentExamples() {
     ['customer_id', 'establishment_id'].every((property) =>
       Object.hasOwn(example?.value ?? {}, property)
     )
-  const tenantIds = (example) =>
-    [example?.customer_tenant_id, example?.establishment_tenant_id]
-  const legalEntityIds = (example) =>
-    [example?.customer_legal_entity_id, example?.establishment_legal_entity_id]
+  const tenantIds = (example) => [
+    example?.customer_tenant_id,
+    example?.establishment_tenant_id,
+  ]
+  const legalEntityIds = (example) => [
+    example?.customer_legal_entity_id,
+    example?.establishment_legal_entity_id,
+  ]
   const isValid = (example) =>
     payloadIsPresent(example) &&
-    [...tenantIds(example), ...legalEntityIds(example), example?.value?.customer_id, example?.value?.establishment_id].every(uuidValue)
+    [
+      ...tenantIds(example),
+      ...legalEntityIds(example),
+      example?.value?.customer_id,
+      example?.value?.establishment_id,
+    ].every(uuidValue)
 
   return (
     isValid(accepted) &&
@@ -286,14 +383,106 @@ if (!hasTenantConsistentCustomerEstablishmentExamples()) {
   )
 }
 
-const customerEstablishmentDelete = customerEstablishmentPath.delete
+const customerUpdate = paths['/customers/{customer}']?.patch
 const customerDelete = paths['/customers/{customer}']?.delete
+const customerEstablishmentDelete = customerEstablishmentPath.delete
 const organizationalUnitUpdate =
   paths['/organizational-units/{organizational_unit}']?.patch
 const organizationalUnitDelete =
   paths['/organizational-units/{organizational_unit}']?.delete
 
-requireTextRules([
+const assignmentLookups = {
+  legalEntities: {
+    label: 'GET Legal Entity lookups',
+    operation: paths['/lookups/legal-entities']?.get,
+  },
+  establishments: {
+    label: 'GET establishment lookups',
+    operation:
+      paths['/lookups/legal-entities/{legal_entity}/establishments']?.get,
+  },
+  linkedCustomers: {
+    label: 'GET linked customer lookups',
+    operation: paths['/lookups/establishments/{establishment}/customers']?.get,
+  },
+  customerLinkCandidates: {
+    label: 'GET customer link candidates',
+    operation:
+      paths['/lookups/establishments/{establishment}/customer-candidates']?.get,
+  },
+}
+
+requireAssignmentWorkflows(
+  [
+    {
+      label: 'POST customer assignments',
+      operation: paths['/customers']?.post,
+      requestSchema: 'CustomerCreateRequest',
+      relationshipFields: ['legal_entity_id'],
+      permission: 'customers.create',
+      lookups: ['legalEntities'],
+    },
+    {
+      label: 'PATCH customer assignments',
+      operation: customerUpdate,
+      requestSchema: 'CustomerUpdateRequest',
+      relationshipFields: ['legal_entity_id'],
+      permission: 'customers.update',
+      lookups: ['legalEntities'],
+    },
+    {
+      label: 'POST customer-establishment assignments',
+      operation: paths['/customer-establishments']?.post,
+      requestSchema: 'CustomerEstablishmentCreateRequest',
+      relationshipFields: ['customer_id', 'establishment_id'],
+      permission: 'customers.update',
+      lookups: ['legalEntities', 'establishments', 'customerLinkCandidates'],
+    },
+    {
+      label: 'POST site assignments',
+      operation: paths['/sites']?.post,
+      requestSchema: 'SiteCreateRequest',
+      relationshipFields: [
+        'customer_id',
+        'legal_entity_id',
+        'establishment_id',
+      ],
+      permission: 'sites.create',
+      lookups: ['legalEntities', 'establishments', 'linkedCustomers'],
+    },
+    {
+      label: 'PATCH site assignments',
+      operation: paths['/sites/{site}']?.patch,
+      requestSchema: 'SiteUpdateRequest',
+      relationshipFields: [
+        'customer_id',
+        'legal_entity_id',
+        'establishment_id',
+      ],
+      permission: 'sites.update',
+      lookups: ['legalEntities', 'establishments', 'linkedCustomers'],
+    },
+    {
+      label: 'POST employee assignments',
+      operation: paths['/employees']?.post,
+      requestSchema: 'EmployeeCreateRequest',
+      relationshipFields: ['legal_entity_id', 'establishment_id'],
+      permission: 'employees.create',
+      lookups: ['legalEntities', 'establishments'],
+    },
+    {
+      label: 'PATCH employee assignments',
+      operation: paths['/employees/{employee}']?.patch,
+      requestSchema: 'EmployeeUpdateRequest',
+      relationshipFields: ['legal_entity_id', 'establishment_id'],
+      permission: 'employees.update',
+      lookups: ['legalEntities', 'establishments'],
+    },
+  ],
+  assignmentLookups
+)
+
+requireContractRules([
   {
     label: 'POST employee assignments',
     text: paths['/employees']?.post?.description,
@@ -342,60 +531,24 @@ requireTextRules([
     ],
   },
   {
-    label: 'PATCH customer Legal Entity reassignment',
-    text: paths['/customers/{customer}']?.patch?.description,
-    patterns: [/no customer-establishment links or sites/i],
-  },
-  {
     label: 'PATCH customer-establishment links',
     text: customerEstablishmentPath.patch?.description,
     patterns: [/customers\.update/i],
   },
   {
-    label: 'DELETE customer-establishment links',
-    text: customerEstablishmentDelete?.description,
-    patterns: [/customers\.update/i, /blocked.*sites/i],
-  },
-  {
-    label: 'DELETE customers',
-    text: customerDelete?.description,
-    patterns: [/customer-establishment links or sites/i],
-  },
-  {
-    label: 'PATCH organizational-unit roles',
-    text: organizationalUnitUpdate?.description,
-    patterns: [
-      /is_legal_entity.*is_establishment/i,
-      /referenced.*customers.*customer-establishment links.*sites.*employees/i,
-    ],
-  },
-  {
-    label: 'DELETE organizational units',
-    text: organizationalUnitDelete?.description,
-    patterns: [/customers, customer-establishment links, sites, or employees/i],
-  },
-  {
     label: 'GET Legal Entity lookups',
-    text: paths['/lookups/legal-entities']?.get?.description,
-    patterns: [
-      /customers\.create.*customers\.update.*sites\.create.*employees\.create/i,
-    ],
+    text: assignmentLookups.legalEntities.operation?.description,
+    patterns: [/same tenant, active, assignable, non-deleted/i],
   },
   {
     label: 'GET establishment lookups',
-    text: paths['/lookups/legal-entities/{legal_entity}/establishments']?.get
-      ?.description,
-    patterns: [
-      /customers\.update.*sites\.create.*employees\.create/i,
-      /same tenant, active, assignable, non-deleted/i,
-    ],
+    text: assignmentLookups.establishments.operation?.description,
+    patterns: [/same tenant, active, assignable, non-deleted/i],
   },
   {
     label: 'GET linked customer lookups',
-    text: paths['/lookups/establishments/{establishment}/customers']?.get
-      ?.description,
+    text: assignmentLookups.linkedCustomers.operation?.description,
     patterns: [
-      /sites\.create/i,
       /active, assignable, non-deleted establishment/i,
       /organizational write access/i,
       /active, non-deleted customers/i,
@@ -404,11 +557,8 @@ requireTextRules([
   },
   {
     label: 'GET customer link candidates',
-    text: paths[
-      '/lookups/establishments/{establishment}/customer-candidates'
-    ]?.get?.description,
+    text: assignmentLookups.customerLinkCandidates.operation?.description,
     patterns: [
-      /customers\.update/i,
       /active, assignable, non-deleted establishment/i,
       /same tenant and Legal Entity/i,
       /active, non-deleted customers/i,
@@ -418,37 +568,68 @@ requireTextRules([
   },
 ])
 
-requireResponseRefs([
+requireContractRules([
+  {
+    label: 'PATCH customer Legal Entity reassignment',
+    text: customerUpdate?.description,
+    patterns: [/no customer-establishment links or sites/i],
+    response: {
+      operation: customerUpdate,
+      status: '409',
+      ref: '#/components/responses/Conflict',
+    },
+  },
   {
     label: 'DELETE customer-establishment links',
-    operation: customerEstablishmentDelete,
-    status: '409',
-    ref: '#/components/responses/Conflict',
+    text: customerEstablishmentDelete?.description,
+    patterns: [/customers\.update/i, /blocked.*sites/i],
+    response: {
+      operation: customerEstablishmentDelete,
+      status: '409',
+      ref: '#/components/responses/Conflict',
+    },
   },
   {
     label: 'DELETE customers',
-    operation: customerDelete,
-    status: '409',
-    ref: '#/components/responses/Conflict',
+    text: customerDelete?.description,
+    patterns: [/customer-establishment links or sites/i],
+    response: {
+      operation: customerDelete,
+      status: '409',
+      ref: '#/components/responses/Conflict',
+    },
   },
   {
     label: 'PATCH organizational-unit roles',
-    operation: organizationalUnitUpdate,
-    status: '409',
-    ref: '#/components/responses/Conflict',
+    text: organizationalUnitUpdate?.description,
+    patterns: [
+      /is_legal_entity.*is_establishment/i,
+      /referenced.*customers.*customer-establishment links.*sites.*employees/i,
+    ],
+    response: {
+      operation: organizationalUnitUpdate,
+      status: '409',
+      ref: '#/components/responses/Conflict',
+    },
   },
   {
     label: 'DELETE organizational units',
-    operation: organizationalUnitDelete,
-    status: '409',
-    ref: '#/components/responses/OrganizationalUnitDeletionConflict',
+    text: organizationalUnitDelete?.description,
+    patterns: [/customers, customer-establishment links, sites, or employees/i],
+    response: {
+      operation: organizationalUnitDelete,
+      status: '409',
+      ref: '#/components/responses/OrganizationalUnitDeletionConflict',
+    },
   },
 ])
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum
 if (siteIncludes?.some((value) => /organizational/i.test(value))) {
-  errors.push('GET /sites/{site} must not expose an organizational-unit include.')
+  errors.push(
+    'GET /sites/{site} must not expose an organizational-unit include.'
+  )
 }
 
 const expectedCustomerEstablishmentRequired = [

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -7,7 +7,9 @@ import { resolve } from 'node:path'
 import * as yaml from 'js-yaml'
 
 const contractPath = resolve(process.argv[2] ?? 'docs/openapi.yaml')
+const changelogPath = resolve(process.argv[3] ?? 'CHANGELOG.md')
 const contract = yaml.load(readFileSync(contractPath, 'utf8'))
+const changelog = readFileSync(changelogPath, 'utf8')
 const schemas = contract?.components?.schemas ?? {}
 const responses = contract?.components?.responses ?? {}
 const paths = contract?.paths ?? {}
@@ -22,9 +24,18 @@ const uuidValue = (value) =>
   )
 
 function requireContractRules(rules) {
-  for (const { label, text: value, patterns = [], response } of rules) {
+  for (const {
+    label,
+    text: value,
+    patterns = [],
+    forbiddenPatterns = [],
+    response,
+  } of rules) {
     if (patterns.some((pattern) => !pattern.test(value ?? ''))) {
       errors.push(`${label} must document its complete domain invariant.`)
+    }
+    if (forbiddenPatterns.some((pattern) => pattern.test(value ?? ''))) {
+      errors.push(`${label} must not document a contradictory invariant.`)
     }
     if (
       response &&
@@ -32,6 +43,71 @@ function requireContractRules(rules) {
     ) {
       errors.push(
         `${label} must use ${response.ref} for HTTP ${response.status}.`
+      )
+    }
+  }
+}
+
+function requireUniquenessRules(rules) {
+  const coveredSchemas = new Set(
+    rules.map(({ resourceSchema }) => resourceSchema)
+  )
+
+  for (const rule of rules) {
+    const resource = schemas[rule.resourceSchema] ?? {}
+    const request = schemas[rule.requestSchema] ?? {}
+    const examples = request['x-uniqueness-examples'] ?? {}
+    const description = rule.operation?.description ?? ''
+    const sameFields = (left, right, fields) =>
+      fields.every((field) => left?.[field] === right?.[field])
+    const sharesReusableValue = (left, right) =>
+      rule.reusableFields.some(
+        (field) => left?.[field] != null && left[field] === right?.[field]
+      )
+    const changesReusableValue = (left, right) =>
+      rule.reusableFields.some(
+        (field) => left?.[field] != null && left[field] !== right?.[field]
+      )
+
+    const acceptedEvidence = (examples.accepted ?? []).some(
+      ({ existing, value }) =>
+        !sameFields(existing, value, rule.uniqueBy) &&
+        sharesReusableValue(existing, value)
+    )
+    const rejectedEvidence = (examples.rejected ?? []).some(
+      ({ existing, value, status }) =>
+        sameFields(existing, value, rule.uniqueBy) &&
+        changesReusableValue(existing, value) &&
+        status === 409
+    )
+    const documentsUniqueKey =
+      rule.uniqueBy.every((field) => description.includes(field)) &&
+      /pair/i.test(description)
+    const excludesReusableIdentifiers =
+      /without treating local contact data as a duplicate identifier/i.test(
+        description
+      )
+
+    if (
+      JSON.stringify(resource['x-unique-by']) !==
+        JSON.stringify(rule.uniqueBy) ||
+      !acceptedEvidence ||
+      !rejectedEvidence ||
+      !documentsUniqueKey ||
+      !excludesReusableIdentifiers ||
+      rule.operation?.responses?.['409']?.$ref !==
+        '#/components/responses/DuplicateConflict'
+    ) {
+      errors.push(
+        `${rule.label} must keep its composite key, reusable fields, evidence, description, and conflict response aligned.`
+      )
+    }
+  }
+
+  for (const [schemaName, schema] of Object.entries(schemas)) {
+    if (schema?.['x-unique-by'] && !coveredSchemas.has(schemaName)) {
+      errors.push(
+        `${schemaName} declares composite uniqueness and must be represented in the uniqueness model.`
       )
     }
   }
@@ -66,6 +142,40 @@ function requireAssignmentWorkflows(workflows, lookups) {
     if (missingFields.length > 0) {
       errors.push(
         `${workflow.label} must expose relationship fields: ${missingFields.join(', ')}.`
+      )
+    }
+
+    const examples =
+      schemas[workflow.requestSchema]?.['x-validation-examples'] ?? {}
+    const accepted = examples.accepted?.[0]
+    const rejected = examples.rejected?.[0]
+    const isUpdate = workflow.label.startsWith('PATCH ')
+    const hasValidEvidence = (example) => {
+      const submittedFields = workflow.relationshipFields.filter((field) =>
+        Object.hasOwn(example?.value ?? {}, field)
+      )
+      const resultingFields = workflow.relationshipFields.filter((field) =>
+        Object.hasOwn(example?.resulting ?? {}, field)
+      )
+      const identifiers = [
+        ...submittedFields.map((field) => example.value[field]),
+        ...resultingFields.map((field) => example.resulting[field]),
+      ]
+      return (
+        (isUpdate
+          ? submittedFields.length > 0 &&
+            resultingFields.length === workflow.relationshipFields.length
+          : submittedFields.length === workflow.relationshipFields.length) &&
+        identifiers.every(uuidValue)
+      )
+    }
+    if (
+      !hasValidEvidence(accepted) ||
+      !hasValidEvidence(rejected) ||
+      ![409, 422].includes(rejected?.status)
+    ) {
+      errors.push(
+        `${workflow.label} must retain complete positive and negative workflow evidence.`
       )
     }
 
@@ -535,6 +645,24 @@ requireContractRules([
     text: customerEstablishmentPath.patch?.description,
     patterns: [/customers\.update/i],
   },
+  ...[
+    [
+      'GET customer-establishment collections',
+      paths['/customer-establishments']?.get,
+    ],
+    ['GET customer-establishment links', customerEstablishmentPath.get],
+  ].map(([label, operation]) => ({
+    label,
+    text: operation?.description,
+    patterns: [
+      /view access.*customer assignment.*organizational scope.*authorized/is,
+    ],
+    response: {
+      operation,
+      status: '403',
+      ref: '#/components/responses/Forbidden',
+    },
+  })),
   {
     label: 'GET Legal Entity lookups',
     text: assignmentLookups.legalEntities.operation?.description,
@@ -623,6 +751,19 @@ requireContractRules([
     },
   },
 ])
+
+requireContractRules([
+  {
+    label: 'CHANGELOG OU lifecycle notes',
+    text: changelog,
+    patterns: [
+      /role-downgraded or deleted; these dependency conflicts add explicit `409`/is,
+    ],
+    forbiddenPatterns: [
+      /organizational-unit and scope administration contracts remain unchanged/i,
+    ],
+  },
+])
 const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
   (parameter) => parameter?.name === 'include'
 )?.schema?.enum
@@ -641,14 +782,9 @@ const expectedCustomerEstablishmentRequired = [
 ]
 if (
   JSON.stringify(customerEstablishment.required) !==
-    JSON.stringify(expectedCustomerEstablishmentRequired) ||
-  !/unique.*customer_id.*establishment_id/i.test(
-    customerEstablishment.description ?? ''
-  )
+  JSON.stringify(expectedCustomerEstablishmentRequired)
 ) {
-  errors.push(
-    'CustomerEstablishment must define the unique customer_id and establishment_id pair and required response fields.'
-  )
+  errors.push('CustomerEstablishment must retain its required response fields.')
 }
 for (const propertyName of [
   'customer_id',
@@ -662,6 +798,17 @@ for (const propertyName of [
     errors.push(`CustomerEstablishment must expose ${propertyName}.`)
   }
 }
+
+requireUniquenessRules([
+  {
+    label: 'CustomerEstablishment uniqueness',
+    resourceSchema: 'CustomerEstablishment',
+    requestSchema: 'CustomerEstablishmentCreateRequest',
+    operation: paths['/customer-establishments']?.post,
+    uniqueBy: ['customer_id', 'establishment_id'],
+    reusableFields: ['contact_name', 'phone', 'email', 'comments'],
+  },
+])
 
 for (const schemaName of [
   'LegalEntityLookup',

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -20,6 +20,7 @@ const guardPath = fileURLToPath(
 const contractSource = readFileSync(contractPath, 'utf8')
 const contract = yaml.load(contractSource)
 const schemas = contract.components.schemas
+const paths = contract.paths
 
 function runGuard(candidate) {
   const directory = mkdtempSync(join(tmpdir(), 'domain-contracts-'))
@@ -156,6 +157,65 @@ test('uses one neutral duplicate response for every domain create operation', ()
   )
 })
 
+test('keeps the closed customer response free of undeclared relationship includes', () => {
+  assert.equal(schemas.Customer.additionalProperties, false)
+  assert.equal(
+    paths['/customers/{customer}'].get.parameters.some(
+      (parameter) => parameter.name === 'include'
+    ),
+    false
+  )
+  assert.doesNotMatch(
+    paths['/customers/{customer}'].get.description,
+    /optional relationships/i
+  )
+})
+
+test('uses an approved example domain for customer establishment contacts', () => {
+  assert.equal(
+    schemas.CustomerEstablishment.properties.email.example,
+    'max.mustermann@secpal.dev'
+  )
+})
+
+test('defines the customer establishment path parameter once', () => {
+  const pathItem = paths['/customer-establishments/{customer_establishment}']
+
+  assert.deepEqual(pathItem.parameters, [
+    {
+      name: 'customer_establishment',
+      in: 'path',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+    },
+  ])
+  for (const operation of ['get', 'patch', 'delete']) {
+    assert.equal(pathItem[operation].parameters, undefined, operation)
+  }
+})
+
+test('models pagination links for customer establishment collections', () => {
+  assert.deepEqual(schemas.CustomerEstablishmentCollectionResponse.required, [
+    'data',
+    'links',
+    'meta',
+  ])
+  assert.equal(
+    schemas.CustomerEstablishmentCollectionResponse.properties.links.$ref,
+    '#/components/schemas/PaginationLinks'
+  )
+})
+
+test('documents accepted and rejected site and employee domain assignments', () => {
+  for (const schemaName of ['SiteCreateRequest', 'EmployeeCreateRequest']) {
+    const examples = schemas[schemaName]['x-validation-examples']
+
+    assert.ok(examples?.accepted?.length > 0, `${schemaName} accepted example`)
+    assert.ok(examples?.rejected?.length > 0, `${schemaName} rejected example`)
+    assert.equal(examples.rejected[0].status, 422, schemaName)
+  }
+})
+
 test('guard rejects restored OU fields and list filters', () => {
   const candidate = structuredClone(contract)
   candidate.components.schemas.Employee.properties.organizational_unit_id = {
@@ -210,4 +270,70 @@ test('guard rejects distinguishable duplicate responses', () => {
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /neutral fixed shape/)
+})
+
+test('guard rejects customer includes that widen the closed response', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/customers/{customer}'].get.parameters.push({
+    name: 'include',
+    in: 'query',
+    schema: { type: 'string', enum: ['sites'] },
+  })
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /closed Customer response/)
+})
+
+test('guard rejects unapproved contact example domains', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.CustomerEstablishment.properties.email.example =
+    'max.mustermann@example.com'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /secpal\.dev/)
+})
+
+test('guard rejects duplicated customer establishment path parameters', () => {
+  const candidate = structuredClone(contract)
+  const pathItem =
+    candidate.paths['/customer-establishments/{customer_establishment}']
+  pathItem.get.parameters = structuredClone(pathItem.parameters)
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /path-level UUID parameter/)
+})
+
+test('guard rejects incomplete pagination and domain-assignment examples', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.schemas.CustomerEstablishmentCollectionResponse
+    .properties.links
+  candidate.components.schemas.CustomerEstablishmentCollectionResponse.required =
+    ['data', 'meta']
+  delete candidate.components.schemas.EmployeeCreateRequest[
+    'x-validation-examples'
+  ].rejected
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /pagination links/)
+  assert.match(result.stderr, /EmployeeCreateRequest/)
+})
+
+test('guard rejects malformed UUIDs in domain-assignment examples', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.SiteCreateRequest[
+    'x-validation-examples'
+  ].accepted[0].value.establishment_id = 'not-a-uuid'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /SiteCreateRequest/)
 })

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -87,6 +87,105 @@ test('defines OU-free customer, site, and employee domain relationships', () => 
   }
 })
 
+test('aligns migrated collection filters with the domain APIs', () => {
+  const cases = [
+    {
+      path: '/customers',
+      names: ['page', 'per_page', 'search', 'is_active'],
+      uuidNames: [],
+      search: /name and customer_number/i,
+    },
+    {
+      path: '/sites',
+      names: [
+        'page',
+        'per_page',
+        'search',
+        'customer_id',
+        'establishment_id',
+        'type',
+        'is_active',
+      ],
+      uuidNames: ['customer_id', 'establishment_id'],
+      search: /name and site_number/i,
+    },
+    {
+      path: '/employees',
+      names: [
+        'page',
+        'per_page',
+        'status',
+        'search',
+        'legal_entity_id',
+        'establishment_id',
+      ],
+      uuidNames: ['legal_entity_id', 'establishment_id'],
+      search: /email and employee_number/i,
+    },
+  ]
+
+  for (const { path, names, uuidNames, search } of cases) {
+    const parameters = paths[path].get.parameters
+    assert.deepEqual(
+      parameters.map(({ name }) => name),
+      names,
+      `${path} filters`
+    )
+    for (const name of uuidNames) {
+      const parameter = parameters.find((candidate) => candidate.name === name)
+      assert.equal(parameter.schema.type, 'string')
+      assert.equal(parameter.schema.format, 'uuid')
+    }
+    assert.match(
+      parameters.find(({ name }) => name === 'search').description,
+      search
+    )
+  }
+})
+
+test('retains supported customer and site business identifier inputs', () => {
+  for (const [schemaName, propertyName] of [
+    ['CustomerCreateRequest', 'customer_number'],
+    ['SiteCreateRequest', 'site_number'],
+  ]) {
+    const schema = schemas[schemaName]
+    assert.deepEqual(schema.properties[propertyName].type, ['string', 'null'])
+    assert.equal(schema.properties[propertyName].maxLength, 50)
+    assert.equal(schema.required?.includes(propertyName) ?? false, false)
+  }
+
+  assert.equal(schemas.SiteUpdateRequest.properties.site_number.type, 'string')
+  assert.equal(schemas.SiteUpdateRequest.properties.site_number.maxLength, 50)
+  assert.equal(
+    schemas.SiteUpdateRequest.required?.includes('site_number') ?? false,
+    false
+  )
+
+  for (const schemaName of ['CustomerCreateRequest', 'SiteCreateRequest']) {
+    assert.deepEqual(schemas[schemaName].properties.is_active.type, [
+      'boolean',
+      'null',
+    ])
+    assert.equal(schemas[schemaName].properties.is_active.default, true)
+    assert.equal(
+      schemas[schemaName].required?.includes('is_active') ?? false,
+      false
+    )
+  }
+  assert.deepEqual(schemas.SiteCreateRequest.properties.contact.anyOf, [
+    { $ref: '#/components/schemas/Contact' },
+    { type: 'null' },
+  ])
+  assert.match(
+    paths['/customers'].post.description,
+    /customer_number.*omitted or null.*generat(?:ed|es)/is
+  )
+  assert.match(
+    paths['/sites'].post.description,
+    /site_number.*omitted or null.*generat(?:ed|es)/is
+  )
+})
+
 test('keeps employee creation audit examples aligned with domain assignments', () => {
   const employeeCreationActivities = [
     paths['/activity-logs'].get.responses['200'].content['application/json']
@@ -101,6 +200,11 @@ test('keeps employee creation audit examples aligned with domain assignments', (
     assert.equal(activity.event, 'created')
     assert.equal(activity.log_name, 'employee_changes')
     assert.equal(activity.description, 'created')
+    assert.equal(
+      activity.subject?.name ?? null,
+      null,
+      'employee creation audit subjects must not expose a personal name'
+    )
     assert.match(
       activity.properties.attributes.legal_entity_id,
       /^[0-9a-f-]{36}$/i
@@ -186,12 +290,44 @@ test('limits customer-establishment uniqueness to the relationship pair', () => 
   assert.equal(duplicatePair.status, 409)
 })
 
-test('documents OU conflict changes without claiming administration is unchanged', () => {
-  assert.match(changelogSource, /role-downgraded or deleted.*conflict/is)
+test('keeps tenant-local domain lifecycle independent from OU role flags', () => {
+  const domainDescriptions = [
+    schemas.CustomerCreateRequest.properties.legal_entity_id.description,
+    schemas.CustomerUpdateRequest.properties.legal_entity_id.description,
+    schemas.EmployeeUpdateRequest.description,
+    schemas.SiteUpdateRequest.description,
+    paths['/customers'].post.description,
+    paths['/customers/{customer}'].patch.description,
+    paths['/customer-establishments'].post.description,
+    paths['/sites'].post.description,
+    paths['/employees'].post.description,
+    paths['/employees/{employee}'].patch.description,
+    paths['/lookups/legal-entities'].get.description,
+    paths['/lookups/legal-entities/{legal_entity}/establishments'].get
+      .description,
+    paths['/lookups/establishments/{establishment}/customers'].get.description,
+    paths['/lookups/establishments/{establishment}/customer-candidates'].get
+      .description,
+  ]
+  for (const description of domainDescriptions) {
+    assert.doesNotMatch(
+      description,
+      /active, assignable|assignable (?:Legal Entit|establishment)|(?:Legal Entit|establishment)[^.]*assignable/i
+    )
+  }
+
+  const organizationalUnit =
+    paths['/organizational-units/{organizational_unit}']
   assert.doesNotMatch(
-    changelogSource,
-    /organizational-unit and scope administration contracts remain unchanged/i
+    `${organizationalUnit.patch.description}\n${organizationalUnit.delete.description}`,
+    /customers|customer-establishment|sites|employees/i
   )
+  assert.equal(organizationalUnit.patch.responses['409'], undefined)
+  assert.equal(
+    organizationalUnit.delete.responses['409'].$ref,
+    '#/components/responses/OrganizationalUnitHasChildrenConflict'
+  )
+  assert.doesNotMatch(changelogSource, /role-downgraded or deleted.*conflict/is)
 })
 
 test('defines minimal legal entity, establishment, and customer lookups', () => {
@@ -244,6 +380,12 @@ test('uses one neutral duplicate response for every domain create operation', ()
 
 test('keeps the closed customer response free of undeclared relationship includes', () => {
   assert.equal(schemas.Customer.additionalProperties, false)
+  assert.deepEqual(schemas.Customer.properties.sites_count, {
+    type: 'integer',
+    minimum: 0,
+    description:
+      "Number of the customer's sites visible to the current caller. Present on customer list and detail responses.",
+  })
   assert.equal(
     paths['/customers/{customer}'].get.parameters.some(
       (parameter) => parameter.name === 'include'
@@ -350,14 +492,66 @@ test('documents tenant-consistent customer establishment links', () => {
   assert.equal(examples.rejected[0].status, 422)
 })
 
-test('documents customer-establishment read authorization consistently', () => {
+test('keeps customer and site domain mutations outside OU entitlement', () => {
+  const createOperations = [
+    [paths['/customers'].post, 'customers.create'],
+    [paths['/customer-establishments'].post, 'customers.update'],
+    [paths['/sites'].post, 'sites.create'],
+  ]
+  for (const [operation, permission] of createOperations) {
+    assert.match(
+      operation.description,
+      /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is
+    )
+    assert.match(
+      operation.description,
+      new RegExp(permission.replace('.', '\\.'))
+    )
+    assert.doesNotMatch(operation.description, /organizational write access/i)
+    assert.equal(
+      operation.responses['403'].$ref,
+      '#/components/responses/Forbidden'
+    )
+  }
+
+  assert.match(
+    paths['/customers/{customer}'].patch.description,
+    /legal_entity_id.*customers\.update.*organizational scopes.*403/is
+  )
+  for (const description of [
+    paths['/sites/{site}'].patch.description,
+    schemas.SiteUpdateRequest.description,
+  ]) {
+    assert.match(
+      description,
+      /domain relationship.*sites\.update.*organizational scopes.*403/is
+    )
+    assert.doesNotMatch(description, /organizational write access/i)
+  }
+})
+
+test('documents customer record read authorization without OU entitlement', () => {
   for (const operation of [
-    paths['/customer-establishments'].get,
+    paths['/customers/{customer}'].get,
     paths['/customer-establishments/{customer_establishment}'].get,
   ]) {
     assert.match(
       operation.description,
-      /view access.*customer assignment.*organizational scope.*authorized/is
+      /active customer or site assignment.*customers\.read.*without organizational scopes.*OU scopes alone do not grant record access/is
+    )
+    assert.equal(
+      operation.responses['403'].$ref,
+      '#/components/responses/Forbidden'
+    )
+  }
+
+  for (const operation of [
+    paths['/customers'].get,
+    paths['/customer-establishments'].get,
+  ]) {
+    assert.match(
+      operation.description,
+      /customers\.read.*without organizational scopes.*active customer or site assignment.*OU scope alone.*empty authorized collection/is
     )
     assert.equal(
       operation.responses['403'].$ref,
@@ -366,28 +560,143 @@ test('documents customer-establishment read authorization consistently', () => {
   }
 })
 
-test('documents employee qualification access after OU decoupling', () => {
-  const operation = paths['/employees/{employee}/qualifications'].get
-
+test('documents site record read authorization without OU entitlement', () => {
   assert.match(
-    operation.description,
-    /OU scopes do not grant access.*organizational scopes.*403.*No organizational entitlement exists/is
+    paths['/sites'].get.description,
+    /sites\.read.*active customer or site assignment.*OU scope alone.*empty authorized collection/is
   )
   assert.equal(
-    operation.responses['403'].$ref,
-    '#/components/responses/SimpleForbidden'
+    paths['/sites'].get.responses['403'].$ref,
+    '#/components/responses/Forbidden'
   )
+
+  assert.match(
+    paths['/sites/{site}'].get.description,
+    /sites\.read.*active customer or site assignment.*OU scopes alone do not grant record access/is
+  )
+  assert.equal(
+    paths['/sites/{site}'].get.responses['403'].$ref,
+    '#/components/responses/Forbidden'
+  )
+})
+
+test('documents all employee subresource authorization after OU decoupling', () => {
+  const noOuBoundary =
+    /OU scopes do not grant access to domain employees.*organizational scopes.*403/is
+  const qualificationOperations = [
+    [
+      paths['/employees/{employee}/qualifications'].get,
+      'employee_qualification.read',
+      true,
+    ],
+    [
+      paths['/employees/{employee}/qualifications'].post,
+      'employee_qualification.write',
+      false,
+    ],
+    [
+      paths['/employee-qualifications/{employeeQualification}'].get,
+      'employee_qualification.read',
+      true,
+    ],
+    [
+      paths['/employee-qualifications/{employeeQualification}'].patch,
+      'employee_qualification.write',
+      false,
+    ],
+    [
+      paths['/employee-qualifications/{employeeQualification}'].delete,
+      'employee_qualification.write',
+      false,
+    ],
+  ]
+  const documentOperations = [
+    [
+      paths['/employees/{employee}/documents'].get,
+      'employee_document.read',
+      true,
+    ],
+    [
+      paths['/employees/{employee}/documents'].post,
+      'employee_document.write',
+      false,
+    ],
+    [
+      paths['/employees/{employee}/documents/{document}'].get,
+      'employee_document.read',
+      true,
+    ],
+    [
+      paths['/employees/{employee}/documents/{document}'].delete,
+      'employee_document.write',
+      false,
+    ],
+    [
+      paths['/employees/{employee}/documents/{document}/download'].get,
+      'employee_document.read',
+      true,
+    ],
+  ]
+
+  for (const [operation, permission, selfService] of qualificationOperations) {
+    assert.match(operation.description, noOuBoundary)
+    assert.match(
+      operation.description,
+      new RegExp(permission.replace('.', '\\.'))
+    )
+    assert.equal(
+      /\*\*Self-service:\*\*/i.test(operation.description),
+      selfService
+    )
+    if (selfService) {
+      assert.match(
+        operation.description,
+        /non-self callers.*organizational scopes.*403/is
+      )
+    }
+    assert.equal(
+      operation.responses['403'].$ref,
+      '#/components/responses/SimpleForbidden'
+    )
+  }
+  for (const [operation, permission, selfService] of documentOperations) {
+    assert.match(operation.description, noOuBoundary)
+    assert.match(
+      operation.description,
+      new RegExp(permission.replace('.', '\\.'))
+    )
+    assert.equal(
+      /\*\*Self-service:\*\*/i.test(operation.description),
+      selfService
+    )
+    if (selfService) {
+      assert.match(
+        operation.description,
+        /non-self callers.*organizational scopes.*403/is
+      )
+    }
+    assert.equal(
+      operation.responses['403'].$ref,
+      '#/components/responses/Forbidden'
+    )
+  }
+  for (const schemaName of [
+    'AttachQualificationRequest',
+    'UpdateEmployeeQualificationRequest',
+  ]) {
+    assert.match(schemas[schemaName].description, noOuBoundary)
+  }
 })
 
 test('keeps lookup eligibility and dependent relationship lifecycle rules explicit', () => {
   assert.match(
     paths['/lookups/legal-entities'].get.description,
-    /customers\.create.*sites\.create.*employees\.create/i
+    /customers\.create.*sites\.create.*employee\.create/i
   )
   assert.match(
     paths['/lookups/legal-entities/{legal_entity}/establishments'].get
       .description,
-    /same tenant, active, assignable, non-deleted/i
+    /same tenant, active, non-deleted/i
   )
   assert.match(paths['/sites'].post.description, /customer-establishment link/i)
   assert.match(
@@ -416,11 +725,11 @@ test('keeps create and update domain assignments closed and validates their fina
   assert.equal(schemas.EmployeeUpdateRequest.additionalProperties, false)
   assert.match(
     paths['/employees'].post.description,
-    /active, assignable, non-deleted.*organizational write access/i
+    /active(?:,| and) non-deleted.*organizational write access/i
   )
   assert.match(
     paths['/employees/{employee}'].patch.description,
-    /resulting.*same tenant.*Legal Entity.*active, assignable, non-deleted/i
+    /resulting.*same tenant.*Legal Entity.*active, non-deleted/i
   )
   assert.match(
     schemas.SiteUpdateRequest.description,
@@ -431,15 +740,15 @@ test('keeps create and update domain assignments closed and validates their fina
 test('enforces lookup eligibility when assignment UUIDs are submitted directly', () => {
   assert.match(
     paths['/customer-establishments'].post.description,
-    /active, non-deleted customer.*active, assignable, non-deleted establishment.*organizational write access/i
+    /active, non-deleted customer.*active, non-deleted establishment.*OU scopes do not grant.*organizational scopes.*403/is
   )
   assert.match(
     paths['/sites'].post.description,
-    /active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i
+    /active, non-deleted customer.*active, non-deleted Legal Entity and establishment.*OU scopes do not grant.*organizational scopes.*403/is
   )
   assert.match(
     schemas.SiteUpdateRequest.description,
-    /active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i
+    /active, non-deleted customer.*active, non-deleted Legal Entity and establishment.*sites\.update.*organizational scopes.*403/is
   )
 })
 
@@ -468,21 +777,21 @@ test('separates customer link candidates from customers already linked for sites
 test('keeps lookup permissions aligned with every link and assignment workflow', () => {
   assert.match(
     paths['/lookups/legal-entities'].get.description,
-    /customers\.create.*customers\.update.*sites\.create.*sites\.update.*employees\.create.*employees\.update/i
+    /customers\.create.*customers\.update.*sites\.create.*sites\.update.*employee\.write.*employee\.create.*employee\.update/i
   )
   assert.match(
     paths['/lookups/legal-entities/{legal_entity}/establishments'].get
       .description,
-    /customers\.update.*sites\.create.*sites\.update.*employees\.create.*employees\.update/i
+    /customers\.update.*sites\.create.*sites\.update.*employee\.write.*employee\.create.*employee\.update/i
   )
   assert.match(
     paths['/lookups/establishments/{establishment}/customers'].get.description,
-    /sites\.create.*sites\.update.*active, assignable, non-deleted establishment/i
+    /sites\.create.*sites\.update.*active, non-deleted establishment.*authorized domain write access/i
   )
   assert.match(
     paths['/lookups/establishments/{establishment}/customer-candidates'].get
       .description,
-    /customers\.update.*active, assignable, non-deleted establishment/i
+    /customers\.update.*active, non-deleted establishment.*authorized domain write access/i
   )
 
   const linkPath = paths['/customer-establishments/{customer_establishment}']
@@ -490,25 +799,18 @@ test('keeps lookup permissions aligned with every link and assignment workflow',
   assert.match(linkPath.delete.description, /customers\.update/i)
   assert.match(
     paths['/employees/{employee}'].patch.description,
-    /employees\.update/i
+    /employee\.write.*employee\.update/i
+  )
+  assert.match(
+    paths['/employees'].post.description,
+    /employee\.write.*employee\.create/i
   )
 })
 
-test('names link-management permission and blocks referenced OU role downgrades', () => {
+test('names the link-management permission', () => {
   assert.match(
     paths['/customer-establishments'].post.description,
     /customers\.update/i
-  )
-
-  const organizationalUnitUpdate =
-    paths['/organizational-units/{organizational_unit}'].patch
-  assert.match(
-    organizationalUnitUpdate.description,
-    /is_legal_entity.*is_establishment.*referenced.*customers.*customer-establishment links.*sites.*employees/i
-  )
-  assert.equal(
-    organizationalUnitUpdate.responses['409'].$ref,
-    '#/components/responses/Conflict'
   )
 })
 
@@ -527,17 +829,6 @@ test('blocks deletion of domain records that still have dependents', () => {
   assert.equal(
     customerDelete.responses['409'].$ref,
     '#/components/responses/Conflict'
-  )
-
-  const organizationalUnitDelete =
-    paths['/organizational-units/{organizational_unit}'].delete
-  assert.match(
-    organizationalUnitDelete.description,
-    /customers, customer-establishment links, sites, or employees/i
-  )
-  assert.equal(
-    organizationalUnitDelete.responses['409'].$ref,
-    '#/components/responses/OrganizationalUnitDeletionConflict'
   )
 })
 
@@ -574,21 +865,55 @@ test('guard rejects restored OU fields and list filters', () => {
   assert.match(result.stderr, /organizational_unit_id/)
 })
 
+test('guard rejects incomplete or unsupported migrated list filters', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/employees'].get.parameters = candidate.paths[
+    '/employees'
+  ].get.parameters.filter(({ name }) => name !== 'establishment_id')
+  candidate.paths['/sites'].get.parameters.push({
+    name: 'currently_valid',
+    in: 'query',
+    schema: { type: 'boolean' },
+  })
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET \/employees collection filters/)
+  assert.match(result.stderr, /GET \/sites collection filters/)
+})
+
+test('guard rejects dropped customer or site business identifier inputs', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.schemas.CustomerCreateRequest.properties
+    .customer_number
+  delete candidate.components.schemas.SiteCreateRequest.properties.site_number
+  delete candidate.components.schemas.CustomerCreateRequest.properties.is_active
+  delete candidate.components.schemas.SiteCreateRequest.properties.is_active
+  delete candidate.components.schemas.SiteUpdateRequest.properties.site_number
+  candidate.components.schemas.SiteCreateRequest.properties.contact = {
+    $ref: '#/components/schemas/Contact',
+  }
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /CustomerCreateRequest\.customer_number/)
+  assert.match(result.stderr, /SiteCreateRequest\.site_number/)
+  assert.match(result.stderr, /CustomerCreateRequest\.is_active/)
+  assert.match(result.stderr, /SiteCreateRequest\.is_active/)
+  assert.match(result.stderr, /SiteCreateRequest\.contact/)
+  assert.match(result.stderr, /SiteUpdateRequest\.site_number/)
+})
+
 test('guard rejects stale or privacy-widened employee creation audit examples', () => {
   const candidate = structuredClone(contract)
-  const listActivity =
-    candidate.paths['/activity-logs'].get.responses['200'].content[
-      'application/json'
-    ].examples.paginatedResponse.value.data[0]
   const detailActivity =
     candidate.paths['/activity-logs/{activity}'].get.responses['200'].content[
       'application/json'
     ].examples.employeeCreation.value.data
 
-  delete listActivity.properties.attributes.establishment_id
-  detailActivity.properties.attributes.organizational_unit_id =
-    '550e8400-e29b-41d4-a716-446655440030'
-  detailActivity.properties.attributes.name = 'John Doe'
+  detailActivity.subject.name = 'John Doe'
 
   const result = runGuard(candidate)
 
@@ -621,7 +946,26 @@ test('guard rejects widened lookup data', () => {
   assert.match(result.stderr, /CustomerLookup/)
 })
 
-test('guard rejects weakened lookup, permission, and OU role invariants', () => {
+test('guard rejects inherited OU lifecycle rules in tenant-local domains', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/lookups/legal-entities'].get.description +=
+    ' Legal Entities must be assignable.'
+  candidate.paths[
+    '/organizational-units/{organizational_unit}'
+  ].patch.description +=
+    ' Clearing roles is blocked while customers or employees reference the unit.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(
+    result.stderr,
+    /tenant-local domain.*organizational-unit assignability/i
+  )
+  assert.match(result.stderr, /organizational-unit lifecycle.*tenant-local/i)
+})
+
+test('guard rejects weakened lookup and permission invariants', () => {
   const candidate = structuredClone(contract)
   candidate.paths[
     '/lookups/establishments/{establishment}/customers'
@@ -637,12 +981,6 @@ test('guard rejects weakened lookup, permission, and OU role invariants', () => 
   candidate.paths[
     '/customer-establishments/{customer_establishment}'
   ].delete.description = 'Deletes a link when unused.'
-  candidate.paths[
-    '/organizational-units/{organizational_unit}'
-  ].patch.description = 'Updates an organizational unit.'
-  delete candidate.paths['/organizational-units/{organizational_unit}'].patch
-    .responses['409']
-
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
@@ -651,7 +989,6 @@ test('guard rejects weakened lookup, permission, and OU role invariants', () => 
   assert.match(result.stderr, /POST customer-establishment links/)
   assert.match(result.stderr, /PATCH customer-establishment links/)
   assert.match(result.stderr, /DELETE customer-establishment links/)
-  assert.match(result.stderr, /PATCH organizational-unit roles/)
 })
 
 test('guard derives lookup permissions and conflict responses from workflows', () => {
@@ -663,6 +1000,9 @@ test('guard derives lookup permissions and conflict responses from workflows', (
     candidate.paths[pathName].get.description = candidate.paths[
       pathName
     ].get.description.replace('`sites.update`, ', '')
+    candidate.paths[pathName].get.description = candidate.paths[
+      pathName
+    ].get.description.replace('`employee.update`', '`employee.read`')
   }
   candidate.paths[
     '/lookups/establishments/{establishment}/customers'
@@ -670,13 +1010,19 @@ test('guard derives lookup permissions and conflict responses from workflows', (
     '/lookups/establishments/{establishment}/customers'
   ].get.description.replace(' or `sites.update`', '')
   delete candidate.paths['/customers/{customer}'].patch.responses['409']
+  candidate.paths['/employees/{employee}'].patch.description = candidate.paths[
+    '/employees/{employee}'
+  ].patch.description.replace('`employee.update`', '`employee.read`')
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /GET Legal Entity lookups.*sites\.update/)
   assert.match(result.stderr, /GET establishment lookups.*sites\.update/)
+  assert.match(result.stderr, /GET Legal Entity lookups.*employee\.update/)
+  assert.match(result.stderr, /GET establishment lookups.*employee\.update/)
   assert.match(result.stderr, /GET linked customer lookups.*sites\.update/)
+  assert.match(result.stderr, /PATCH employee assignments.*employee\.update/)
   assert.match(
     result.stderr,
     /PATCH customer Legal Entity reassignment.*Conflict.*409/
@@ -730,13 +1076,16 @@ test('guard rejects widened relationship uniqueness and missing evidence', () =>
   assert.match(result.stderr, /CustomerEstablishment uniqueness/)
 })
 
-test('guard rejects changelog claims that contradict OU conflicts', () => {
-  const contradictoryChangelog = `${changelogSource}\nOrganizational-unit and scope administration contracts remain unchanged.\n`
+test('guard rejects false OU-domain lifecycle coupling', () => {
+  const contradictoryChangelog = `${changelogSource}\nReferenced Legal Entities may not be role-downgraded or deleted; this conflict protects domain records.\n`
 
   const result = runGuard(contract, contradictoryChangelog)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /CHANGELOG OU lifecycle notes/)
+  assert.match(
+    result.stderr,
+    /CHANGELOG must not couple.*organizational-unit roles/i
+  )
 })
 
 test('guard rejects incomplete customer-establishment read authorization', () => {
@@ -753,15 +1102,89 @@ test('guard rejects incomplete customer-establishment read authorization', () =>
   assert.match(result.stderr, /GET customer-establishment links/)
 })
 
-test('guard rejects stale OU-based employee qualification access', () => {
+test('guard rejects OU-entitled customer and site record reads', () => {
   const candidate = structuredClone(contract)
-  candidate.paths['/employees/{employee}/qualifications'].get.description =
-    'Users with organizational scopes see employees in their allowed units.'
+  candidate.paths['/customers'].get.description =
+    'Organizational scopes grant access to customer records.'
+  candidate.paths['/customers/{customer}'].get.description =
+    'Organizational scopes grant access to this customer.'
+  candidate.paths['/sites'].get.description =
+    'Organizational scopes grant access to site records.'
+  candidate.paths['/sites/{site}'].get.description =
+    'Organizational scopes grant access to this site.'
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /GET employee qualifications/)
+  assert.match(result.stderr, /GET customer collections/)
+  assert.match(result.stderr, /GET customer records/)
+  assert.match(result.stderr, /GET site collections/)
+  assert.match(result.stderr, /GET site records/)
+})
+
+test('guard rejects OU-entitled customer or site domain mutations', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/customers'].post.description +=
+    ' Organizational write access also grants this write.'
+  candidate.paths['/sites/{site}'].patch.description +=
+    ' Domain reassignment also follows organizational write access.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /POST customer assignments/)
+  assert.match(result.stderr, /PATCH site assignment operation/)
+})
+
+test('guard rejects stale OU-based employee subresource access', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/employees/{employee}/qualifications'].post.description =
+    'Users with organizational scopes see employees in their allowed units.'
+  candidate.paths['/employees/{employee}/documents'].get.description =
+    'Scoped managers see employee documents.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /employee qualification authorization/)
+  assert.match(result.stderr, /employee document authorization/)
+})
+
+test('guard rejects missing or invented employee self-service exceptions', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/employees/{employee}/documents'].get.description =
+    candidate.paths['/employees/{employee}/documents'].get.description.replace(
+      /\n\n\*\*Self-service:\*\*.*?(?=\n\n)/s,
+      ''
+    )
+  candidate.paths['/employees/{employee}/qualifications'].post.description +=
+    '\n\n**Self-service:** the employee may attach their own qualifications.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /employee qualification authorization/)
+  assert.match(result.stderr, /employee document authorization/)
+})
+
+test('guard rejects unmodeled employee subresource operations', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/employees/{employee}/qualifications'].put = structuredClone(
+    candidate.paths['/employees/{employee}/qualifications'].post
+  )
+  candidate.paths['/employee-qualifications'] = {
+    post: structuredClone(
+      candidate.paths['/employees/{employee}/qualifications'].post
+    ),
+  }
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.equal(
+    result.stderr.match(/unmodeled employee qualification operation/g)?.length,
+    2
+  )
 })
 
 test('guard rejects missing assignment workflow evidence', () => {
@@ -797,6 +1220,16 @@ test('guard rejects customer includes that widen the closed response', () => {
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /closed Customer response/)
+})
+
+test('guard rejects a closed customer response without its visible site count', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.schemas.Customer.properties.sites_count
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /Customer\.sites_count/)
 })
 
 test('guard rejects unapproved contact example domains', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
+
+const contractPath = fileURLToPath(
+  new URL('../docs/openapi.yaml', import.meta.url)
+)
+const guardPath = fileURLToPath(
+  new URL('./check-domain-contracts.mjs', import.meta.url)
+)
+const contractSource = readFileSync(contractPath, 'utf8')
+const contract = yaml.load(contractSource)
+const schemas = contract.components.schemas
+
+function runGuard(candidate) {
+  const directory = mkdtempSync(join(tmpdir(), 'domain-contracts-'))
+  const candidatePath = join(directory, 'openapi.yaml')
+  writeFileSync(candidatePath, yaml.dump(candidate))
+
+  try {
+    return spawnSync(process.execPath, [guardPath, candidatePath], {
+      encoding: 'utf8',
+    })
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+test('accepts the repository domain contract', () => {
+  const result = runGuard(contract)
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('defines OU-free customer, site, and employee domain relationships', () => {
+  assert.deepEqual(
+    schemas.Customer.required.includes('legal_entity_id'),
+    true
+  )
+  assert.deepEqual(
+    schemas.Site.required.filter((field) =>
+      ['customer_id', 'legal_entity_id', 'establishment_id'].includes(field)
+    ),
+    ['customer_id', 'legal_entity_id', 'establishment_id']
+  )
+  assert.deepEqual(
+    schemas.Employee.required.filter((field) =>
+      ['legal_entity_id', 'establishment_id'].includes(field)
+    ),
+    ['legal_entity_id', 'establishment_id']
+  )
+
+  for (const schemaName of [
+    'Customer',
+    'CustomerCreateRequest',
+    'CustomerUpdateRequest',
+    'Site',
+    'SiteCreateRequest',
+    'SiteUpdateRequest',
+    'Employee',
+    'EmployeeCreateRequest',
+    'EmployeeUpdateRequest',
+  ]) {
+    assert.equal(
+      Object.hasOwn(schemas[schemaName].properties, 'organizational_unit_id'),
+      false,
+      `${schemaName} must not expose organizational_unit_id`
+    )
+    assert.equal(
+      Object.hasOwn(schemas[schemaName].properties, 'organizational_unit'),
+      false,
+      `${schemaName} must not expose an organizational_unit relationship`
+    )
+  }
+})
+
+test('moves local customer data to a unique customer establishment contract', () => {
+  assert.equal(Object.hasOwn(schemas.Customer.properties, 'contact'), false)
+  assert.equal(Object.hasOwn(schemas.Customer.properties, 'notes'), false)
+  assert.equal(Object.hasOwn(schemas.Customer.properties, 'metadata'), false)
+
+  assert.deepEqual(schemas.CustomerEstablishment.required, [
+    'id',
+    'customer_id',
+    'establishment_id',
+    'created_at',
+    'updated_at',
+  ])
+  assert.match(
+    schemas.CustomerEstablishment.description,
+    /unique.*customer_id.*establishment_id/i
+  )
+  for (const property of [
+    'customer_id',
+    'establishment_id',
+    'contact_name',
+    'phone',
+    'email',
+    'comments',
+  ]) {
+    assert.ok(schemas.CustomerEstablishment.properties[property], property)
+  }
+})
+
+test('defines minimal legal entity, establishment, and customer lookups', () => {
+  assert.deepEqual(Object.keys(schemas.LegalEntityLookup.properties), [
+    'id',
+    'name',
+  ])
+  assert.deepEqual(Object.keys(schemas.EstablishmentLookup.properties), [
+    'id',
+    'name',
+  ])
+  assert.deepEqual(Object.keys(schemas.CustomerLookup.properties), ['id', 'name'])
+
+  for (const schemaName of [
+    'LegalEntityLookup',
+    'EstablishmentLookup',
+    'CustomerLookup',
+  ]) {
+    assert.deepEqual(schemas[schemaName].required, ['id', 'name'])
+    assert.equal(schemas[schemaName].additionalProperties, false)
+  }
+})
+
+test('uses one neutral duplicate response for every domain create operation', () => {
+  assert.deepEqual(schemas.DuplicateResourceError.required, ['message', 'code'])
+  assert.deepEqual(schemas.DuplicateResourceError.properties.code.enum, [
+    'DUPLICATE_RESOURCE',
+  ])
+
+  for (const path of [
+    '/customers',
+    '/customer-establishments',
+    '/sites',
+    '/employees',
+  ]) {
+    assert.equal(
+      contract.paths[path].post.responses['409'].$ref,
+      '#/components/responses/DuplicateConflict',
+      path
+    )
+  }
+  assert.match(
+    contract.components.responses.DuplicateConflict.description,
+    /atomically.*same transaction/i
+  )
+})
+
+test('guard rejects restored OU fields and list filters', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.Employee.properties.organizational_unit_id = {
+    type: 'string',
+    format: 'uuid',
+  }
+  candidate.paths['/sites'].get.parameters.push({
+    name: 'organizational_unit_id',
+    in: 'query',
+    required: false,
+    schema: { type: 'string', format: 'uuid' },
+  })
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /organizational_unit_id/)
+})
+
+test('guard rejects optionalized domain relationships', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.Site.required =
+    candidate.components.schemas.Site.required.filter(
+      (property) => property !== 'establishment_id'
+    )
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /Site\.establishment_id/)
+})
+
+test('guard rejects widened lookup data', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.CustomerLookup.properties.customer_number = {
+    type: 'string',
+  }
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /CustomerLookup/)
+})
+
+test('guard rejects distinguishable duplicate responses', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.DuplicateResourceError.properties.message.enum = [
+    'This email address already exists.',
+  ]
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /neutral fixed shape/)
+})

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -87,6 +87,45 @@ test('defines OU-free customer, site, and employee domain relationships', () => 
   }
 })
 
+test('keeps employee creation audit examples aligned with domain assignments', () => {
+  const employeeCreationActivities = [
+    paths['/activity-logs'].get.responses['200'].content['application/json']
+      .examples.paginatedResponse.value.data[0],
+    paths['/activity-logs/{activity}'].get.responses['200'].content[
+      'application/json'
+    ].examples.employeeCreation.value.data,
+  ]
+
+  for (const activity of employeeCreationActivities) {
+    assert.equal(activity.subject_type, 'App\\Models\\Employee')
+    assert.equal(activity.event, 'created')
+    assert.equal(activity.log_name, 'employee_changes')
+    assert.equal(activity.description, 'created')
+    assert.match(
+      activity.properties.attributes.legal_entity_id,
+      /^[0-9a-f-]{36}$/i
+    )
+    assert.match(
+      activity.properties.attributes.establishment_id,
+      /^[0-9a-f-]{36}$/i
+    )
+    for (const forbiddenField of [
+      'organizational_unit_id',
+      'name',
+      'first_name',
+      'last_name',
+      'email',
+      'phone',
+    ]) {
+      assert.equal(
+        Object.hasOwn(activity.properties.attributes, forbiddenField),
+        false,
+        `employee audit attributes must not expose ${forbiddenField}`
+      )
+    }
+  }
+})
+
 test('moves local customer data to a unique customer establishment contract', () => {
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'contact'), false)
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'notes'), false)
@@ -327,6 +366,19 @@ test('documents customer-establishment read authorization consistently', () => {
   }
 })
 
+test('documents employee qualification access after OU decoupling', () => {
+  const operation = paths['/employees/{employee}/qualifications'].get
+
+  assert.match(
+    operation.description,
+    /OU scopes do not grant access.*organizational scopes.*403.*No organizational entitlement exists/is
+  )
+  assert.equal(
+    operation.responses['403'].$ref,
+    '#/components/responses/SimpleForbidden'
+  )
+})
+
 test('keeps lookup eligibility and dependent relationship lifecycle rules explicit', () => {
   assert.match(
     paths['/lookups/legal-entities'].get.description,
@@ -522,6 +574,28 @@ test('guard rejects restored OU fields and list filters', () => {
   assert.match(result.stderr, /organizational_unit_id/)
 })
 
+test('guard rejects stale or privacy-widened employee creation audit examples', () => {
+  const candidate = structuredClone(contract)
+  const listActivity =
+    candidate.paths['/activity-logs'].get.responses['200'].content[
+      'application/json'
+    ].examples.paginatedResponse.value.data[0]
+  const detailActivity =
+    candidate.paths['/activity-logs/{activity}'].get.responses['200'].content[
+      'application/json'
+    ].examples.employeeCreation.value.data
+
+  delete listActivity.properties.attributes.establishment_id
+  detailActivity.properties.attributes.organizational_unit_id =
+    '550e8400-e29b-41d4-a716-446655440030'
+  detailActivity.properties.attributes.name = 'John Doe'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /employee creation audit examples/)
+})
+
 test('guard rejects optionalized domain relationships', () => {
   const candidate = structuredClone(contract)
   candidate.components.schemas.Site.required =
@@ -677,6 +751,17 @@ test('guard rejects incomplete customer-establishment read authorization', () =>
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /GET customer-establishment collections/)
   assert.match(result.stderr, /GET customer-establishment links/)
+})
+
+test('guard rejects stale OU-based employee qualification access', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/employees/{employee}/qualifications'].get.description =
+    'Users with organizational scopes see employees in their allowed units.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET employee qualifications/)
 })
 
 test('guard rejects missing assignment workflow evidence', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -257,6 +257,75 @@ test('keeps lookup eligibility and dependent relationship lifecycle rules explic
   )
 })
 
+test('keeps create and update domain assignments closed and validates their final state', () => {
+  assert.equal(schemas.EmployeeCreateRequest.additionalProperties, false)
+  assert.equal(schemas.EmployeeUpdateRequest.additionalProperties, false)
+  assert.match(
+    paths['/employees'].post.description,
+    /active, assignable, non-deleted.*organizational write access/i
+  )
+  assert.match(
+    paths['/employees/{employee}'].patch.description,
+    /resulting.*same tenant.*Legal Entity.*active, assignable, non-deleted/i
+  )
+  assert.match(
+    schemas.SiteUpdateRequest.description,
+    /resulting.*existing customer-establishment link/i
+  )
+})
+
+test('enforces lookup eligibility when assignment UUIDs are submitted directly', () => {
+  assert.match(
+    paths['/customer-establishments'].post.description,
+    /active, non-deleted customer.*active, assignable, non-deleted establishment.*organizational write access/i
+  )
+  assert.match(
+    paths['/sites'].post.description,
+    /active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i
+  )
+  assert.match(
+    schemas.SiteUpdateRequest.description,
+    /active, non-deleted customer.*active, assignable, non-deleted.*organizational write access/i
+  )
+})
+
+test('blocks deletion of domain records that still have dependents', () => {
+  const customerDelete = paths['/customers/{customer}'].delete
+  assert.match(
+    customerDelete.description,
+    /customer-establishment links or sites/i
+  )
+  assert.equal(
+    customerDelete.responses['409'].$ref,
+    '#/components/responses/Conflict'
+  )
+
+  const organizationalUnitDelete =
+    paths['/organizational-units/{organizational_unit}'].delete
+  assert.match(
+    organizationalUnitDelete.description,
+    /customers, customer-establishment links, sites, or employees/i
+  )
+  assert.equal(
+    organizationalUnitDelete.responses['409'].$ref,
+    '#/components/responses/OrganizationalUnitDeletionConflict'
+  )
+})
+
+test('guard rejects reopened writes and weakened final-state or deletion rules', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.schemas.EmployeeUpdateRequest.additionalProperties
+  candidate.components.schemas.SiteUpdateRequest.description = 'Partial update.'
+  candidate.paths['/customers/{customer}'].delete.responses['409'] = undefined
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /EmployeeUpdateRequest/)
+  assert.match(result.stderr, /PATCH site assignments/)
+  assert.match(result.stderr, /DELETE customers/)
+})
+
 test('guard rejects restored OU fields and list filters', () => {
   const candidate = structuredClone(contract)
   candidate.components.schemas.Employee.properties.organizational_unit_id = {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -216,6 +216,47 @@ test('documents accepted and rejected site and employee domain assignments', () 
   }
 })
 
+test('documents tenant-consistent customer establishment links', () => {
+  const examples = schemas.CustomerEstablishmentCreateRequest[
+    'x-validation-examples'
+  ]
+
+  assert.ok(examples?.accepted?.length > 0)
+  assert.ok(examples?.rejected?.length > 0)
+  assert.equal(examples.rejected[0].status, 422)
+})
+
+test('keeps lookup eligibility and dependent relationship lifecycle rules explicit', () => {
+  assert.match(
+    paths['/lookups/legal-entities'].get.description,
+    /customers\.create.*sites\.create.*employees\.create/i
+  )
+  assert.match(
+    paths['/lookups/legal-entities/{legal_entity}/establishments'].get.description,
+    /same tenant, active, assignable, non-deleted/i
+  )
+  assert.match(paths['/sites'].post.description, /customer-establishment link/i)
+  assert.match(
+    paths['/lookups/establishments/{establishment}/customers'].get.description,
+    /existing customer-establishment link/i
+  )
+  assert.match(
+    paths['/customers/{customer}'].patch.description,
+    /no customer-establishment links or sites/i
+  )
+  assert.match(
+    paths['/customer-establishments/{customer_establishment}'].delete
+      .description,
+    /blocked.*sites/i
+  )
+  assert.equal(
+    paths['/customer-establishments/{customer_establishment}'].delete.responses[
+      '409'
+    ].$ref,
+    '#/components/responses/Conflict'
+  )
+})
+
 test('guard rejects restored OU fields and list filters', () => {
   const candidate = structuredClone(contract)
   candidate.components.schemas.Employee.properties.organizational_unit_id = {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -289,6 +289,73 @@ test('enforces lookup eligibility when assignment UUIDs are submitted directly',
   )
 })
 
+test('separates customer link candidates from customers already linked for sites', () => {
+  const linkedCustomers =
+    paths['/lookups/establishments/{establishment}/customers'].get
+  assert.match(
+    linkedCustomers.description,
+    /active, non-deleted customers.*existing customer-establishment link/i
+  )
+
+  const linkCandidates =
+    paths['/lookups/establishments/{establishment}/customer-candidates']?.get
+  assert.ok(linkCandidates)
+  assert.match(linkCandidates.description, /customers\.update/i)
+  assert.match(
+    linkCandidates.description,
+    /active, non-deleted customers.*not yet linked/i
+  )
+  assert.equal(
+    linkCandidates.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/CustomerLookupCollectionResponse'
+  )
+})
+
+test('keeps lookup permissions aligned with every link and assignment workflow', () => {
+  assert.match(
+    paths['/lookups/legal-entities'].get.description,
+    /customers\.create.*customers\.update.*sites\.create.*employees\.create/i
+  )
+  assert.match(
+    paths['/lookups/legal-entities/{legal_entity}/establishments'].get
+      .description,
+    /customers\.update.*sites\.create.*employees\.create/i
+  )
+  assert.match(
+    paths['/lookups/establishments/{establishment}/customers'].get.description,
+    /sites\.create.*active, assignable, non-deleted establishment/i
+  )
+  assert.match(
+    paths[
+      '/lookups/establishments/{establishment}/customer-candidates'
+    ].get.description,
+    /customers\.update.*active, assignable, non-deleted establishment/i
+  )
+
+  const linkPath =
+    paths['/customer-establishments/{customer_establishment}']
+  assert.match(linkPath.patch.description, /customers\.update/i)
+  assert.match(linkPath.delete.description, /customers\.update/i)
+})
+
+test('names link-management permission and blocks referenced OU role downgrades', () => {
+  assert.match(
+    paths['/customer-establishments'].post.description,
+    /customers\.update/i
+  )
+
+  const organizationalUnitUpdate =
+    paths['/organizational-units/{organizational_unit}'].patch
+  assert.match(
+    organizationalUnitUpdate.description,
+    /is_legal_entity.*is_establishment.*referenced.*customers.*customer-establishment links.*sites.*employees/i
+  )
+  assert.equal(
+    organizationalUnitUpdate.responses['409'].$ref,
+    '#/components/responses/Conflict'
+  )
+})
+
 test('blocks deletion of domain records that still have dependents', () => {
   const customerDelete = paths['/customers/{customer}'].delete
   assert.match(
@@ -368,6 +435,39 @@ test('guard rejects widened lookup data', () => {
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /CustomerLookup/)
+})
+
+test('guard rejects weakened lookup, permission, and OU role invariants', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths[
+    '/lookups/establishments/{establishment}/customers'
+  ].get.description = 'Returns authorized customer options.'
+  candidate.paths[
+    '/lookups/establishments/{establishment}/customer-candidates'
+  ].get.description = 'Returns authorized customer options.'
+  candidate.paths['/customer-establishments'].post.description =
+    'Creates a customer-establishment link.'
+  candidate.paths[
+    '/customer-establishments/{customer_establishment}'
+  ].patch.description = 'Updates local contact data.'
+  candidate.paths[
+    '/customer-establishments/{customer_establishment}'
+  ].delete.description = 'Deletes a link when unused.'
+  candidate.paths[
+    '/organizational-units/{organizational_unit}'
+  ].patch.description = 'Updates an organizational unit.'
+  delete candidate.paths['/organizational-units/{organizational_unit}'].patch
+    .responses['409']
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET linked customer lookups/)
+  assert.match(result.stderr, /GET customer link candidates/)
+  assert.match(result.stderr, /POST customer-establishment links/)
+  assert.match(result.stderr, /PATCH customer-establishment links/)
+  assert.match(result.stderr, /DELETE customer-establishment links/)
+  assert.match(result.stderr, /PATCH organizational-unit roles/)
 })
 
 test('guard rejects distinguishable duplicate responses', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -43,10 +43,7 @@ test('accepts the repository domain contract', () => {
 })
 
 test('defines OU-free customer, site, and employee domain relationships', () => {
-  assert.deepEqual(
-    schemas.Customer.required.includes('legal_entity_id'),
-    true
-  )
+  assert.deepEqual(schemas.Customer.required.includes('legal_entity_id'), true)
   assert.deepEqual(
     schemas.Site.required.filter((field) =>
       ['customer_id', 'legal_entity_id', 'establishment_id'].includes(field)
@@ -121,7 +118,10 @@ test('defines minimal legal entity, establishment, and customer lookups', () => 
     'id',
     'name',
   ])
-  assert.deepEqual(Object.keys(schemas.CustomerLookup.properties), ['id', 'name'])
+  assert.deepEqual(Object.keys(schemas.CustomerLookup.properties), [
+    'id',
+    'name',
+  ])
 
   for (const schemaName of [
     'LegalEntityLookup',
@@ -217,9 +217,8 @@ test('documents accepted and rejected site and employee domain assignments', () 
 })
 
 test('documents tenant-consistent customer establishment links', () => {
-  const examples = schemas.CustomerEstablishmentCreateRequest[
-    'x-validation-examples'
-  ]
+  const examples =
+    schemas.CustomerEstablishmentCreateRequest['x-validation-examples']
 
   assert.ok(examples?.accepted?.length > 0)
   assert.ok(examples?.rejected?.length > 0)
@@ -232,7 +231,8 @@ test('keeps lookup eligibility and dependent relationship lifecycle rules explic
     /customers\.create.*sites\.create.*employees\.create/i
   )
   assert.match(
-    paths['/lookups/legal-entities/{legal_entity}/establishments'].get.description,
+    paths['/lookups/legal-entities/{legal_entity}/establishments'].get
+      .description,
     /same tenant, active, assignable, non-deleted/i
   )
   assert.match(paths['/sites'].post.description, /customer-establishment link/i)
@@ -314,28 +314,30 @@ test('separates customer link candidates from customers already linked for sites
 test('keeps lookup permissions aligned with every link and assignment workflow', () => {
   assert.match(
     paths['/lookups/legal-entities'].get.description,
-    /customers\.create.*customers\.update.*sites\.create.*employees\.create/i
+    /customers\.create.*customers\.update.*sites\.create.*sites\.update.*employees\.create.*employees\.update/i
   )
   assert.match(
     paths['/lookups/legal-entities/{legal_entity}/establishments'].get
       .description,
-    /customers\.update.*sites\.create.*employees\.create/i
+    /customers\.update.*sites\.create.*sites\.update.*employees\.create.*employees\.update/i
   )
   assert.match(
     paths['/lookups/establishments/{establishment}/customers'].get.description,
-    /sites\.create.*active, assignable, non-deleted establishment/i
+    /sites\.create.*sites\.update.*active, assignable, non-deleted establishment/i
   )
   assert.match(
-    paths[
-      '/lookups/establishments/{establishment}/customer-candidates'
-    ].get.description,
+    paths['/lookups/establishments/{establishment}/customer-candidates'].get
+      .description,
     /customers\.update.*active, assignable, non-deleted establishment/i
   )
 
-  const linkPath =
-    paths['/customer-establishments/{customer_establishment}']
+  const linkPath = paths['/customer-establishments/{customer_establishment}']
   assert.match(linkPath.patch.description, /customers\.update/i)
   assert.match(linkPath.delete.description, /customers\.update/i)
+  assert.match(
+    paths['/employees/{employee}'].patch.description,
+    /employees\.update/i
+  )
 })
 
 test('names link-management permission and blocks referenced OU role downgrades', () => {
@@ -357,6 +359,12 @@ test('names link-management permission and blocks referenced OU role downgrades'
 })
 
 test('blocks deletion of domain records that still have dependents', () => {
+  const customerUpdate = paths['/customers/{customer}'].patch
+  assert.equal(
+    customerUpdate.responses['409'].$ref,
+    '#/components/responses/Conflict'
+  )
+
   const customerDelete = paths['/customers/{customer}'].delete
   assert.match(
     customerDelete.description,
@@ -470,11 +478,69 @@ test('guard rejects weakened lookup, permission, and OU role invariants', () => 
   assert.match(result.stderr, /PATCH organizational-unit roles/)
 })
 
+test('guard derives lookup permissions and conflict responses from workflows', () => {
+  const candidate = structuredClone(contract)
+  for (const pathName of [
+    '/lookups/legal-entities',
+    '/lookups/legal-entities/{legal_entity}/establishments',
+  ]) {
+    candidate.paths[pathName].get.description = candidate.paths[
+      pathName
+    ].get.description.replace('`sites.update`, ', '')
+  }
+  candidate.paths[
+    '/lookups/establishments/{establishment}/customers'
+  ].get.description = candidate.paths[
+    '/lookups/establishments/{establishment}/customers'
+  ].get.description.replace(' or `sites.update`', '')
+  delete candidate.paths['/customers/{customer}'].patch.responses['409']
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET Legal Entity lookups.*sites\.update/)
+  assert.match(result.stderr, /GET establishment lookups.*sites\.update/)
+  assert.match(result.stderr, /GET linked customer lookups.*sites\.update/)
+  assert.match(
+    result.stderr,
+    /PATCH customer Legal Entity reassignment.*Conflict.*409/
+  )
+})
+
+test('guard rejects relationship-writing operations missing from the workflow model', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/sites/{site}/domain-copy'] = {
+    patch: {
+      description: 'Requires sites.update.',
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                establishment_id: { type: 'string', format: 'uuid' },
+              },
+            },
+          },
+        },
+      },
+      responses: {},
+    },
+  }
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(
+    result.stderr,
+    /PATCH \/sites\/\{site\}\/domain-copy.*workflow model/
+  )
+})
+
 test('guard rejects distinguishable duplicate responses', () => {
   const candidate = structuredClone(contract)
-  candidate.components.schemas.DuplicateResourceError.properties.message.enum = [
-    'This email address already exists.',
-  ]
+  candidate.components.schemas.DuplicateResourceError.properties.message.enum =
+    ['This email address already exists.']
 
   const result = runGuard(candidate)
 

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -493,19 +493,34 @@ test('documents tenant-consistent customer establishment links', () => {
 })
 
 test('keeps customer and site domain mutations outside OU entitlement', () => {
-  const createOperations = [
+  const domainMutations = [
     [paths['/customers'].post, 'customers.create'],
+    [paths['/customers/{customer}'].patch, 'customers.update'],
+    [paths['/customers/{customer}'].delete, 'customers.delete'],
     [paths['/customer-establishments'].post, 'customers.update'],
+    [
+      paths['/customer-establishments/{customer_establishment}'].patch,
+      'customers.update',
+    ],
+    [
+      paths['/customer-establishments/{customer_establishment}'].delete,
+      'customers.update',
+    ],
     [paths['/sites'].post, 'sites.create'],
+    [paths['/sites/{site}'].patch, 'sites.update'],
+    [paths['/sites/{site}'].delete, 'sites.delete'],
   ]
-  for (const [operation, permission] of createOperations) {
+  for (const [operation, permission] of domainMutations) {
     assert.match(
       operation.description,
       /OU scopes do not grant access to customer or site domain writes.*callers with any organizational scopes.*403/is
     )
     assert.match(
       operation.description,
-      new RegExp(permission.replace('.', '\\.'))
+      new RegExp(
+        'unscoped callers require `' + permission.replace('.', '\\.') + '`',
+        'i'
+      )
     )
     assert.doesNotMatch(operation.description, /organizational write access/i)
     assert.equal(
@@ -516,18 +531,16 @@ test('keeps customer and site domain mutations outside OU entitlement', () => {
 
   assert.match(
     paths['/customers/{customer}'].patch.description,
-    /legal_entity_id.*customers\.update.*organizational scopes.*403/is
+    /legal_entity_id.*same-tenant, active, non-deleted Legal Entity/is
   )
-  for (const description of [
-    paths['/sites/{site}'].patch.description,
+  assert.match(
     schemas.SiteUpdateRequest.description,
-  ]) {
-    assert.match(
-      description,
-      /domain relationship.*sites\.update.*organizational scopes.*403/is
-    )
-    assert.doesNotMatch(description, /organizational write access/i)
-  }
+    /resulting customer, Legal Entity, and establishment combination/is
+  )
+  assert.doesNotMatch(
+    schemas.SiteUpdateRequest.description,
+    /organizational scopes.*403/is
+  )
 })
 
 test('documents customer record read authorization without OU entitlement', () => {
@@ -748,7 +761,7 @@ test('enforces lookup eligibility when assignment UUIDs are submitted directly',
   )
   assert.match(
     schemas.SiteUpdateRequest.description,
-    /active, non-deleted customer.*active, non-deleted Legal Entity and establishment.*sites\.update.*organizational scopes.*403/is
+    /active, non-deleted customer.*active, non-deleted Legal Entity and establishment.*existing customer-establishment link/is
   )
 })
 
@@ -1124,16 +1137,61 @@ test('guard rejects OU-entitled customer and site record reads', () => {
 
 test('guard rejects OU-entitled customer or site domain mutations', () => {
   const candidate = structuredClone(contract)
-  candidate.paths['/customers'].post.description +=
+  const domainMutations = [
+    candidate.paths['/customers'].post,
+    candidate.paths['/customers/{customer}'].patch,
+    candidate.paths['/customers/{customer}'].delete,
+    candidate.paths['/customer-establishments'].post,
+    candidate.paths['/customer-establishments/{customer_establishment}'].patch,
+    candidate.paths['/customer-establishments/{customer_establishment}'].delete,
+    candidate.paths['/sites'].post,
+    candidate.paths['/sites/{site}'].patch,
+    candidate.paths['/sites/{site}'].delete,
+  ]
+  domainMutations[0].description +=
     ' Organizational write access also grants this write.'
-  candidate.paths['/sites/{site}'].patch.description +=
-    ' Domain reassignment also follows organizational write access.'
+  domainMutations[1].description = domainMutations[1].description.replace(
+    'unscoped callers require `customers.update`',
+    'unscoped callers require `customers.read`'
+  )
+  for (const operation of domainMutations.slice(2)) {
+    operation.description = operation.description.replace(
+      /OU scopes do not grant access to customer or site domain writes/i,
+      'OU scopes grant access to this domain write'
+    )
+  }
+  candidate.paths['/customers/{customer}/archive'] = {
+    post: {
+      operationId: 'archiveCustomer',
+      tags: ['Customers'],
+      description:
+        'Requires customers.update. Callers with organizational scopes receive 403.',
+      responses: {
+        403: { $ref: '#/components/responses/Forbidden' },
+      },
+    },
+  }
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /POST customer assignments/)
-  assert.match(result.stderr, /PATCH site assignment operation/)
+  for (const label of [
+    'POST customers',
+    'PATCH customers',
+    'DELETE customers',
+    'POST customer-establishment links',
+    'PATCH customer-establishment links',
+    'DELETE customer-establishment links',
+    'POST sites',
+    'PATCH sites',
+    'DELETE sites',
+  ]) {
+    assert.match(result.stderr, new RegExp(label))
+  }
+  assert.match(
+    result.stderr,
+    /POST \/customers\/\{customer\}\/archive.*no-OU domain mutation model/
+  )
 })
 
 test('guard rejects stale OU-based employee subresource access', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -14,23 +14,29 @@ import * as yaml from 'js-yaml'
 const contractPath = fileURLToPath(
   new URL('../docs/openapi.yaml', import.meta.url)
 )
+const changelogPath = fileURLToPath(new URL('../CHANGELOG.md', import.meta.url))
 const guardPath = fileURLToPath(
   new URL('./check-domain-contracts.mjs', import.meta.url)
 )
 const contractSource = readFileSync(contractPath, 'utf8')
+const changelogSource = readFileSync(changelogPath, 'utf8')
 const contract = yaml.load(contractSource)
 const schemas = contract.components.schemas
 const paths = contract.paths
 
-function runGuard(candidate) {
+function runGuard(candidate, candidateChangelog = changelogSource) {
   const directory = mkdtempSync(join(tmpdir(), 'domain-contracts-'))
   const candidatePath = join(directory, 'openapi.yaml')
+  const candidateChangelogPath = join(directory, 'CHANGELOG.md')
   writeFileSync(candidatePath, yaml.dump(candidate))
+  writeFileSync(candidateChangelogPath, candidateChangelog)
 
   try {
-    return spawnSync(process.execPath, [guardPath, candidatePath], {
-      encoding: 'utf8',
-    })
+    return spawnSync(
+      process.execPath,
+      [guardPath, candidatePath, candidateChangelogPath],
+      { encoding: 'utf8' }
+    )
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }
@@ -107,6 +113,46 @@ test('moves local customer data to a unique customer establishment contract', ()
   ]) {
     assert.ok(schemas.CustomerEstablishment.properties[property], property)
   }
+})
+
+test('limits customer-establishment uniqueness to the relationship pair', () => {
+  assert.deepEqual(schemas.CustomerEstablishment['x-unique-by'], [
+    'customer_id',
+    'establishment_id',
+  ])
+  assert.doesNotMatch(
+    paths['/customer-establishments'].post.description,
+    /local identifying data/i
+  )
+
+  const examples =
+    schemas.CustomerEstablishmentCreateRequest['x-uniqueness-examples']
+  const reusableContact = examples.accepted[0]
+  assert.notEqual(
+    reusableContact.existing.customer_id,
+    reusableContact.value.customer_id
+  )
+  assert.equal(reusableContact.existing.email, reusableContact.value.email)
+
+  const duplicatePair = examples.rejected[0]
+  assert.equal(
+    duplicatePair.existing.customer_id,
+    duplicatePair.value.customer_id
+  )
+  assert.equal(
+    duplicatePair.existing.establishment_id,
+    duplicatePair.value.establishment_id
+  )
+  assert.notEqual(duplicatePair.existing.email, duplicatePair.value.email)
+  assert.equal(duplicatePair.status, 409)
+})
+
+test('documents OU conflict changes without claiming administration is unchanged', () => {
+  assert.match(changelogSource, /role-downgraded or deleted.*conflict/is)
+  assert.doesNotMatch(
+    changelogSource,
+    /organizational-unit and scope administration contracts remain unchanged/i
+  )
 })
 
 test('defines minimal legal entity, establishment, and customer lookups', () => {
@@ -216,6 +262,46 @@ test('documents accepted and rejected site and employee domain assignments', () 
   }
 })
 
+test('documents evidence for every relationship-writing workflow', () => {
+  for (const schemaName of [
+    'CustomerCreateRequest',
+    'CustomerUpdateRequest',
+    'CustomerEstablishmentCreateRequest',
+    'SiteCreateRequest',
+    'SiteUpdateRequest',
+    'EmployeeCreateRequest',
+    'EmployeeUpdateRequest',
+  ]) {
+    const examples = schemas[schemaName]['x-validation-examples']
+    assert.ok(examples?.accepted?.length > 0, `${schemaName} accepted evidence`)
+    assert.ok(examples?.rejected?.length > 0, `${schemaName} rejected evidence`)
+  }
+
+  for (const [schemaName, relationshipFields] of [
+    ['CustomerUpdateRequest', ['legal_entity_id']],
+    [
+      'SiteUpdateRequest',
+      ['customer_id', 'legal_entity_id', 'establishment_id'],
+    ],
+    ['EmployeeUpdateRequest', ['legal_entity_id', 'establishment_id']],
+  ]) {
+    const examples = schemas[schemaName]['x-validation-examples']
+    for (const example of [examples.accepted[0], examples.rejected[0]]) {
+      assert.ok(
+        relationshipFields.some((field) => Object.hasOwn(example.value, field)),
+        `${schemaName} must mutate a relationship field`
+      )
+      assert.deepEqual(
+        relationshipFields.filter((field) =>
+          Object.hasOwn(example.resulting, field)
+        ),
+        relationshipFields,
+        `${schemaName} resulting state`
+      )
+    }
+  }
+})
+
 test('documents tenant-consistent customer establishment links', () => {
   const examples =
     schemas.CustomerEstablishmentCreateRequest['x-validation-examples']
@@ -223,6 +309,22 @@ test('documents tenant-consistent customer establishment links', () => {
   assert.ok(examples?.accepted?.length > 0)
   assert.ok(examples?.rejected?.length > 0)
   assert.equal(examples.rejected[0].status, 422)
+})
+
+test('documents customer-establishment read authorization consistently', () => {
+  for (const operation of [
+    paths['/customer-establishments'].get,
+    paths['/customer-establishments/{customer_establishment}'].get,
+  ]) {
+    assert.match(
+      operation.description,
+      /view access.*customer assignment.*organizational scope.*authorized/is
+    )
+    assert.equal(
+      operation.responses['403'].$ref,
+      '#/components/responses/Forbidden'
+    )
+  }
 })
 
 test('keeps lookup eligibility and dependent relationship lifecycle rules explicit', () => {
@@ -535,6 +637,56 @@ test('guard rejects relationship-writing operations missing from the workflow mo
     result.stderr,
     /PATCH \/sites\/\{site\}\/domain-copy.*workflow model/
   )
+})
+
+test('guard rejects widened relationship uniqueness and missing evidence', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.CustomerEstablishment['x-unique-by'].push(
+    'email'
+  )
+  delete candidate.components.schemas.CustomerEstablishmentCreateRequest[
+    'x-uniqueness-examples'
+  ]
+  candidate.paths['/customer-establishments'].post.description =
+    'Duplicate identification includes local identifying data.'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /CustomerEstablishment uniqueness/)
+})
+
+test('guard rejects changelog claims that contradict OU conflicts', () => {
+  const contradictoryChangelog = `${changelogSource}\nOrganizational-unit and scope administration contracts remain unchanged.\n`
+
+  const result = runGuard(contract, contradictoryChangelog)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /CHANGELOG OU lifecycle notes/)
+})
+
+test('guard rejects incomplete customer-establishment read authorization', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/customer-establishments'].get.description =
+    'Lists authorized assignments.'
+  delete candidate.paths['/customer-establishments/{customer_establishment}']
+    .get.responses['403']
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET customer-establishment collections/)
+  assert.match(result.stderr, /GET customer-establishment links/)
+})
+
+test('guard rejects missing assignment workflow evidence', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.schemas.SiteUpdateRequest['x-validation-examples']
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /PATCH site assignments.*workflow evidence/)
 })
 
 test('guard rejects distinguishable duplicate responses', () => {

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -45,7 +45,7 @@ const REQUIRED_OPERATIONS = [
   ['get', '/organizational-units/{organizational_unit}/ancestors'],
   ['post', '/organizational-units/{organizational_unit}/parent'],
   ['delete', '/organizational-units/{organizational_unit}/parent/{parent}'],
-  ['get', '/customers/legal-entities'],
+  ['get', '/lookups/legal-entities'],
 ]
 
 const target = process.argv[2]
@@ -107,7 +107,7 @@ const customerUpdateRequestBody =
   paths['/customers/{customer}']?.patch?.requestBody ?? {}
 const customerUpdateSchema =
   customerUpdateRequestBody?.content?.['application/json']?.schema ?? {}
-const customerLegalEntityLookup = schemas.CustomerLegalEntityLookup ?? {}
+const legalEntityLookup = schemas.LegalEntityLookup ?? {}
 const customerUpdateRequest = schemas.CustomerUpdateRequest ?? {}
 const organizationalUnit = schemas.OrganizationalUnit ?? {}
 const createRequest = schemas.OrganizationalUnitCreateRequest ?? {}
@@ -297,42 +297,36 @@ for (const [label, responseSchema] of [
 }
 
 const legalEntityLookupProperties = Object.keys(
-  customerLegalEntityLookup.properties ?? {}
+  legalEntityLookup.properties ?? {}
 )
 const legalEntityLookupAllowed = new Set(['id', 'name'])
 if (
-  customerLegalEntityLookup.type !== 'object' ||
-  customerLegalEntityLookup.additionalProperties !== false ||
+  legalEntityLookup.type !== 'object' ||
+  legalEntityLookup.additionalProperties !== false ||
   legalEntityLookupProperties.some(
     (property) => !legalEntityLookupAllowed.has(property)
   ) ||
-  !customerLegalEntityLookup.required?.includes('id') ||
-  !customerLegalEntityLookup.required?.includes('name') ||
-  customerLegalEntityLookup.properties?.id?.type !== 'string' ||
-  customerLegalEntityLookup.properties?.id?.format !== 'uuid' ||
-  customerLegalEntityLookup.properties?.name?.type !== 'string'
+  !legalEntityLookup.required?.includes('id') ||
+  !legalEntityLookup.required?.includes('name') ||
+  legalEntityLookup.properties?.id?.type !== 'string' ||
+  legalEntityLookup.properties?.id?.format !== 'uuid' ||
+  legalEntityLookup.properties?.name?.type !== 'string'
 ) {
   contractErrors.push(
-    'CustomerLegalEntityLookup must expose only required id and name fields.'
+    'LegalEntityLookup must expose only required id and name fields.'
   )
 }
 
-const customerLegalEntitiesResponse =
-  paths['/customers/legal-entities']?.get?.responses?.['200']?.content?.[
+const legalEntitiesResponse =
+  paths['/lookups/legal-entities']?.get?.responses?.['200']?.content?.[
     'application/json'
   ]?.schema
-const customerLegalEntitiesItems =
-  customerLegalEntitiesResponse?.properties?.data?.items
 if (
-  customerLegalEntitiesResponse?.type !== 'object' ||
-  customerLegalEntitiesResponse?.additionalProperties !== false ||
-  !customerLegalEntitiesResponse?.required?.includes('data') ||
-  customerLegalEntitiesResponse?.properties?.data?.type !== 'array' ||
-  customerLegalEntitiesItems?.$ref !==
-    '#/components/schemas/CustomerLegalEntityLookup'
+  legalEntitiesResponse?.$ref !==
+  '#/components/schemas/LegalEntityLookupCollectionResponse'
 ) {
   contractErrors.push(
-    'GET /customers/legal-entities must return data[] of CustomerLegalEntityLookup.'
+    'GET /lookups/legal-entities must return LegalEntityLookupCollectionResponse.'
   )
 }
 
@@ -406,7 +400,7 @@ const customerCreateDescription = paths['/customers']?.post?.description ?? ''
 const customerUpdateDescription =
   paths['/customers/{customer}']?.patch?.description ?? ''
 const legalEntitiesDescription =
-  paths['/customers/legal-entities']?.get?.description ?? ''
+  paths['/lookups/legal-entities']?.get?.description ?? ''
 const customerDescription = customer.description ?? ''
 const customerLegalEntityDescription =
   customer.properties?.legal_entity_id?.description ?? ''
@@ -418,7 +412,7 @@ for (const [label, description, requiredPermission] of [
     'customers.update',
   ],
   [
-    'GET /customers/legal-entities',
+    'GET /lookups/legal-entities',
     legalEntitiesDescription,
     'customers.create',
   ],

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -680,11 +680,11 @@ if (
 if (
   paths['/organizational-units/{organizational_unit}']?.delete?.responses?.[
     '409'
-  ]?.$ref !== '#/components/responses/OrganizationalUnitHasChildrenConflict' ||
-  responses.OrganizationalUnitHasChildrenConflict == null
+  ]?.$ref !== '#/components/responses/OrganizationalUnitDeletionConflict' ||
+  responses.OrganizationalUnitDeletionConflict == null
 ) {
   contractErrors.push(
-    'Organizational-unit deletion must document its child-conflict response shape.'
+    'Organizational-unit deletion must document its child and domain dependency conflict response shapes.'
   )
 }
 
@@ -703,7 +703,7 @@ const childConflictDescriptions = [
 ]
 if (
   !organizationalUnitDeleteDescription.includes('non-deleted direct child') ||
-  !responses.OrganizationalUnitHasChildrenConflict?.description
+  !responses.OrganizationalUnitDeletionConflict?.description
     ?.toLowerCase()
     .includes('non-deleted direct child') ||
   childConflictDescriptions.some(

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -396,38 +396,9 @@ for (const [schemaName, schema] of [
   }
 }
 
-const customerCreateDescription = paths['/customers']?.post?.description ?? ''
-const customerUpdateDescription =
-  paths['/customers/{customer}']?.patch?.description ?? ''
-const legalEntitiesDescription =
-  paths['/lookups/legal-entities']?.get?.description ?? ''
 const customerDescription = customer.description ?? ''
 const customerLegalEntityDescription =
   customer.properties?.legal_entity_id?.description ?? ''
-for (const [label, description, requiredPermission] of [
-  ['POST /customers', customerCreateDescription, 'customers.create'],
-  [
-    'PATCH /customers/{customer}',
-    customerUpdateDescription,
-    'customers.update',
-  ],
-  [
-    'GET /lookups/legal-entities',
-    legalEntitiesDescription,
-    'customers.create',
-  ],
-]) {
-  for (const requiredText of [
-    requiredPermission,
-    'same tenant',
-    'active, assignable, non-deleted Legal Entity',
-    'organizational write access',
-  ]) {
-    if (!description.includes(requiredText)) {
-      contractErrors.push(`${label} must document ${requiredText}.`)
-    }
-  }
-}
 
 for (const [label, description] of [
   ['Customer', customerDescription],
@@ -445,21 +416,14 @@ for (const [label, description] of [
   }
 }
 
-for (const relationship of [
-  'parent',
-  'children',
-  'ancestors',
-  'descendants',
-]) {
+for (const relationship of ['parent', 'children', 'ancestors', 'descendants']) {
   const property = organizationalUnit.properties?.[relationship]
   const reference =
     relationship === 'parent'
       ? property?.anyOf?.find((schema) => schema?.$ref)?.$ref
       : property?.items?.$ref
   const mustBeNullable = relationship === 'parent'
-  const isNullable = property?.anyOf?.some(
-    (schema) => schema?.type === 'null'
-  )
+  const isNullable = property?.anyOf?.some((schema) => schema?.type === 'null')
   if (
     reference !== '#/components/schemas/OrganizationalUnit' ||
     (mustBeNullable && !isNullable)
@@ -680,16 +644,17 @@ if (
 if (
   paths['/organizational-units/{organizational_unit}']?.delete?.responses?.[
     '409'
-  ]?.$ref !== '#/components/responses/OrganizationalUnitDeletionConflict' ||
-  responses.OrganizationalUnitDeletionConflict == null
+  ]?.$ref !== '#/components/responses/OrganizationalUnitHasChildrenConflict' ||
+  responses.OrganizationalUnitHasChildrenConflict == null
 ) {
   contractErrors.push(
-    'Organizational-unit deletion must document its child and domain dependency conflict response shapes.'
+    'Organizational-unit deletion must document its direct-child conflict response shape.'
   )
 }
 
 const organizationalUnitDeleteDescription =
-  paths['/organizational-units/{organizational_unit}']?.delete?.description ?? ''
+  paths['/organizational-units/{organizational_unit}']?.delete?.description ??
+  ''
 const organizationalUnitHierarchyDescriptions = [
   paths['/organizational-units/{organizational_unit}/descendants']?.get
     ?.description ?? '',
@@ -703,7 +668,7 @@ const childConflictDescriptions = [
 ]
 if (
   !organizationalUnitDeleteDescription.includes('non-deleted direct child') ||
-  !responses.OrganizationalUnitDeletionConflict?.description
+  !responses.OrganizationalUnitHasChildrenConflict?.description
     ?.toLowerCase()
     .includes('non-deleted direct child') ||
   childConflictDescriptions.some(
@@ -718,7 +683,8 @@ if (
 if (
   organizationalUnitHierarchyDescriptions.some(
     (description) =>
-      !description.includes('is_active') || !description.includes('is_assignable')
+      !description.includes('is_active') ||
+      !description.includes('is_assignable')
   )
 ) {
   contractErrors.push(

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -67,6 +67,18 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('rejects an OU deletion response without the direct-child conflict', () => {
+  const candidate = structuredClone(parsedContract)
+  candidate.paths[
+    '/organizational-units/{organizational_unit}'
+  ].delete.responses['409'].$ref = '#/components/responses/Conflict'
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /direct-child conflict response/i)
+})
+
 test('defines organizational-unit filters as booleans', () => {
   for (const name of ['is_active', 'is_assignable']) {
     const parameter = organizationalUnitListParameter(
@@ -152,10 +164,7 @@ test('accepts additional organizational-unit wire examples with allowed values',
       candidate.paths['/organizational-units'].get.parameters,
       name
     )
-    const wireExamples = organizationalUnitWireExamples(
-      parameter,
-      name
-    )
+    const wireExamples = organizationalUnitWireExamples(parameter, name)
     wireExamples.additional_text_true = { value: 'true' }
   }
 
@@ -171,10 +180,7 @@ test('rejects organizational-unit boolean filters with unrelated wire values', (
       candidate.paths['/organizational-units'].get.parameters,
       name
     )
-    const wireExamples = organizationalUnitWireExamples(
-      parameter,
-      name
-    )
+    const wireExamples = organizationalUnitWireExamples(parameter, name)
     wireExamples.unsupported = { value: 'yes' }
 
     const result = runGuard(yaml.dump(candidate))

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -186,7 +186,7 @@ test('rejects organizational-unit boolean filters with unrelated wire values', (
 test('accepts schema-valid nullable example fields', () => {
   const candidate = contract.replaceAll(
     '              name: ACME Corporation GmbH\n',
-    '              name: ACME Corporation GmbH\n              contact: null\n'
+    '              name: ACME Corporation GmbH\n              vat_id: null\n'
   )
   const result = runGuard(candidate)
 


### PR DESCRIPTION
# Reproduced defects

- The customer/site no-OU authorization test failed because the contract restricted only creates and relationship reassignments; ordinary customer/site updates and customer-establishment update/delete operations remained open to OU-scoped callers. The complete mutation matrix also exposed the same missing boundary on customer and site deletion.
- The employee-creation activity example still exposed the employee name through `subject.name` after personal-name attributes had been removed.
- Employee Qualification mutations and the Employee Document family still documented obsolete OU-scoped access after the domain migration.
- The first full validation run failed because the older verified-endpoint guard still required the superseded OU-backed Legal Entity model, including `is_assignable` and domain-dependent OU deletion conflicts.
- Cross-workspace comparison reproduced additional contract drift in collection filters, nullable create inputs, response fields, read authorization, and effective employee permission names.

## Change

- remove personal names from the complete employee-creation audit example and guard the full activity payload
- model every Employee Qualification and Employee Document operation with explicit self-service exceptions, dedicated permissions, fail-closed OU boundaries, and closed operation-family discovery
- align Legal Entity and establishment lifecycle rules with the current tenant-local domain model instead of OU role and assignability flags
- align customer, site, and employee filters, nullable create inputs, response counts, read authorization, and employee permission names with the linked API implementation
- keep all nine Customer, CustomerEstablishment, and Site create/update/delete operations outside OU entitlement, bind each unscoped path to its effective permission, and discover future tagged domain mutations automatically
- restore the direct-child-only organizational-unit deletion conflict and remove duplicate domain-policy ownership from the verified-endpoint guard
- update the changelog and add positive and negative regression coverage for each corrected invariant

## Validation

- `npm run validate` passes with 103 tests, Redocly validation, verified-endpoint checks, domain-contract checks, and repository-wide formatting
- `reuse lint` passes with 59 of 59 files compliant
- the signed push preflight passes formatting, REUSE, domain policy, dependency audit, lint, and contract validation
- the pushed head is `d8d548d6947f2da532c4754fc3379cb8b33c4bf3`; CodeQL JavaScript/Python and OpenAPI CI checks are still running, while no current check is failing
- the pushed-head PR review reports zero unresolved review threads

## Linked follow-up

- The linked SecPal/frontend, SecPal/api, and SecPal/android workspaces still need to complete their consumer alignment before this contract can be integrated across repositories.
- Existing out-of-scope findings are tracked in SecPal/contracts #379 through #383 and SecPal/api #1333 through #1337; no untracked follow-up remains from this review.
- The repository's approved large-PR override remains active for this already oversized branch, and the PR-size check passes.
