### PR TITLE
fix: align Customer establishment embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the `Customer` response schema with US-003 by requiring the always-present
+  `customer_establishments` array of local-contact customer-establishment assignments.
+  Customer list and detail response examples now demonstrate the embedded relationship,
+  including its OU-free shape (closes #376).
 - Indented the documented merge-conflict marker example so the pre-commit
   conflict check continues to catch real unindented markers during a merge
   without failing on its own documentation, and added regression coverage for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Aligned the `Customer` response schema with US-003 by requiring the always-present
   `customer_establishments` array of local-contact customer-establishment assignments.
-  Customer list and detail response examples now demonstrate the embedded relationship,
-  including its OU-free shape (closes #376).
+  Customer list and detail response examples now demonstrate both populated and empty
+  caller-visible embeddings, including site-assignment filtering and their OU-free shape
+  (closes #376).
 - Indented the documented merge-conflict marker example so the pre-commit
   conflict check continues to catch real unindented markers during a merge
   without failing on its own documentation, and added regression coverage for

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5407,6 +5407,7 @@ components:
         - name
         - billing_address
         - is_active
+        - customer_establishments
         - created_at
         - updated_at
       properties:
@@ -5448,6 +5449,11 @@ components:
           type: integer
           minimum: 0
           description: Number of the customer's sites visible to the current caller. Present on customer list and detail responses.
+        customer_establishments:
+          type: array
+          description: Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments. No organizational-unit relationships are exposed.
+          items:
+            $ref: '#/components/schemas/CustomerEstablishment'
         created_at:
           allOf:
             - $ref: '#/components/schemas/ApiTimestamp'
@@ -10012,6 +10018,37 @@ paths:
                       $ref: '#/components/schemas/Customer'
                   meta:
                     $ref: '#/components/schemas/PaginationMeta'
+              examples:
+                withCustomerEstablishment:
+                  summary: Customer with an embedded establishment assignment
+                  value:
+                    data:
+                      - id: '550e8400-e29b-41d4-a716-446655440000'
+                        customer_number: 'KD-2025-0001'
+                        legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+                        name: 'ACME Corporation GmbH'
+                        billing_address:
+                          street: Hauptstraße 123
+                          city: Berlin
+                          postal_code: '10115'
+                          country: DE
+                        is_active: true
+                        customer_establishments:
+                          - id: '790e8400-e29b-41d4-a716-446655440000'
+                            customer_id: '550e8400-e29b-41d4-a716-446655440000'
+                            establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+                            contact_name: Max Mustermann
+                            phone: '+49 30 12345678'
+                            email: 'max.mustermann@secpal.dev'
+                            comments: Use the service entrance after 18:00.
+                            created_at: '2025-12-05T10:00:00Z'
+                            updated_at: '2025-12-15T14:30:00Z'
+                        created_at: '2025-12-05T10:00:00Z'
+                        updated_at: '2025-12-15T14:30:00Z'
+                    meta:
+                      current_page: 1
+                      per_page: 15
+                      total: 1
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -10380,6 +10417,33 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/Customer'
+              examples:
+                withCustomerEstablishment:
+                  summary: Customer with an embedded establishment assignment
+                  value:
+                    data:
+                      id: '550e8400-e29b-41d4-a716-446655440000'
+                      customer_number: 'KD-2025-0001'
+                      legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+                      name: 'ACME Corporation GmbH'
+                      billing_address:
+                        street: Hauptstraße 123
+                        city: Berlin
+                        postal_code: '10115'
+                        country: DE
+                      is_active: true
+                      customer_establishments:
+                        - id: '790e8400-e29b-41d4-a716-446655440000'
+                          customer_id: '550e8400-e29b-41d4-a716-446655440000'
+                          establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+                          contact_name: Max Mustermann
+                          phone: '+49 30 12345678'
+                          email: 'max.mustermann@secpal.dev'
+                          comments: Use the service entrance after 18:00.
+                          created_at: '2025-12-05T10:00:00Z'
+                          updated_at: '2025-12-15T14:30:00Z'
+                      created_at: '2025-12-05T10:00:00Z'
+                      updated_at: '2025-12-15T14:30:00Z'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10033,6 +10033,7 @@ paths:
                           postal_code: '10115'
                           country: DE
                         is_active: true
+                        sites_count: 2
                         customer_establishments:
                           - id: '790e8400-e29b-41d4-a716-446655440000'
                             customer_id: '550e8400-e29b-41d4-a716-446655440000'
@@ -10063,6 +10064,7 @@ paths:
                           postal_code: '10117'
                           country: DE
                         is_active: true
+                        sites_count: 0
                         customer_establishments: []
                         created_at: '2025-12-05T10:00:00Z'
                         updated_at: '2025-12-15T14:30:00Z'
@@ -10453,6 +10455,7 @@ paths:
                         postal_code: '10115'
                         country: DE
                       is_active: true
+                      sites_count: 2
                       customer_establishments:
                         - id: '790e8400-e29b-41d4-a716-446655440000'
                           customer_id: '550e8400-e29b-41d4-a716-446655440000'
@@ -10479,6 +10482,7 @@ paths:
                         postal_code: '10117'
                         country: DE
                       is_active: true
+                      sites_count: 0
                       customer_establishments: []
                       created_at: '2025-12-05T10:00:00Z'
                       updated_at: '2025-12-15T14:30:00Z'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5451,7 +5451,7 @@ components:
           description: Number of the customer's sites visible to the current caller. Present on customer list and detail responses.
         customer_establishments:
           type: array
-          description: Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments. No organizational-unit relationships are exposed.
+          description: Customer-to-establishment assignments with local contact data that are visible to the current caller. Always present; empty when the customer has no visible assignments. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.
           items:
             $ref: '#/components/schemas/CustomerEstablishment'
         created_at:
@@ -10049,6 +10049,27 @@ paths:
                       current_page: 1
                       per_page: 15
                       total: 1
+                withoutCustomerEstablishments:
+                  summary: Customer without a caller-visible establishment assignment
+                  value:
+                    data:
+                      - id: '550e8400-e29b-41d4-a716-446655440001'
+                        customer_number: 'KD-2025-0002'
+                        legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+                        name: 'Example Services GmbH'
+                        billing_address:
+                          street: Nebenstraße 5
+                          city: Berlin
+                          postal_code: '10117'
+                          country: DE
+                        is_active: true
+                        customer_establishments: []
+                        created_at: '2025-12-05T10:00:00Z'
+                        updated_at: '2025-12-15T14:30:00Z'
+                    meta:
+                      current_page: 1
+                      per_page: 15
+                      total: 1
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -10442,6 +10463,23 @@ paths:
                           comments: Use the service entrance after 18:00.
                           created_at: '2025-12-05T10:00:00Z'
                           updated_at: '2025-12-15T14:30:00Z'
+                      created_at: '2025-12-05T10:00:00Z'
+                      updated_at: '2025-12-15T14:30:00Z'
+                withoutCustomerEstablishments:
+                  summary: Customer without a caller-visible establishment assignment
+                  value:
+                    data:
+                      id: '550e8400-e29b-41d4-a716-446655440001'
+                      customer_number: 'KD-2025-0002'
+                      legal_entity_id: '770e8400-e29b-41d4-a716-446655440000'
+                      name: 'Example Services GmbH'
+                      billing_address:
+                        street: Nebenstraße 5
+                        city: Berlin
+                        postal_code: '10117'
+                        country: DE
+                      is_active: true
+                      customer_establishments: []
                       created_at: '2025-12-05T10:00:00Z'
                       updated_at: '2025-12-15T14:30:00Z'
         '401':

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -444,6 +444,7 @@ const customerAllowedProperties = new Set([
   'billing_address',
   'is_active',
   'sites_count',
+  'customer_establishments',
   'created_at',
   'updated_at',
   'deleted_at',
@@ -467,6 +468,52 @@ if (
   errors.push(
     'Customer.sites_count must remain an optional non-negative visible-site count.'
   )
+}
+
+const customerEstablishments =
+  schemas.Customer?.properties?.customer_establishments
+if (
+  customerEstablishments?.type !== 'array' ||
+  customerEstablishments?.items?.$ref !==
+    '#/components/schemas/CustomerEstablishment' ||
+  !schemas.Customer?.required?.includes('customer_establishments') ||
+  !/always present.*empty/i.test(customerEstablishments?.description ?? '')
+) {
+  errors.push(
+    'Customer.customer_establishments must be a required, always-present CustomerEstablishment array.'
+  )
+}
+
+for (const [label, response] of [
+  [
+    'GET /customers',
+    paths['/customers']?.get?.responses?.['200']?.content?.[
+      'application/json'
+    ],
+  ],
+  [
+    'GET /customers/{customer}',
+    paths['/customers/{customer}']?.get?.responses?.['200']?.content?.[
+      'application/json'
+    ],
+  ],
+]) {
+  const data = response?.examples?.withCustomerEstablishment?.value?.data
+  const customer = Array.isArray(data) ? data[0] : data
+  const assignment = customer?.customer_establishments?.[0]
+
+  if (
+    !Array.isArray(customer?.customer_establishments) ||
+    !uuidValue(assignment?.id) ||
+    !uuidValue(assignment?.customer_id) ||
+    !uuidValue(assignment?.establishment_id) ||
+    Object.hasOwn(assignment ?? {}, 'organizational_unit_id') ||
+    Object.hasOwn(assignment ?? {}, 'organizational_unit')
+  ) {
+    errors.push(
+      `${label} must include an OU-free customer_establishments response example.`
+    )
+  }
 }
 
 const customerGet = paths['/customers/{customer}']?.get

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -500,9 +500,7 @@ if (
 for (const [label, response] of [
   [
     'GET /customers',
-    paths['/customers']?.get?.responses?.['200']?.content?.[
-      'application/json'
-    ],
+    paths['/customers']?.get?.responses?.['200']?.content?.['application/json'],
   ],
   [
     'GET /customers/{customer}',
@@ -517,6 +515,8 @@ for (const [label, response] of [
     customers.length > 0 &&
     customers.every(
       (customer) =>
+        Number.isInteger(customer?.sites_count) &&
+        customer.sites_count >= 0 &&
         Array.isArray(customer?.customer_establishments) &&
         customer.customer_establishments.length > 0 &&
         customer.customer_establishments.every(
@@ -524,6 +524,7 @@ for (const [label, response] of [
             uuidValue(assignment?.id) &&
             uuidValue(assignment?.customer_id) &&
             uuidValue(assignment?.establishment_id) &&
+            assignment.customer_id === customer.id &&
             !Object.hasOwn(assignment, 'organizational_unit_id') &&
             !Object.hasOwn(assignment, 'organizational_unit')
         )
@@ -531,7 +532,7 @@ for (const [label, response] of [
 
   if (!hasValidAssignments) {
     errors.push(
-      `${label} must include an OU-free customer_establishments response example.`
+      `${label} must include a non-negative sites_count and OU-free customer_establishments with matching customer_id values.`
     )
   }
 
@@ -544,12 +545,14 @@ for (const [label, response] of [
     customersWithoutAssignments.length === 0 ||
     customersWithoutAssignments.some(
       (customer) =>
+        !Number.isInteger(customer?.sites_count) ||
+        customer.sites_count < 0 ||
         !Array.isArray(customer?.customer_establishments) ||
         customer.customer_establishments.length !== 0
     )
   ) {
     errors.push(
-      `${label} must include an empty customer_establishments response example.`
+      `${label} must include a non-negative sites_count and an empty customer_establishments response example.`
     )
   }
 }

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -484,6 +484,19 @@ if (
   )
 }
 
+if (
+  !/visible to the current caller/i.test(
+    customerEstablishments?.description ?? ''
+  ) ||
+  !/site-only access.*active site assignments/i.test(
+    customerEstablishments?.description ?? ''
+  )
+) {
+  errors.push(
+    'Customer must preserve caller-visible customer_establishments filtering for customer and site assignments.'
+  )
+}
+
 for (const [label, response] of [
   [
     'GET /customers',
@@ -499,19 +512,44 @@ for (const [label, response] of [
   ],
 ]) {
   const data = response?.examples?.withCustomerEstablishment?.value?.data
-  const customer = Array.isArray(data) ? data[0] : data
-  const assignment = customer?.customer_establishments?.[0]
+  const customers = Array.isArray(data) ? data : [data]
+  const hasValidAssignments =
+    customers.length > 0 &&
+    customers.every(
+      (customer) =>
+        Array.isArray(customer?.customer_establishments) &&
+        customer.customer_establishments.length > 0 &&
+        customer.customer_establishments.every(
+          (assignment) =>
+            uuidValue(assignment?.id) &&
+            uuidValue(assignment?.customer_id) &&
+            uuidValue(assignment?.establishment_id) &&
+            !Object.hasOwn(assignment, 'organizational_unit_id') &&
+            !Object.hasOwn(assignment, 'organizational_unit')
+        )
+    )
 
-  if (
-    !Array.isArray(customer?.customer_establishments) ||
-    !uuidValue(assignment?.id) ||
-    !uuidValue(assignment?.customer_id) ||
-    !uuidValue(assignment?.establishment_id) ||
-    Object.hasOwn(assignment ?? {}, 'organizational_unit_id') ||
-    Object.hasOwn(assignment ?? {}, 'organizational_unit')
-  ) {
+  if (!hasValidAssignments) {
     errors.push(
       `${label} must include an OU-free customer_establishments response example.`
+    )
+  }
+
+  const emptyData =
+    response?.examples?.withoutCustomerEstablishments?.value?.data
+  const customersWithoutAssignments = Array.isArray(emptyData)
+    ? emptyData
+    : [emptyData]
+  if (
+    customersWithoutAssignments.length === 0 ||
+    customersWithoutAssignments.some(
+      (customer) =>
+        !Array.isArray(customer?.customer_establishments) ||
+        customer.customer_establishments.length !== 0
+    )
+  ) {
+    errors.push(
+      `${label} must include an empty customer_establishments response example.`
     )
   }
 }

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -234,6 +234,19 @@ test('moves local customer data to a unique customer establishment contract', ()
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'contact'), false)
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'notes'), false)
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'metadata'), false)
+  assert.equal(
+    schemas.Customer.required.includes('customer_establishments'),
+    true,
+    'customer responses must always include customer_establishments, including when empty'
+  )
+  assert.deepEqual(schemas.Customer.properties.customer_establishments, {
+    type: 'array',
+    description:
+      'Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments. No organizational-unit relationships are exposed.',
+    items: {
+      $ref: '#/components/schemas/CustomerEstablishment',
+    },
+  })
 
   assert.deepEqual(schemas.CustomerEstablishment.required, [
     'id',
@@ -255,6 +268,31 @@ test('moves local customer data to a unique customer establishment contract', ()
     'comments',
   ]) {
     assert.ok(schemas.CustomerEstablishment.properties[property], property)
+  }
+})
+
+test('documents embedded customer-establishment assignments in customer responses', () => {
+  const listResponse = paths['/customers'].get.responses['200'].content[
+    'application/json'
+  ]
+  const detailResponse = paths['/customers/{customer}'].get.responses['200']
+    .content['application/json']
+
+  for (const response of [listResponse, detailResponse]) {
+    const customer = response.examples.withCustomerEstablishment.value.data
+    const customers = Array.isArray(customer) ? customer : [customer]
+
+    for (const item of customers) {
+      assert.ok(Array.isArray(item.customer_establishments))
+      assert.equal(
+        Object.hasOwn(item.customer_establishments[0], 'organizational_unit_id'),
+        false
+      )
+      assert.equal(
+        Object.hasOwn(item.customer_establishments[0], 'organizational_unit'),
+        false
+      )
+    }
   }
 })
 

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -277,26 +277,33 @@ test('documents embedded customer-establishment assignments in customer response
     /visible to the current caller.*site-only access.*active site assignments/is
   )
 
-  const listResponse = paths['/customers'].get.responses['200'].content[
-    'application/json'
-  ]
-  const detailResponse = paths['/customers/{customer}'].get.responses['200']
-    .content['application/json']
+  const listResponse =
+    paths['/customers'].get.responses['200'].content['application/json']
+  const detailResponse =
+    paths['/customers/{customer}'].get.responses['200'].content[
+      'application/json'
+    ]
 
   for (const response of [listResponse, detailResponse]) {
     const customer = response.examples.withCustomerEstablishment.value.data
     const customers = Array.isArray(customer) ? customer : [customer]
 
     for (const item of customers) {
+      assert.equal(Number.isInteger(item.sites_count), true)
+      assert.ok(item.sites_count >= 0)
       assert.ok(Array.isArray(item.customer_establishments))
       assert.equal(
-        Object.hasOwn(item.customer_establishments[0], 'organizational_unit_id'),
+        Object.hasOwn(
+          item.customer_establishments[0],
+          'organizational_unit_id'
+        ),
         false
       )
       assert.equal(
         Object.hasOwn(item.customer_establishments[0], 'organizational_unit'),
         false
       )
+      assert.equal(item.customer_establishments[0].customer_id, item.id)
     }
 
     const customerWithoutAssignments =
@@ -308,6 +315,8 @@ test('documents embedded customer-establishment assignments in customer response
       : [customerWithoutAssignments]
 
     for (const item of customersWithoutAssignments) {
+      assert.equal(Number.isInteger(item.sites_count), true)
+      assert.ok(item.sites_count >= 0)
       assert.deepEqual(item.customer_establishments, [])
     }
   }
@@ -1361,6 +1370,24 @@ test('guard rejects weakened customer-establishment embedding visibility or empt
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /caller-visible customer_establishments/)
   assert.match(result.stderr, /empty customer_establishments response example/)
+})
+
+test('guard rejects customer examples with invalid site counts or foreign assignments', () => {
+  const candidate = structuredClone(contract)
+  const listCustomer =
+    candidate.paths['/customers'].get.responses['200'].content[
+      'application/json'
+    ].examples.withCustomerEstablishment.value.data[0]
+
+  listCustomer.sites_count = -1
+  listCustomer.customer_establishments[0].customer_id =
+    '550e8400-e29b-41d4-a716-446655440001'
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /non-negative sites_count/)
+  assert.match(result.stderr, /matching customer_id/)
 })
 
 test('guard rejects unapproved contact example domains', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -242,7 +242,7 @@ test('moves local customer data to a unique customer establishment contract', ()
   assert.deepEqual(schemas.Customer.properties.customer_establishments, {
     type: 'array',
     description:
-      'Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments. No organizational-unit relationships are exposed.',
+      "Customer-to-establishment assignments with local contact data that are visible to the current caller. Always present; empty when the customer has no visible assignments. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.",
     items: {
       $ref: '#/components/schemas/CustomerEstablishment',
     },
@@ -272,6 +272,11 @@ test('moves local customer data to a unique customer establishment contract', ()
 })
 
 test('documents embedded customer-establishment assignments in customer responses', () => {
+  assert.match(
+    schemas.Customer.properties.customer_establishments.description,
+    /visible to the current caller.*site-only access.*active site assignments/is
+  )
+
   const listResponse = paths['/customers'].get.responses['200'].content[
     'application/json'
   ]
@@ -292,6 +297,18 @@ test('documents embedded customer-establishment assignments in customer response
         Object.hasOwn(item.customer_establishments[0], 'organizational_unit'),
         false
       )
+    }
+
+    const customerWithoutAssignments =
+      response.examples.withoutCustomerEstablishments.value.data
+    const customersWithoutAssignments = Array.isArray(
+      customerWithoutAssignments
+    )
+      ? customerWithoutAssignments
+      : [customerWithoutAssignments]
+
+    for (const item of customersWithoutAssignments) {
+      assert.deepEqual(item.customer_establishments, [])
     }
   }
 })
@@ -1326,6 +1343,24 @@ test('guard rejects a closed customer response without its visible site count', 
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /Customer\.sites_count/)
+})
+
+test('guard rejects weakened customer-establishment embedding visibility or empty-array evidence', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.Customer.properties.customer_establishments.description =
+    'Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments.'
+  delete candidate.paths['/customers'].get.responses['200'].content[
+    'application/json'
+  ].examples.withoutCustomerEstablishments
+  delete candidate.paths['/customers/{customer}'].get.responses['200'].content[
+    'application/json'
+  ].examples.withoutCustomerEstablishments
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /caller-visible customer_establishments/)
+  assert.match(result.stderr, /empty customer_establishments response example/)
 })
 
 test('guard rejects unapproved contact example domains', () => {


### PR DESCRIPTION
## Reproduced defect

The customer contract rejected valid US-003 responses: `Customer` was closed with `additionalProperties: false`, yet it did not declare the returned `customer_establishments` field. The new regression assertion first failed because the field was absent, then passes with the aligned schema.

Closes #376.

## Change summary

- Require `Customer.customer_establishments` as an array of `CustomerEstablishment` records and document that it is always present, including as an empty array.
- Add customer list and detail response examples with local contact data and no organizational-unit fields.
- Extend the domain contract guard and regression tests to preserve the response shape and OU-free examples.
- Record the contract correction in `CHANGELOG.md`.

## Validation

- `npm run validate`
- `reuse lint`
- `git diff --check`
- Signed commit verified locally.

## Follow-up before ready for review

No unresolved local checks or out-of-scope findings. CI checks are queued or in progress and must pass before this draft can be marked ready. The linked SecPal/api and SecPal/frontend workspaces were not changed by this contracts-only PR. Keep this PR as a draft until the final PR-view self-review is complete.
