### PR TITLE
fix: align Employee activity example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced the unsupported Employee access activity example with the runtime
+  `employee_changes` update event and added contract validation that rejects
+  unsupported categories/events and personal-name values in that example
+  (closes #379).
 - Aligned the `Customer` response schema with US-003 by requiring the always-present
   `customer_establishments` array of local-contact customer-establishment assignments.
   Customer list and detail response examples now demonstrate both populated and empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Replaced the unsupported Employee access activity example with the runtime
-  `employee_changes` update event and added contract validation that rejects
-  unsupported categories/events and personal-name values in that example
-  (closes #379).
+  `employee_changes` update event and its metadata-free API representation.
+  Contract validation rejects unsupported categories/events, automatic diffs
+  misplaced in caller-supplied properties, and personal-name values in that
+  example (closes #379).
 - Aligned the `Customer` response schema with US-003 by requiring the always-present
   `customer_establishments` array of local-contact customer-establishment assignments.
   Customer list and detail response examples now demonstrate both populated and empty

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8156,11 +8156,7 @@ paths:
                         causer_type: App\Models\User
                         causer_id: 550e8400-e29b-41d4-a716-446655440022
                         event: updated
-                        properties:
-                          attributes:
-                            status: active
-                          old:
-                            status: inactive
+                        properties: null
                         ip_address: 198.51.100.10
                         user_agent: curl/8.8.0
                         batch_uuid: 550e8400-e29b-41d4-a716-446655440101

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8149,14 +8149,18 @@ paths:
                         updated_at: '2025-01-15T11:00:00Z'
                       - id: 550e8400-e29b-41d4-a716-446655440003
                         tenant_id: 550e8400-e29b-41d4-a716-446655440000
-                        log_name: employee
-                        description: Viewed Employee "Jane Smith"
+                        log_name: employee_changes
+                        description: updated
                         subject_type: App\Models\Employee
                         subject_id: 550e8400-e29b-41d4-a716-446655440011
                         causer_type: App\Models\User
                         causer_id: 550e8400-e29b-41d4-a716-446655440022
-                        event: accessed
-                        properties: {} # yamllint disable-line rule:braces
+                        event: updated
+                        properties:
+                          attributes:
+                            status: active
+                          old:
+                            status: inactive
                         ip_address: 198.51.100.10
                         user_agent: curl/8.8.0
                         batch_uuid: 550e8400-e29b-41d4-a716-446655440101

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -617,6 +617,33 @@ if (
   )
 }
 
+const paginatedEmployeeUpdateActivity =
+  paths['/activity-logs']?.get?.responses?.['200']?.content[
+    'application/json'
+  ]?.examples?.paginatedResponse?.value?.data?.[2]
+const employeeUpdateAttributes =
+  paginatedEmployeeUpdateActivity?.properties?.attributes ?? {}
+const employeeUpdateOldValues =
+  paginatedEmployeeUpdateActivity?.properties?.old ?? {}
+if (
+  paginatedEmployeeUpdateActivity?.subject_type !== 'App\\Models\\Employee' ||
+  paginatedEmployeeUpdateActivity.log_name !== 'employee_changes' ||
+  paginatedEmployeeUpdateActivity.description !== 'updated' ||
+  paginatedEmployeeUpdateActivity.event !== 'updated' ||
+  employeeUpdateAttributes.status !== 'active' ||
+  employeeUpdateOldValues.status !== 'inactive' ||
+  paginatedEmployeeUpdateActivity.subject?.name != null ||
+  forbiddenEmployeeAuditFields.some(
+    (field) =>
+      Object.hasOwn(employeeUpdateAttributes, field) ||
+      Object.hasOwn(employeeUpdateOldValues, field)
+  )
+) {
+  errors.push(
+    'Paginated employee activity examples must document the supported employee_changes update event and exclude personal-name values.'
+  )
+}
+
 requireUuid('Customer', 'legal_entity_id', true)
 requireUuid('CustomerCreateRequest', 'legal_entity_id', true)
 requireUuid('CustomerUpdateRequest', 'legal_entity_id', false)

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -618,16 +618,20 @@ if (
 }
 
 const paginatedEmployeeUpdateActivity =
-  paths['/activity-logs']?.get?.responses?.['200']?.content[
+  paths['/activity-logs']?.get?.responses?.['200']?.content?.[
     'application/json'
   ]?.examples?.paginatedResponse?.value?.data?.[2]
+const paginatedEmployeeUpdateSubject =
+  paginatedEmployeeUpdateActivity?.subject ?? {}
 if (
   paginatedEmployeeUpdateActivity?.subject_type !== 'App\\Models\\Employee' ||
-  paginatedEmployeeUpdateActivity.log_name !== 'employee_changes' ||
-  paginatedEmployeeUpdateActivity.description !== 'updated' ||
-  paginatedEmployeeUpdateActivity.event !== 'updated' ||
-  paginatedEmployeeUpdateActivity.properties !== null ||
-  paginatedEmployeeUpdateActivity.subject?.name != null
+  paginatedEmployeeUpdateActivity?.log_name !== 'employee_changes' ||
+  paginatedEmployeeUpdateActivity?.description !== 'updated' ||
+  paginatedEmployeeUpdateActivity?.event !== 'updated' ||
+  paginatedEmployeeUpdateActivity?.properties !== null ||
+  forbiddenEmployeeAuditFields.some((field) =>
+    Object.hasOwn(paginatedEmployeeUpdateSubject, field)
+  )
 ) {
   errors.push(
     'Paginated employee activity examples must document the supported employee_changes update event with metadata-free properties and exclude personal-name values.'

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -621,26 +621,16 @@ const paginatedEmployeeUpdateActivity =
   paths['/activity-logs']?.get?.responses?.['200']?.content[
     'application/json'
   ]?.examples?.paginatedResponse?.value?.data?.[2]
-const employeeUpdateAttributes =
-  paginatedEmployeeUpdateActivity?.properties?.attributes ?? {}
-const employeeUpdateOldValues =
-  paginatedEmployeeUpdateActivity?.properties?.old ?? {}
 if (
   paginatedEmployeeUpdateActivity?.subject_type !== 'App\\Models\\Employee' ||
   paginatedEmployeeUpdateActivity.log_name !== 'employee_changes' ||
   paginatedEmployeeUpdateActivity.description !== 'updated' ||
   paginatedEmployeeUpdateActivity.event !== 'updated' ||
-  employeeUpdateAttributes.status !== 'active' ||
-  employeeUpdateOldValues.status !== 'inactive' ||
-  paginatedEmployeeUpdateActivity.subject?.name != null ||
-  forbiddenEmployeeAuditFields.some(
-    (field) =>
-      Object.hasOwn(employeeUpdateAttributes, field) ||
-      Object.hasOwn(employeeUpdateOldValues, field)
-  )
+  paginatedEmployeeUpdateActivity.properties !== null ||
+  paginatedEmployeeUpdateActivity.subject?.name != null
 ) {
   errors.push(
-    'Paginated employee activity examples must document the supported employee_changes update event and exclude personal-name values.'
+    'Paginated employee activity examples must document the supported employee_changes update event with metadata-free properties and exclude personal-name values.'
   )
 }
 

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -270,6 +270,18 @@ test('guard rejects unsupported or privacy-widened employee activity examples', 
   assert.equal(privacyResult.status, 1)
   assert.match(privacyResult.stderr, /employee activity examples/i)
 
+  const privacyWidenedSubject = structuredClone(contract)
+  privacyWidenedSubject.paths['/activity-logs'].get.responses['200'].content[
+    'application/json'
+  ].examples.paginatedResponse.value.data[2].subject = {
+    first_name: 'Jane',
+  }
+
+  const privacySubjectResult = runGuard(privacyWidenedSubject)
+
+  assert.equal(privacySubjectResult.status, 1)
+  assert.match(privacySubjectResult.stderr, /employee activity examples/i)
+
   const misplacedAutomaticDiff = structuredClone(contract)
   misplacedAutomaticDiff.paths['/activity-logs'].get.responses['200'].content[
     'application/json'
@@ -282,6 +294,16 @@ test('guard rejects unsupported or privacy-widened employee activity examples', 
 
   assert.equal(misplacedDiffResult.status, 1)
   assert.match(misplacedDiffResult.stderr, /employee activity examples/i)
+
+  const missingExample = structuredClone(contract)
+  missingExample.paths['/activity-logs'].get.responses['200'].content[
+    'application/json'
+  ].examples.paginatedResponse.value.data = []
+
+  const missingExampleResult = runGuard(missingExample)
+
+  assert.equal(missingExampleResult.status, 1)
+  assert.match(missingExampleResult.stderr, /employee activity examples/i)
 })
 
 test('moves local customer data to a unique customer establishment contract', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -230,6 +230,35 @@ test('keeps employee creation audit examples aligned with domain assignments', (
   }
 })
 
+test('guard rejects unsupported or privacy-widened employee activity examples', () => {
+  const unsupportedEvent = structuredClone(contract)
+  const unsupportedActivity =
+    unsupportedEvent.paths['/activity-logs'].get.responses['200'].content[
+      'application/json'
+    ].examples.paginatedResponse.value.data[2]
+
+  unsupportedActivity.log_name = 'employee'
+  unsupportedActivity.description = 'Viewed Employee "Jane Smith"'
+  unsupportedActivity.event = 'accessed'
+  unsupportedActivity.properties = {}
+
+  const unsupportedResult = runGuard(unsupportedEvent)
+
+  assert.equal(unsupportedResult.status, 1)
+  assert.match(unsupportedResult.stderr, /employee activity examples/i)
+
+  const privacyWidened = structuredClone(contract)
+  privacyWidened.paths['/activity-logs'].get.responses['200'].content[
+    'application/json'
+  ].examples.paginatedResponse.value.data[2].properties.attributes.name =
+    'Jane Smith'
+
+  const privacyResult = runGuard(privacyWidened)
+
+  assert.equal(privacyResult.status, 1)
+  assert.match(privacyResult.stderr, /employee activity examples/i)
+})
+
 test('moves local customer data to a unique customer establishment contract', () => {
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'contact'), false)
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'notes'), false)

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -231,6 +231,17 @@ test('keeps employee creation audit examples aligned with domain assignments', (
 })
 
 test('guard rejects unsupported or privacy-widened employee activity examples', () => {
+  const supportedActivity =
+    contract.paths['/activity-logs'].get.responses['200'].content[
+      'application/json'
+    ].examples.paginatedResponse.value.data[2]
+
+  assert.equal(
+    supportedActivity.properties,
+    null,
+    'automatic employee update diffs are not exposed through properties'
+  )
+
   const unsupportedEvent = structuredClone(contract)
   const unsupportedActivity =
     unsupportedEvent.paths['/activity-logs'].get.responses['200'].content[
@@ -250,13 +261,27 @@ test('guard rejects unsupported or privacy-widened employee activity examples', 
   const privacyWidened = structuredClone(contract)
   privacyWidened.paths['/activity-logs'].get.responses['200'].content[
     'application/json'
-  ].examples.paginatedResponse.value.data[2].properties.attributes.name =
-    'Jane Smith'
+  ].examples.paginatedResponse.value.data[2].properties = {
+    name: 'Jane Smith',
+  }
 
   const privacyResult = runGuard(privacyWidened)
 
   assert.equal(privacyResult.status, 1)
   assert.match(privacyResult.stderr, /employee activity examples/i)
+
+  const misplacedAutomaticDiff = structuredClone(contract)
+  misplacedAutomaticDiff.paths['/activity-logs'].get.responses['200'].content[
+    'application/json'
+  ].examples.paginatedResponse.value.data[2].properties = {
+    attributes: { status: 'active' },
+    old: { status: 'on_leave' },
+  }
+
+  const misplacedDiffResult = runGuard(misplacedAutomaticDiff)
+
+  assert.equal(misplacedDiffResult.status, 1)
+  assert.match(misplacedDiffResult.stderr, /employee activity examples/i)
 })
 
 test('moves local customer data to a unique customer establishment contract', () => {


### PR DESCRIPTION
# Summary

The paginated `GET /activity-logs` example documented an Employee `accessed`
event in the `employee` category with a personal name, but no corresponding
runtime producer or test exists. The new regression test first restores that
unsupported shape and verifies that the contract guard rejects it.

- Replace the example with the supported `employee_changes` `updated` event.
- Show only the privacy-safe `status` change in `attributes` and `old`.
- Reject unsupported event/category combinations and personal-name values in
  the paginated Employee activity example.

Closes #379.

# Validation

- `npm run validate`
- Push preflight: formatting, REUSE, domain policy, `npm test`, and `npm run lint`

# Follow-up

No unresolved checks remain before review. Runtime evidence was inspected in
the linked `SecPal/api` workspace; this PR changes only `SecPal/contracts`.
