### PR TITLE
fix: format repository policy scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extended the canonical Prettier validation and formatting commands to cover
+  repository JavaScript and MJS policy scripts, preventing formatting drift
+  (closes #380).
 - Documented interoperable `GET /organizational-units` `is_active` and
   `is_assignable` boolean-query encodings: clients may send `1` or `true` for
   `true`, and `0` or `false` for `false`; omitted or empty values do not apply

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
     "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml && node scripts/check-domain-contracts.mjs docs/openapi.yaml",
-    "format": "prettier --write '**/*.{md,yml,yaml,json}'",
-    "format:check": "prettier --check '**/*.{md,yml,yaml,json}'",
+    "format": "prettier --write '**/*.{md,yml,yaml,json,js,mjs}'",
+    "format:check": "prettier --check '**/*.{md,yml,yaml,json,js,mjs}'",
     "test": "npm run validate",
-    "validate": "npm run lint && prettier --check '**/*.{md,yml,yaml,json}'"
+    "validate": "npm run lint && npm run format:check"
   },
   "devDependencies": {
     "@redocly/cli": "^2.39.0",

--- a/scripts/check-conflict-marker-documentation.test.mjs
+++ b/scripts/check-conflict-marker-documentation.test.mjs
@@ -2,41 +2,43 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import test from "node:test";
-import { fileURLToPath } from "node:url";
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 const documentationPath = fileURLToPath(
-  new URL("../docs/scripts/CHECK_CONFLICT_MARKERS.md", import.meta.url),
-);
-const conflictMarkerPattern = /^(?:<<<<<<< |=======(?: |$)|>>>>>>> )/u;
+  new URL('../docs/scripts/CHECK_CONFLICT_MARKERS.md', import.meta.url)
+)
+const conflictMarkerPattern = /^(?:<<<<<<< |=======(?: |$)|>>>>>>> )/u
 
 function conflictMarkerLines(source) {
-  return source.split(/\r?\n/u).flatMap((line, index) =>
-    conflictMarkerPattern.test(line) ? [index + 1] : [],
-  );
+  return source
+    .split(/\r?\n/u)
+    .flatMap((line, index) =>
+      conflictMarkerPattern.test(line) ? [index + 1] : []
+    )
 }
 
-test("accepts the documented conflict-marker example", () => {
-  const documentation = readFileSync(documentationPath, "utf8");
+test('accepts the documented conflict-marker example', () => {
+  const documentation = readFileSync(documentationPath, 'utf8')
 
-  assert.deepEqual(conflictMarkerLines(documentation), []);
-});
+  assert.deepEqual(conflictMarkerLines(documentation), [])
+})
 
-test("detects real unindented conflict markers", () => {
+test('detects real unindented conflict markers', () => {
   const unresolvedConflict =
     [
-      ["<<<<<<<", "HEAD"].join(" "),
-      "current branch",
-      "=======",
-      "incoming branch",
-      [">>>>>>>", "feature-branch"].join(" "),
-    ].join("\n") + "\n";
+      ['<<<<<<<', 'HEAD'].join(' '),
+      'current branch',
+      '=======',
+      'incoming branch',
+      ['>>>>>>>', 'feature-branch'].join(' '),
+    ].join('\n') + '\n'
 
-  assert.deepEqual(conflictMarkerLines(unresolvedConflict), [1, 3, 5]);
-});
+  assert.deepEqual(conflictMarkerLines(unresolvedConflict), [1, 3, 5])
+})
 
-test("detects an unterminated separator marker", () => {
-  assert.deepEqual(conflictMarkerLines("======="), [1]);
-});
+test('detects an unterminated separator marker', () => {
+  assert.deepEqual(conflictMarkerLines('======='), [1])
+})

--- a/scripts/check-dependabot-config.mjs
+++ b/scripts/check-dependabot-config.mjs
@@ -2,81 +2,85 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import { readFileSync } from "node:fs";
-import * as yaml from "js-yaml";
+import { readFileSync } from 'node:fs'
+import * as yaml from 'js-yaml'
 
 function fail(message) {
-  console.error(`Error: ${message}`);
-  process.exit(1);
+  console.error(`Error: ${message}`)
+  process.exit(1)
 }
 
 const configPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
-  : new URL("../.github/dependabot.yml", import.meta.url);
+  : new URL('../.github/dependabot.yml', import.meta.url)
 
-let config;
+let config
 try {
-  config = yaml.load(readFileSync(configPath, "utf8"), {
+  config = yaml.load(readFileSync(configPath, 'utf8'), {
     schema: yaml.JSON_SCHEMA,
-  });
+  })
 } catch (error) {
-  fail(`could not parse .github/dependabot.yml: ${error}`);
+  fail(`could not parse .github/dependabot.yml: ${error}`)
 }
 
-const updates = Array.isArray(config?.updates) ? config.updates : [];
+const updates = Array.isArray(config?.updates) ? config.updates : []
 const githubActionsUpdate = updates.find(
-  (entry) => entry?.["package-ecosystem"] === "github-actions",
-);
+  (entry) => entry?.['package-ecosystem'] === 'github-actions'
+)
 
 if (!githubActionsUpdate) {
-  fail("missing github-actions update entry in .github/dependabot.yml.");
+  fail('missing github-actions update entry in .github/dependabot.yml.')
 }
 
-if (githubActionsUpdate?.["pull-request-branch-name"]?.separator !== "-") {
-  fail('github-actions pull-request-branch-name.separator must stay set to "-".');
+if (githubActionsUpdate?.['pull-request-branch-name']?.separator !== '-') {
+  fail(
+    'github-actions pull-request-branch-name.separator must stay set to "-".'
+  )
 }
 
-const groups = githubActionsUpdate.groups;
-if (!groups || typeof groups !== "object") {
-  fail("github-actions updates must define readable Dependabot groups.");
+const groups = githubActionsUpdate.groups
+if (!groups || typeof groups !== 'object') {
+  fail('github-actions updates must define readable Dependabot groups.')
 }
 
 const expectedGroups = {
-  "secpal-workflows": ["SecPal/.github*"],
-  "github-actions": ["actions/*"],
-  "third-party-actions": ["*"],
-};
+  'secpal-workflows': ['SecPal/.github*'],
+  'github-actions': ['actions/*'],
+  'third-party-actions': ['*'],
+}
 
 for (const [name, patterns] of Object.entries(expectedGroups)) {
-  const group = groups[name];
+  const group = groups[name]
   if (!group || !Array.isArray(group.patterns)) {
-    fail(`github-actions group "${name}" must define patterns.`);
+    fail(`github-actions group "${name}" must define patterns.`)
   }
 
   if (group.patterns.length !== patterns.length) {
     fail(
-      `github-actions group "${name}" must define exactly ${patterns.length} pattern(s).`,
-    );
+      `github-actions group "${name}" must define exactly ${patterns.length} pattern(s).`
+    )
   }
 
   for (const pattern of patterns) {
     if (!group.patterns.includes(pattern)) {
-      fail(`github-actions group "${name}" must include pattern "${pattern}".`);
+      fail(`github-actions group "${name}" must include pattern "${pattern}".`)
     }
   }
 }
 
-const thirdPartyExcludes = groups["third-party-actions"]?.["exclude-patterns"];
+const thirdPartyExcludes = groups['third-party-actions']?.['exclude-patterns']
 if (!Array.isArray(thirdPartyExcludes)) {
-  fail('github-actions group "third-party-actions" must define exclude-patterns.');
+  fail(
+    'github-actions group "third-party-actions" must define exclude-patterns.'
+  )
 }
 
-for (const excludedPattern of ["SecPal/.github*", "actions/*"]) {
+for (const excludedPattern of ['SecPal/.github*', 'actions/*']) {
   if (!thirdPartyExcludes.includes(excludedPattern)) {
     fail(
-      `github-actions group "third-party-actions" must exclude "${excludedPattern}".`,
-    );
+      `github-actions group "third-party-actions" must exclude "${excludedPattern}".`
+    )
   }
 }
 
-console.log("Dependabot config guard OK.");
+console.log('Dependabot config guard OK.')

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -2,214 +2,242 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: MIT
 
-import { readFileSync } from "node:fs";
+import { readFileSync } from 'node:fs'
 
-import { load as loadYaml } from "js-yaml";
+import { load as loadYaml } from 'js-yaml'
 
-const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const EXACT_VERSION_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
 
 function fail(message) {
-  console.error(`Error: ${message}`);
-  process.exit(1);
+  console.error(`Error: ${message}`)
+  process.exit(1)
 }
 
 function requireInvariant(condition, message) {
   if (!condition) {
-    throw new Error(message);
+    throw new Error(message)
   }
 }
 
 function parsePreCommitConfig(preCommitConfig) {
   try {
-    return loadYaml(preCommitConfig);
+    return loadYaml(preCommitConfig)
   } catch (error) {
-    throw new Error(`could not parse .pre-commit-config.yaml: ${error.message}`, { cause: error });
+    throw new Error(
+      `could not parse .pre-commit-config.yaml: ${error.message}`,
+      { cause: error }
+    )
   }
 }
 
 function findHooks(config, hookId) {
-  const repositories = Array.isArray(config?.repos) ? config.repos : [];
+  const repositories = Array.isArray(config?.repos) ? config.repos : []
 
   return repositories.flatMap((repository) =>
     (Array.isArray(repository?.hooks) ? repository.hooks : [])
       .filter((hook) => hook?.id === hookId)
-      .map((hook) => ({ hook, repository: repository.repo })),
-  );
+      .map((hook) => ({ hook, repository: repository.repo }))
+  )
 }
 
-export function validatePrettierToolchain({ packageJson, packageLock, preCommitConfig }) {
-  const declaredPrettierRange = packageJson.devDependencies?.prettier ?? "";
+export function validatePrettierToolchain({
+  packageJson,
+  packageLock,
+  preCommitConfig,
+}) {
+  const declaredPrettierRange = packageJson.devDependencies?.prettier ?? ''
   requireInvariant(
     declaredPrettierRange.length > 0,
-    "package.json must declare Prettier in devDependencies.",
-  );
+    'package.json must declare Prettier in devDependencies.'
+  )
 
-  const lockfileDeclaredPrettierRange = packageLock.packages?.[""]?.devDependencies?.prettier ?? "";
+  const lockfileDeclaredPrettierRange =
+    packageLock.packages?.['']?.devDependencies?.prettier ?? ''
   requireInvariant(
     lockfileDeclaredPrettierRange === declaredPrettierRange,
-    `package-lock.json root package must match the package.json Prettier declaration ${declaredPrettierRange}, found ${lockfileDeclaredPrettierRange || "missing"}.`,
-  );
+    `package-lock.json root package must match the package.json Prettier declaration ${declaredPrettierRange}, found ${lockfileDeclaredPrettierRange || 'missing'}.`
+  )
 
-  const lockedPrettierVersion = packageLock.packages?.["node_modules/prettier"]?.version ?? "";
+  const lockedPrettierVersion =
+    packageLock.packages?.['node_modules/prettier']?.version ?? ''
   requireInvariant(
     EXACT_VERSION_PATTERN.test(lockedPrettierVersion),
-    `package-lock.json must resolve node_modules/prettier to an exact version, found ${lockedPrettierVersion || "missing"}.`,
-  );
+    `package-lock.json must resolve node_modules/prettier to an exact version, found ${lockedPrettierVersion || 'missing'}.`
+  )
 
-  const config = parsePreCommitConfig(preCommitConfig);
-  const repositories = Array.isArray(config?.repos) ? config.repos : [];
+  const config = parsePreCommitConfig(preCommitConfig)
+  const repositories = Array.isArray(config?.repos) ? config.repos : []
   requireInvariant(
     !repositories.some((repository) =>
-      String(repository?.repo ?? "").includes("github.com/pre-commit/mirrors-prettier"),
+      String(repository?.repo ?? '').includes(
+        'github.com/pre-commit/mirrors-prettier'
+      )
     ),
-    ".pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.",
-  );
+    '.pre-commit-config.yaml must not use the obsolete mirrors-prettier hook.'
+  )
 
-  const prettierHooks = findHooks(config, "prettier");
+  const prettierHooks = findHooks(config, 'prettier')
 
   requireInvariant(
     prettierHooks.length > 0,
-    "could not locate the Prettier hook in .pre-commit-config.yaml.",
-  );
+    'could not locate the Prettier hook in .pre-commit-config.yaml.'
+  )
   requireInvariant(
     prettierHooks.length === 1,
-    ".pre-commit-config.yaml must define exactly one Prettier hook.",
-  );
+    '.pre-commit-config.yaml must define exactly one Prettier hook.'
+  )
 
-  const [{ hook: prettierHook, repository }] = prettierHooks;
+  const [{ hook: prettierHook, repository }] = prettierHooks
   requireInvariant(
-    repository === "local",
-    "the Prettier pre-commit hook must use the repository-local toolchain.",
-  );
+    repository === 'local',
+    'the Prettier pre-commit hook must use the repository-local toolchain.'
+  )
   requireInvariant(
-    prettierHook.entry === "node node_modules/prettier/bin/prettier.cjs",
-    "the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.",
-  );
+    prettierHook.entry === 'node node_modules/prettier/bin/prettier.cjs',
+    'the Prettier pre-commit hook must invoke its locked JavaScript entrypoint.'
+  )
   requireInvariant(
-    prettierHook.language === "system",
-    "the Prettier pre-commit hook must use the repository-local toolchain.",
-  );
+    prettierHook.language === 'system',
+    'the Prettier pre-commit hook must use the repository-local toolchain.'
+  )
   requireInvariant(
-    !Object.hasOwn(prettierHook, "additional_dependencies") &&
-      !JSON.stringify(prettierHook).includes("--ignore-prepublish"),
-    "the Prettier pre-commit hook must not configure a separate npm environment.",
-  );
+    !Object.hasOwn(prettierHook, 'additional_dependencies') &&
+      !JSON.stringify(prettierHook).includes('--ignore-prepublish'),
+    'the Prettier pre-commit hook must not configure a separate npm environment.'
+  )
 }
 
 export function validateMarkdownlintToolchain(preCommitConfig) {
-  const markdownlintHooks = findHooks(parsePreCommitConfig(preCommitConfig), "markdownlint");
+  const markdownlintHooks = findHooks(
+    parsePreCommitConfig(preCommitConfig),
+    'markdownlint'
+  )
 
   requireInvariant(
     markdownlintHooks.length > 0,
-    "could not locate the markdownlint hook in .pre-commit-config.yaml.",
-  );
+    'could not locate the markdownlint hook in .pre-commit-config.yaml.'
+  )
   requireInvariant(
     markdownlintHooks.length === 1,
-    ".pre-commit-config.yaml must define exactly one markdownlint hook.",
-  );
+    '.pre-commit-config.yaml must define exactly one markdownlint hook.'
+  )
 
-  const [{ hook: markdownlintHook, repository }] = markdownlintHooks;
+  const [{ hook: markdownlintHook, repository }] = markdownlintHooks
   requireInvariant(
-    repository === "local",
-    "the markdownlint pre-commit hook must use the repository-local toolchain.",
-  );
+    repository === 'local',
+    'the markdownlint pre-commit hook must use the repository-local toolchain.'
+  )
   requireInvariant(
-    markdownlintHook.entry === "node node_modules/markdownlint-cli/markdownlint.js",
-    "the markdownlint pre-commit hook must invoke its locked JavaScript entrypoint.",
-  );
+    markdownlintHook.entry ===
+      'node node_modules/markdownlint-cli/markdownlint.js',
+    'the markdownlint pre-commit hook must invoke its locked JavaScript entrypoint.'
+  )
   requireInvariant(
-    markdownlintHook.language === "system",
-    "the markdownlint pre-commit hook must use the repository-local toolchain.",
-  );
+    markdownlintHook.language === 'system',
+    'the markdownlint pre-commit hook must use the repository-local toolchain.'
+  )
   requireInvariant(
-    !Object.hasOwn(markdownlintHook, "additional_dependencies"),
-    "the markdownlint pre-commit hook must not install a separate dependency tree.",
-  );
+    !Object.hasOwn(markdownlintHook, 'additional_dependencies'),
+    'the markdownlint pre-commit hook must not install a separate dependency tree.'
+  )
   requireInvariant(
-    !JSON.stringify(markdownlintHook).includes("npx "),
-    "the markdownlint pre-commit hook must not shell out through npx.",
-  );
+    !JSON.stringify(markdownlintHook).includes('npx '),
+    'the markdownlint pre-commit hook must not shell out through npx.'
+  )
 }
 
 export function validateMarkdownlintVersion({ packageJson, packageLock }) {
-  const declaredVersion = packageJson.devDependencies?.["markdownlint-cli"] ?? "";
+  const declaredVersion =
+    packageJson.devDependencies?.['markdownlint-cli'] ?? ''
   requireInvariant(
     EXACT_VERSION_PATTERN.test(declaredVersion),
-    `package.json must pin markdownlint-cli to an exact version, found ${declaredVersion || "missing"}.`,
-  );
+    `package.json must pin markdownlint-cli to an exact version, found ${declaredVersion || 'missing'}.`
+  )
 
   const lockfileDeclaredVersion =
-    packageLock.packages?.[""]?.devDependencies?.["markdownlint-cli"] ?? "";
+    packageLock.packages?.['']?.devDependencies?.['markdownlint-cli'] ?? ''
   requireInvariant(
     lockfileDeclaredVersion === declaredVersion,
-    `package-lock.json root package must match the package.json pin ${declaredVersion}, found ${lockfileDeclaredVersion || "missing"}.`,
-  );
+    `package-lock.json root package must match the package.json pin ${declaredVersion}, found ${lockfileDeclaredVersion || 'missing'}.`
+  )
 
   const lockedPackageVersion =
-    packageLock.packages?.["node_modules/markdownlint-cli"]?.version ?? "";
+    packageLock.packages?.['node_modules/markdownlint-cli']?.version ?? ''
   requireInvariant(
     lockedPackageVersion === declaredVersion,
-    `package-lock.json node_modules/markdownlint-cli must match the package.json pin ${declaredVersion}, found ${lockedPackageVersion || "missing"}.`,
-  );
+    `package-lock.json node_modules/markdownlint-cli must match the package.json pin ${declaredVersion}, found ${lockedPackageVersion || 'missing'}.`
+  )
 }
 
 export function validateSetupScript(setupScript) {
-  const rootDirChangeIndex = setupScript.search(/^cd "\$ROOT_DIR"$/m);
+  const rootDirChangeIndex = setupScript.search(/^cd "\$ROOT_DIR"$/m)
   requireInvariant(
     rootDirChangeIndex !== -1,
-    "scripts/setup-pre-commit.sh must run from the repository root.",
-  );
+    'scripts/setup-pre-commit.sh must run from the repository root.'
+  )
 
-  const npmCiIndex = setupScript.search(/^npm ci$/m);
-  const installHooksIndex = setupScript.search(/^pre-commit install --install-hooks$/m);
+  const npmCiIndex = setupScript.search(/^npm ci$/m)
+  const installHooksIndex = setupScript.search(
+    /^pre-commit install --install-hooks$/m
+  )
   requireInvariant(
     npmCiIndex !== -1 &&
       installHooksIndex !== -1 &&
       rootDirChangeIndex < npmCiIndex &&
       npmCiIndex < installHooksIndex,
-    "scripts/setup-pre-commit.sh must run npm ci from the repository root before installing hooks.",
-  );
+    'scripts/setup-pre-commit.sh must run npm ci from the repository root before installing hooks.'
+  )
 }
 
-const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+)
 const packageLock = JSON.parse(
-  readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
-);
+  readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+)
 const preCommitConfig = readFileSync(
-  new URL("../.pre-commit-config.yaml", import.meta.url),
-  "utf8",
-);
-const preflightScript = readFileSync(new URL("../scripts/preflight.sh", import.meta.url), "utf8");
+  new URL('../.pre-commit-config.yaml', import.meta.url),
+  'utf8'
+)
+const preflightScript = readFileSync(
+  new URL('../scripts/preflight.sh', import.meta.url),
+  'utf8'
+)
 const setupScript = readFileSync(
-  new URL("../scripts/setup-pre-commit.sh", import.meta.url),
-  "utf8",
-);
+  new URL('../scripts/setup-pre-commit.sh', import.meta.url),
+  'utf8'
+)
 
 try {
-  validatePrettierToolchain({ packageJson, packageLock, preCommitConfig });
-  validateMarkdownlintVersion({ packageJson, packageLock });
-  validateMarkdownlintToolchain(preCommitConfig);
-  validateSetupScript(setupScript);
+  validatePrettierToolchain({ packageJson, packageLock, preCommitConfig })
+  validateMarkdownlintVersion({ packageJson, packageLock })
+  validateMarkdownlintToolchain(preCommitConfig)
+  validateSetupScript(setupScript)
 } catch (error) {
-  fail(error.message);
+  fail(error.message)
 }
 
-if (!preflightScript.includes("node_modules/.bin/markdownlint")) {
-  fail("scripts/preflight.sh must run the local locked node_modules/.bin/markdownlint binary.");
-}
-
-if (preflightScript.includes("npx --yes --package markdownlint-cli")) {
-  fail("scripts/preflight.sh must not resolve markdownlint-cli through npx --package.");
-}
-
-if (!preflightScript.includes("ensure_markdownlint_dependencies()")) {
+if (!preflightScript.includes('node_modules/.bin/markdownlint')) {
   fail(
-    "scripts/preflight.sh must centralize markdownlint bootstrap in an ensure_markdownlint_dependencies helper.",
-  );
+    'scripts/preflight.sh must run the local locked node_modules/.bin/markdownlint binary.'
+  )
 }
 
-if (!preflightScript.includes("ensure_markdownlint_dependencies\n")) {
+if (preflightScript.includes('npx --yes --package markdownlint-cli')) {
   fail(
-    "scripts/preflight.sh must only install Node dependencies for markdownlint when the local binary is missing.",
-  );
+    'scripts/preflight.sh must not resolve markdownlint-cli through npx --package.'
+  )
+}
+
+if (!preflightScript.includes('ensure_markdownlint_dependencies()')) {
+  fail(
+    'scripts/preflight.sh must centralize markdownlint bootstrap in an ensure_markdownlint_dependencies helper.'
+  )
+}
+
+if (!preflightScript.includes('ensure_markdownlint_dependencies\n')) {
+  fail(
+    'scripts/preflight.sh must only install Node dependencies for markdownlint when the local binary is missing.'
+  )
 }

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -1,30 +1,33 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: MIT
 
-import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import test from "node:test";
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
 
 import {
   validateMarkdownlintToolchain,
   validateMarkdownlintVersion,
   validatePrettierToolchain,
   validateSetupScript,
-} from "./check-markdownlint-toolchain.mjs";
+} from './check-markdownlint-toolchain.mjs'
 
-const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+)
 const packageLock = JSON.parse(
-  readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
-);
-const markdownlintVersion = packageJson.devDependencies["markdownlint-cli"];
-const prettierRange = packageJson.devDependencies.prettier;
-const lockedPrettierVersion = packageLock.packages["node_modules/prettier"].version;
+  readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+)
+const markdownlintVersion = packageJson.devDependencies['markdownlint-cli']
+const prettierRange = packageJson.devDependencies.prettier
+const lockedPrettierVersion =
+  packageLock.packages['node_modules/prettier'].version
 
 function incrementPatch(version) {
   return version.replace(
     /^(\D*\d+\.\d+\.)(\d+)(.*)$/,
-    (_match, prefix, patch, suffix) => `${prefix}${Number(patch) + 1}${suffix}`,
-  );
+    (_match, prefix, patch, suffix) => `${prefix}${Number(patch) + 1}${suffix}`
+  )
 }
 
 const validHook = `---
@@ -33,96 +36,106 @@ repos:
     hooks:
       - id: prettier
         entry: node node_modules/prettier/bin/prettier.cjs
-        language: system`;
+        language: system`
 
 function validate(preCommitConfig, lockfile = packageLock) {
   validatePrettierToolchain({
     packageJson,
     packageLock: lockfile,
     preCommitConfig,
-  });
+  })
 }
 
-test("accepts the locked repository-local Prettier hook at end of file", () => {
-  assert.doesNotThrow(() => validate(validHook));
-});
+test('accepts the locked repository-local Prettier hook at end of file', () => {
+  assert.doesNotThrow(() => validate(validHook))
+})
 
-test("rejects additional dependencies after an explanatory comment", () => {
+test('rejects additional dependencies after an explanatory comment', () => {
   const config = `${validHook}
         # This dependency would create a separate toolchain.
         additional_dependencies:
-          - prettier`;
+          - prettier`
 
-  assert.throws(() => validate(config), /must not configure a separate npm environment/);
-});
+  assert.throws(
+    () => validate(config),
+    /must not configure a separate npm environment/
+  )
+})
 
-test("rejects an unlocked entry even when a comment contains the expected command", () => {
+test('rejects an unlocked entry even when a comment contains the expected command', () => {
   const config = validHook.replace(
-    "entry: node node_modules/prettier/bin/prettier.cjs",
-    "entry: npx prettier # entry: node node_modules/prettier/bin/prettier.cjs",
-  );
+    'entry: node node_modules/prettier/bin/prettier.cjs',
+    'entry: npx prettier # entry: node node_modules/prettier/bin/prettier.cjs'
+  )
 
-  assert.throws(() => validate(config), /must invoke its locked JavaScript entrypoint/);
-});
+  assert.throws(
+    () => validate(config),
+    /must invoke its locked JavaScript entrypoint/
+  )
+})
 
-test("rejects a prefixed hook id", () => {
-  const config = validHook.replace("id: prettier", "id: prettier-extra");
+test('rejects a prefixed hook id', () => {
+  const config = validHook.replace('id: prettier', 'id: prettier-extra')
 
-  assert.throws(() => validate(config), /could not locate the Prettier hook/);
-});
+  assert.throws(() => validate(config), /could not locate the Prettier hook/)
+})
 
-test("rejects a mismatched root lockfile declaration", () => {
-  const mismatchedLockfile = structuredClone(packageLock);
-  mismatchedLockfile.packages[""].devDependencies.prettier = `${prettierRange}-mismatch`;
+test('rejects a mismatched root lockfile declaration', () => {
+  const mismatchedLockfile = structuredClone(packageLock)
+  mismatchedLockfile.packages[''].devDependencies.prettier =
+    `${prettierRange}-mismatch`
 
   assert.throws(
     () => validate(validHook, mismatchedLockfile),
-    /package-lock.json root package must match the package.json Prettier declaration/,
-  );
-});
+    /package-lock.json root package must match the package.json Prettier declaration/
+  )
+})
 
-test("derives the Prettier versions from package.json and package-lock.json", () => {
-  const alternateRange = incrementPatch(prettierRange);
-  const alternateLockedVersion = incrementPatch(lockedPrettierVersion);
-  const manifest = structuredClone(packageJson);
-  const lockfile = structuredClone(packageLock);
-  manifest.devDependencies.prettier = alternateRange;
-  lockfile.packages[""].devDependencies.prettier = alternateRange;
-  lockfile.packages["node_modules/prettier"].version = alternateLockedVersion;
+test('derives the Prettier versions from package.json and package-lock.json', () => {
+  const alternateRange = incrementPatch(prettierRange)
+  const alternateLockedVersion = incrementPatch(lockedPrettierVersion)
+  const manifest = structuredClone(packageJson)
+  const lockfile = structuredClone(packageLock)
+  manifest.devDependencies.prettier = alternateRange
+  lockfile.packages[''].devDependencies.prettier = alternateRange
+  lockfile.packages['node_modules/prettier'].version = alternateLockedVersion
 
   assert.doesNotThrow(() =>
     validatePrettierToolchain({
       packageJson: manifest,
       packageLock: lockfile,
       preCommitConfig: validHook,
-    }),
-  );
-});
+    })
+  )
+})
 
-test("rejects the obsolete Prettier mirror", () => {
+test('rejects the obsolete Prettier mirror', () => {
   const config = `---
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: obsolete
     hooks:
-      - id: prettier`;
+      - id: prettier`
 
-  assert.throws(() => validate(config), /must not use the obsolete mirrors-prettier hook/);
-});
+  assert.throws(
+    () => validate(config),
+    /must not use the obsolete mirrors-prettier hook/
+  )
+})
 
-test("accepts the repository-local markdownlint hook at end of file", () => {
+test('accepts the repository-local markdownlint hook at end of file', () => {
   const config = `---
 repos:
   - repo: local
     hooks:
       - id: markdownlint
         entry: node node_modules/markdownlint-cli/markdownlint.js
-        language: system`;
+        language: system`
 
-  assert.doesNotThrow(() => validateMarkdownlintToolchain(config));
-});
+  assert.doesNotThrow(() => validateMarkdownlintToolchain(config))
+})
 
-test("rejects a markdownlint hook with a separate dependency tree", () => {
+test('rejects a markdownlint hook with a separate dependency tree', () => {
   const config = `---
 repos:
   - repo: local
@@ -131,65 +144,72 @@ repos:
         entry: node node_modules/markdownlint-cli/markdownlint.js
         language: system
         additional_dependencies:
-          - markdownlint-cli`;
+          - markdownlint-cli`
 
   assert.throws(
     () => validateMarkdownlintToolchain(config),
-    /must not install a separate dependency tree/,
-  );
-});
+    /must not install a separate dependency tree/
+  )
+})
 
-test("derives the markdownlint version from package.json", () => {
-  const alternateVersion = incrementPatch(markdownlintVersion);
-  const manifest = { devDependencies: { "markdownlint-cli": alternateVersion } };
+test('derives the markdownlint version from package.json', () => {
+  const alternateVersion = incrementPatch(markdownlintVersion)
+  const manifest = { devDependencies: { 'markdownlint-cli': alternateVersion } }
   const lockfile = {
     packages: {
-      "": { devDependencies: { "markdownlint-cli": alternateVersion } },
-      "node_modules/markdownlint-cli": { version: alternateVersion },
+      '': { devDependencies: { 'markdownlint-cli': alternateVersion } },
+      'node_modules/markdownlint-cli': { version: alternateVersion },
     },
-  };
+  }
 
   assert.doesNotThrow(() =>
-    validateMarkdownlintVersion({ packageJson: manifest, packageLock: lockfile }),
-  );
-});
+    validateMarkdownlintVersion({
+      packageJson: manifest,
+      packageLock: lockfile,
+    })
+  )
+})
 
-test("rejects a markdownlint lockfile version that differs from package.json", () => {
-  const alternateVersion = incrementPatch(markdownlintVersion);
-  const mismatchedVersion = incrementPatch(alternateVersion);
-  const manifest = { devDependencies: { "markdownlint-cli": alternateVersion } };
+test('rejects a markdownlint lockfile version that differs from package.json', () => {
+  const alternateVersion = incrementPatch(markdownlintVersion)
+  const mismatchedVersion = incrementPatch(alternateVersion)
+  const manifest = { devDependencies: { 'markdownlint-cli': alternateVersion } }
   const lockfile = {
     packages: {
-      "": { devDependencies: { "markdownlint-cli": alternateVersion } },
-      "node_modules/markdownlint-cli": { version: mismatchedVersion },
+      '': { devDependencies: { 'markdownlint-cli': alternateVersion } },
+      'node_modules/markdownlint-cli': { version: mismatchedVersion },
     },
-  };
+  }
 
   assert.throws(
-    () => validateMarkdownlintVersion({ packageJson: manifest, packageLock: lockfile }),
-    /must match the package.json pin/,
-  );
-});
+    () =>
+      validateMarkdownlintVersion({
+        packageJson: manifest,
+        packageLock: lockfile,
+      }),
+    /must match the package.json pin/
+  )
+})
 
-test("rejects a commented-out repository-root change", () => {
+test('rejects a commented-out repository-root change', () => {
   const setupScript = `#!/usr/bin/env bash
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 # cd "$ROOT_DIR"
 npm ci
-pre-commit install --install-hooks`;
+pre-commit install --install-hooks`
 
   assert.throws(
     () => validateSetupScript(setupScript),
-    /must run from the repository root/,
-  );
-});
+    /must run from the repository root/
+  )
+})
 
-test("accepts dependency bootstrap from the repository root", () => {
+test('accepts dependency bootstrap from the repository root', () => {
   const setupScript = `#!/usr/bin/env bash
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 npm ci
-pre-commit install --install-hooks`;
+pre-commit install --install-hooks`
 
-  assert.doesNotThrow(() => validateSetupScript(setupScript));
-});
+  assert.doesNotThrow(() => validateSetupScript(setupScript))
+})

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -2,34 +2,34 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import { readFileSync } from "node:fs";
-import * as yaml from "js-yaml";
+import { readFileSync } from 'node:fs'
+import * as yaml from 'js-yaml'
 
 function fail(message) {
-  console.error(`Error: ${message}`);
-  process.exit(1);
+  console.error(`Error: ${message}`)
+  process.exit(1)
 }
 
 const workflowPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
-  : new URL("../.github/workflows/pr-size.yml", import.meta.url);
+  : new URL('../.github/workflows/pr-size.yml', import.meta.url)
 
-let workflow;
+let workflow
 try {
-  workflow = yaml.load(readFileSync(workflowPath, "utf8"), {
+  workflow = yaml.load(readFileSync(workflowPath, 'utf8'), {
     schema: yaml.JSON_SCHEMA,
-  });
+  })
 } catch (error) {
-  fail(`could not parse .github/workflows/pr-size.yml: ${error}`);
+  fail(`could not parse .github/workflows/pr-size.yml: ${error}`)
 }
 
 const expectedPermissions = {
-  contents: "read",
-  "pull-requests": "read",
-};
+  contents: 'read',
+  'pull-requests': 'read',
+}
 
-if (!workflow?.permissions || typeof workflow.permissions !== "object") {
-  fail(".github/workflows/pr-size.yml must define top-level permissions.");
+if (!workflow?.permissions || typeof workflow.permissions !== 'object') {
+  fail('.github/workflows/pr-size.yml must define top-level permissions.')
 }
 
 if (
@@ -37,24 +37,24 @@ if (
   Object.keys(expectedPermissions).length
 ) {
   fail(
-    ".github/workflows/pr-size.yml must define exactly the required permissions.",
-  );
+    '.github/workflows/pr-size.yml must define exactly the required permissions.'
+  )
 }
 
 for (const [scope, access] of Object.entries(expectedPermissions)) {
   if (workflow.permissions[scope] !== access) {
     fail(
-      `.github/workflows/pr-size.yml permissions.${scope} must be ${access}.`,
-    );
+      `.github/workflows/pr-size.yml permissions.${scope} must be ${access}.`
+    )
   }
 }
 
 for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
-  if (job && typeof job === "object" && Object.hasOwn(job, "permissions")) {
+  if (job && typeof job === 'object' && Object.hasOwn(job, 'permissions')) {
     fail(
-      `.github/workflows/pr-size.yml jobs.${jobName} must not override permissions.`,
-    );
+      `.github/workflows/pr-size.yml jobs.${jobName} must not override permissions.`
+    )
   }
 }
 
-console.log("PR-size workflow permission guard OK.");
+console.log('PR-size workflow permission guard OK.')

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -2,63 +2,65 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { spawnSync } from "node:child_process";
-import test from "node:test";
-import { fileURLToPath } from "node:url";
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 const guardPath = fileURLToPath(
-  new URL("./check-pr-size-workflow.mjs", import.meta.url),
-);
+  new URL('./check-pr-size-workflow.mjs', import.meta.url)
+)
 
-test("accepts the repository workflow", () => {
-  const result = spawnSync(process.execPath, [guardPath], { encoding: "utf8" });
+test('accepts the repository workflow', () => {
+  const result = spawnSync(process.execPath, [guardPath], { encoding: 'utf8' })
 
-  assert.equal(result.status, 0, result.stderr);
-});
+  assert.equal(result.status, 0, result.stderr)
+})
 
 function runGuard(workflow) {
-  const directory = mkdtempSync(join(tmpdir(), "check-pr-size-workflow-"));
-  const workflowPath = join(directory, "pr-size.yml");
-  writeFileSync(workflowPath, workflow);
+  const directory = mkdtempSync(join(tmpdir(), 'check-pr-size-workflow-'))
+  const workflowPath = join(directory, 'pr-size.yml')
+  writeFileSync(workflowPath, workflow)
 
   try {
     return spawnSync(process.execPath, [guardPath, workflowPath], {
-      encoding: "utf8",
-    });
+      encoding: 'utf8',
+    })
   } finally {
-    rmSync(directory, { recursive: true, force: true });
+    rmSync(directory, { recursive: true, force: true })
   }
 }
 
-test("accepts exactly the required read permissions", () => {
-  const result = runGuard(`permissions:\n  contents: read\n  pull-requests: read\n`);
+test('accepts exactly the required read permissions', () => {
+  const result = runGuard(
+    `permissions:\n  contents: read\n  pull-requests: read\n`
+  )
 
-  assert.equal(result.status, 0, result.stderr);
-});
+  assert.equal(result.status, 0, result.stderr)
+})
 
 for (const [name, permissions] of [
-  ["missing contents", "pull-requests: read"],
-  ["writable contents", "contents: write\n  pull-requests: read"],
-  ["missing pull requests", "contents: read"],
-  ["writable pull requests", "contents: read\n  pull-requests: write"],
+  ['missing contents', 'pull-requests: read'],
+  ['writable contents', 'contents: write\n  pull-requests: read'],
+  ['missing pull requests', 'contents: read'],
+  ['writable pull requests', 'contents: read\n  pull-requests: write'],
   [
-    "an unexpected scope",
-    "contents: read\n  pull-requests: read\n  issues: write",
+    'an unexpected scope',
+    'contents: read\n  pull-requests: read\n  issues: write',
   ],
 ]) {
   test(`rejects ${name}`, () => {
-    const workflow = `permissions:\n  ${permissions.replaceAll("\n", "\n  ")}\n`;
-    const result = runGuard(workflow);
+    const workflow = `permissions:\n  ${permissions.replaceAll('\n', '\n  ')}\n`
+    const result = runGuard(workflow)
 
-    assert.notEqual(result.status, 0, result.stderr || result.stdout);
-  });
+    assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  })
 }
 
-test("rejects a PR-size job-level permission override", () => {
+test('rejects a PR-size job-level permission override', () => {
   const result = runGuard(`permissions:
   contents: read
   pull-requests: read
@@ -66,12 +68,12 @@ jobs:
   pr-size:
     permissions:
       contents: write
-`);
+`)
 
-  assert.notEqual(result.status, 0, result.stderr || result.stdout);
-});
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+})
 
-test("rejects a permission override in another job", () => {
+test('rejects a permission override in another job', () => {
   const result = runGuard(`permissions:
   contents: read
   pull-requests: read
@@ -80,13 +82,13 @@ jobs:
   unexpected-job:
     permissions:
       issues: write
-`);
+`)
 
-  assert.notEqual(result.status, 0, result.stderr || result.stdout);
-});
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+})
 
-test("rejects malformed YAML", () => {
-  const result = runGuard("permissions: [\n");
+test('rejects malformed YAML', () => {
+  const result = runGuard('permissions: [\n')
 
-  assert.notEqual(result.status, 0, result.stderr || result.stdout);
-});
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+})


### PR DESCRIPTION
## Reproduced validation failure

Before this change, `npx prettier --check 'scripts/**/*.{js,mjs}'` reported formatting drift in repository policy scripts. The canonical `npm run validate` command did not include JavaScript or MJS files, so it could not catch the drift.

Closes #380.

## Change summary

- Format the repository policy scripts with the pinned Prettier version.
- Extend `format` and `format:check` to include JavaScript and MJS files.
- Route `validate` through the shared formatting check and record the change in `CHANGELOG.md`.

## Validation

- `npm ci`
- `npm run validate`
- `reuse lint`
- Pre-push formatting, licensing, domain-policy, lint, test, and OpenAPI gates

## Follow-up before ready

- #386 tracks the pre-push size-gate policy for mandatory mechanical formatting changes. No linked workspace changes are required.
