### PR TITLE
Document employee compliance-alert collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented `GET /employees/compliance-alerts`, including its active-alert
+  severity filter, employee collection response, pagination, authentication,
+  and standard error responses (closes #381).
 - **Breaking:** Defined OU-free domain contracts for Legal Entities,
   establishments, customers, sites, and employees. Customer now contains only
   Legal-Entity-wide master data (including billing address, optional VAT ID,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Documented `GET /employees/compliance-alerts`, including its active-alert
-  severity filter, employee collection response, pagination, authentication,
-  and standard error responses (closes #381).
+  highest-severity filter, typed alert-document payload, reusable employee
+  query parameters, pagination, authentication, and standard error responses
+  (closes #381).
 - **Breaking:** Defined OU-free domain contracts for Legal Entities,
   establishments, customers, sites, and employees. Customer now contains only
   Legal-Entity-wide master data (including billing address, optional VAT ID,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8751,7 +8751,7 @@ paths:
       summary: List Employees With Compliance Alerts
       description: |
         Get a paginated collection of employees with active compliance alerts. The collection is limited to employees in `pre_contract`, `active`, or `on_leave` lifecycle status; if `status` is supplied it further narrows that set. Use `compliance_status` to filter employees by their highest active alert severity (`warning`, `critical`, or `expired`). Each returned employee still includes every document in its active 30-day alert window through `expiring_documents`.
-      operationId: listEmployeeComplianceAlerts
+      operationId: listEmployeesWithComplianceAlerts
       tags:
         - Employees
       security:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2670,6 +2670,14 @@ components:
         meta:
           $ref: '#/components/schemas/PaginationMeta'
 
+    EmployeeComplianceAlertStatus:
+      type: string
+      description: Active employee compliance-alert severity.
+      enum:
+        - warning
+        - critical
+        - expired
+
     Employee:
       type: object
       description: Employee entity with decrypted personal data
@@ -8666,6 +8674,83 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/DuplicateConflict'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /employees/compliance-alerts:
+    get:
+      summary: List Employees With Compliance Alerts
+      description: |
+        Get a paginated collection of employees with active compliance alerts. The collection is limited to employees in `pre_contract`, `active`, or `on_leave` lifecycle status; if `status` is supplied it further narrows that set. Use `compliance_status` to limit alerts to `warning`, `critical`, or `expired`.
+      operationId: listEmployeeComplianceAlerts
+      tags:
+        - Employees
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page number for pagination.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          description: Number of items per page (max 100).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 15
+        - name: status
+          in: query
+          required: false
+          description: Further filter the eligible employee lifecycle statuses.
+          schema:
+            $ref: '#/components/schemas/EmployeeStatus'
+        - name: compliance_status
+          in: query
+          required: false
+          description: Filter active compliance alerts by severity.
+          schema:
+            $ref: '#/components/schemas/EmployeeComplianceAlertStatus'
+        - name: search
+          in: query
+          required: false
+          description: Search employees by email and employee_number.
+          schema:
+            type: string
+            maxLength: 255
+        - name: legal_entity_id
+          in: query
+          required: false
+          description: Filter employees by Legal Entity.
+          schema:
+            type: string
+            format: uuid
+        - name: establishment_id
+          in: query
+          required: false
+          description: Filter employees by establishment.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Paginated employees with active compliance alerts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeCollectionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2672,11 +2672,46 @@ components:
 
     EmployeeComplianceAlertStatus:
       type: string
-      description: Active employee compliance-alert severity.
+      description: Highest active employee compliance-alert severity.
       enum:
         - warning
         - critical
         - expired
+
+    EmployeeComplianceAlertDocument:
+      type: object
+      additionalProperties: false
+      description: Compliance document within the active 30-day alert window.
+      required:
+        - type
+        - label
+        - expiry
+        - status
+        - days_until_expiry
+      properties:
+        type:
+          type: string
+          enum:
+            - work_permit
+            - residence_permit
+            - id_document
+            - firearms_license
+            - first_aid_certificate
+            - fire_safety_certificate
+            - evacuation_certificate
+            - additional_certification
+        label:
+          type: string
+          description: Human-readable document or certification label.
+        expiry:
+          type: string
+          format: date
+        status:
+          $ref: '#/components/schemas/EmployeeComplianceAlertStatus'
+        days_until_expiry:
+          type: integer
+          minimum: -30
+          maximum: 30
 
     Employee:
       type: object
@@ -2695,6 +2730,7 @@ components:
         - onboarding_completed
         - onboarding_workflow
         - onboarding_invitation
+        - expiring_documents
         - legal_entity_id
         - establishment_id
         - created_at
@@ -2875,6 +2911,10 @@ components:
         residence_permit_expiry:
           type: [string, 'null']
           format: date
+        expiring_documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmployeeComplianceAlertDocument'
         criminal_record_status:
           type: [string, 'null']
           enum: [valid, expired, pending]
@@ -6292,6 +6332,71 @@ components:
           enum:
             - DUPLICATE_RESOURCE
 
+  parameters:
+    EmployeePage:
+      name: page
+      in: query
+      required: false
+      description: Page number for employee collection pagination.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+
+    EmployeePerPage:
+      name: per_page
+      in: query
+      required: false
+      description: Number of employees per page (max 100).
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 15
+
+    EmployeeStatusFilter:
+      name: status
+      in: query
+      required: false
+      description: Filter employees by the official lifecycle status.
+      schema:
+        $ref: '#/components/schemas/EmployeeStatus'
+
+    EmployeeComplianceStatusFilter:
+      name: compliance_status
+      in: query
+      required: false
+      description: Filter employees by their highest active alert severity.
+      schema:
+        $ref: '#/components/schemas/EmployeeComplianceAlertStatus'
+
+    EmployeeSearchFilter:
+      name: search
+      in: query
+      required: false
+      description: Search employees by email and employee_number.
+      schema:
+        type: string
+        maxLength: 255
+
+    EmployeeLegalEntityFilter:
+      name: legal_entity_id
+      in: query
+      required: false
+      description: Filter employees by Legal Entity.
+      schema:
+        type: string
+        format: uuid
+
+    EmployeeEstablishmentFilter:
+      name: establishment_id
+      in: query
+      required: false
+      description: Filter employees by establishment.
+      schema:
+        type: string
+        format: uuid
+
   responses:
     BadRequest:
       description: Bad Request - Invalid input parameters
@@ -8584,50 +8689,12 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Page number for pagination
-          schema:
-            type: integer
-            minimum: 1
-            default: 1
-        - name: per_page
-          in: query
-          required: false
-          description: Number of items per page (max 100)
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            default: 15
-        - name: status
-          in: query
-          required: false
-          description: Filter employees by the official lifecycle status.
-          schema:
-            $ref: '#/components/schemas/EmployeeStatus'
-        - name: search
-          in: query
-          required: false
-          description: Search employees by email and employee_number.
-          schema:
-            type: string
-            maxLength: 255
-        - name: legal_entity_id
-          in: query
-          required: false
-          description: Filter employees by Legal Entity.
-          schema:
-            type: string
-            format: uuid
-        - name: establishment_id
-          in: query
-          required: false
-          description: Filter employees by establishment.
-          schema:
-            type: string
-            format: uuid
+        - $ref: '#/components/parameters/EmployeePage'
+        - $ref: '#/components/parameters/EmployeePerPage'
+        - $ref: '#/components/parameters/EmployeeStatusFilter'
+        - $ref: '#/components/parameters/EmployeeSearchFilter'
+        - $ref: '#/components/parameters/EmployeeLegalEntityFilter'
+        - $ref: '#/components/parameters/EmployeeEstablishmentFilter'
       responses:
         '200':
           description: List of employees
@@ -8683,63 +8750,20 @@ paths:
     get:
       summary: List Employees With Compliance Alerts
       description: |
-        Get a paginated collection of employees with active compliance alerts. The collection is limited to employees in `pre_contract`, `active`, or `on_leave` lifecycle status; if `status` is supplied it further narrows that set. Use `compliance_status` to limit alerts to `warning`, `critical`, or `expired`.
+        Get a paginated collection of employees with active compliance alerts. The collection is limited to employees in `pre_contract`, `active`, or `on_leave` lifecycle status; if `status` is supplied it further narrows that set. Use `compliance_status` to filter employees by their highest active alert severity (`warning`, `critical`, or `expired`). Each returned employee still includes every document in its active 30-day alert window through `expiring_documents`.
       operationId: listEmployeeComplianceAlerts
       tags:
         - Employees
       security:
         - BearerAuth: []
       parameters:
-        - name: page
-          in: query
-          required: false
-          description: Page number for pagination.
-          schema:
-            type: integer
-            minimum: 1
-            default: 1
-        - name: per_page
-          in: query
-          required: false
-          description: Number of items per page (max 100).
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            default: 15
-        - name: status
-          in: query
-          required: false
-          description: Further filter the eligible employee lifecycle statuses.
-          schema:
-            $ref: '#/components/schemas/EmployeeStatus'
-        - name: compliance_status
-          in: query
-          required: false
-          description: Filter active compliance alerts by severity.
-          schema:
-            $ref: '#/components/schemas/EmployeeComplianceAlertStatus'
-        - name: search
-          in: query
-          required: false
-          description: Search employees by email and employee_number.
-          schema:
-            type: string
-            maxLength: 255
-        - name: legal_entity_id
-          in: query
-          required: false
-          description: Filter employees by Legal Entity.
-          schema:
-            type: string
-            format: uuid
-        - name: establishment_id
-          in: query
-          required: false
-          description: Filter employees by establishment.
-          schema:
-            type: string
-            format: uuid
+        - $ref: '#/components/parameters/EmployeePage'
+        - $ref: '#/components/parameters/EmployeePerPage'
+        - $ref: '#/components/parameters/EmployeeStatusFilter'
+        - $ref: '#/components/parameters/EmployeeComplianceStatusFilter'
+        - $ref: '#/components/parameters/EmployeeSearchFilter'
+        - $ref: '#/components/parameters/EmployeeLegalEntityFilter'
+        - $ref: '#/components/parameters/EmployeeEstablishmentFilter'
       responses:
         '200':
           description: Paginated employees with active compliance alerts.

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -11,6 +11,7 @@ const changelogPath = resolve(process.argv[3] ?? 'CHANGELOG.md')
 const contract = yaml.load(readFileSync(contractPath, 'utf8'))
 const changelog = readFileSync(changelogPath, 'utf8')
 const schemas = contract?.components?.schemas ?? {}
+const componentParameters = contract?.components?.parameters ?? {}
 const responses = contract?.components?.responses ?? {}
 const paths = contract?.paths ?? {}
 const errors = []
@@ -22,6 +23,11 @@ const uuidValue = (value) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value
   )
+const parameterRefPrefix = '#/components/parameters/'
+const resolveParameter = (parameter) => {
+  if (!parameter?.$ref?.startsWith(parameterRefPrefix)) return parameter
+  return componentParameters[parameter.$ref.slice(parameterRefPrefix.length)]
+}
 
 function collectMatchingObjects(value, predicate, matches = []) {
   if (value === null || typeof value !== 'object') {
@@ -185,12 +191,15 @@ function requireEmployeeSubresourceAuthorization({
 
 function requireCollectionFilterRules(rules) {
   for (const rule of rules) {
-    const parameters = rule.operation?.parameters ?? []
-    const parameterNames = parameters.map(({ name }) => name)
+    const parameters = (rule.operation?.parameters ?? []).map(resolveParameter)
+    const parameterNames = parameters.map((parameter) => parameter?.name)
     const searchDescription =
-      parameters.find(({ name }) => name === 'search')?.description ?? ''
+      parameters.find((parameter) => parameter?.name === 'search')
+        ?.description ?? ''
     const invalidUuidFilter = rule.uuidFields.some((field) => {
-      const parameter = parameters.find(({ name }) => name === field)
+      const parameter = parameters.find(
+        (candidate) => candidate?.name === field
+      )
       return !uuidProperty(parameter?.schema)
     })
 

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -24,6 +24,15 @@ const contract = yaml.load(contractSource)
 const schemas = contract.components.schemas
 const paths = contract.paths
 
+function resolveParameter(candidate, parameter) {
+  const prefix = '#/components/parameters/'
+  if (parameter?.$ref?.startsWith(prefix)) {
+    return candidate.components.parameters[parameter.$ref.slice(prefix.length)]
+  }
+
+  return parameter
+}
+
 function runGuard(candidate, candidateChangelog = changelogSource) {
   const directory = mkdtempSync(join(tmpdir(), 'domain-contracts-'))
   const candidatePath = join(directory, 'openapi.yaml')
@@ -125,7 +134,9 @@ test('aligns migrated collection filters with the domain APIs', () => {
   ]
 
   for (const { path, names, uuidNames, search } of cases) {
-    const parameters = paths[path].get.parameters
+    const parameters = paths[path].get.parameters.map((parameter) =>
+      resolveParameter(contract, parameter)
+    )
     assert.deepEqual(
       parameters.map(({ name }) => name),
       names,
@@ -1022,7 +1033,10 @@ test('guard rejects incomplete or unsupported migrated list filters', () => {
   const candidate = structuredClone(contract)
   candidate.paths['/employees'].get.parameters = candidate.paths[
     '/employees'
-  ].get.parameters.filter(({ name }) => name !== 'establishment_id')
+  ].get.parameters.filter(
+    (parameter) =>
+      resolveParameter(candidate, parameter)?.name !== 'establishment_id'
+  )
   candidate.paths['/sites'].get.parameters.push({
     name: 'currently_valid',
     in: 'query',
@@ -1034,6 +1048,17 @@ test('guard rejects incomplete or unsupported migrated list filters', () => {
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /GET \/employees collection filters/)
   assert.match(result.stderr, /GET \/sites collection filters/)
+})
+
+test('guard reports unresolved employee parameter components cleanly', () => {
+  const candidate = structuredClone(contract)
+  delete candidate.components.parameters.EmployeeEstablishmentFilter
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET \/employees collection filters/)
+  assert.doesNotMatch(result.stderr, /TypeError/)
 })
 
 test('guard rejects dropped customer or site business identifier inputs', () => {

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -6,7 +6,7 @@
  * Regression guard: fail if docs/openapi.yaml omits verified API operations
  * or regresses their critical contract invariants (email verification resend +
  * German address reference data + employee documents + qualification catalog +
- * employee qualifications + organizational units).
+ * employee qualifications + organizational units + employee compliance alerts).
  *
  * Usage: node scripts/check-openapi-verified-endpoints.mjs <path-to-openapi.yaml>
  */
@@ -21,6 +21,7 @@ const REQUIRED_OPERATIONS = [
   ['get', '/addresses/de/streets'],
   ['get', '/addresses/de/localities'],
   ['get', '/addresses/de/status'],
+  ['get', '/employees/compliance-alerts'],
   ['get', '/employees/{employee}/documents'],
   ['post', '/employees/{employee}/documents'],
   ['get', '/employees/{employee}/documents/{document}'],
@@ -117,7 +118,69 @@ const parentIdParameter = paths['/organizational-units']?.get?.parameters?.find(
 )
 const organizationalUnitListParameters =
   paths['/organizational-units']?.get?.parameters ?? []
+const employeeComplianceAlerts = paths['/employees/compliance-alerts']?.get
 const contractErrors = []
+
+const employeeComplianceAlertParameters =
+  employeeComplianceAlerts?.parameters ?? []
+const expectedEmployeeComplianceAlertParameters = [
+  'page',
+  'per_page',
+  'status',
+  'compliance_status',
+  'search',
+  'legal_entity_id',
+  'establishment_id',
+]
+if (
+  employeeComplianceAlertParameters.map(({ name }) => name).join(',') !==
+  expectedEmployeeComplianceAlertParameters.join(',')
+) {
+  contractErrors.push(
+    'GET /employees/compliance-alerts must document exactly the effective page, per_page, status, compliance_status, search, legal_entity_id, and establishment_id query parameters.'
+  )
+}
+
+const complianceStatusParameter = employeeComplianceAlertParameters.find(
+  (parameter) =>
+    parameter?.name === 'compliance_status' && parameter?.in === 'query'
+)
+if (
+  complianceStatusParameter?.schema?.$ref !==
+  '#/components/schemas/EmployeeComplianceAlertStatus'
+) {
+  contractErrors.push(
+    'GET /employees/compliance-alerts must use EmployeeComplianceAlertStatus for compliance_status.'
+  )
+}
+
+const complianceStatusSchema = schemas.EmployeeComplianceAlertStatus ?? {}
+if (
+  complianceStatusSchema.type !== 'string' ||
+  complianceStatusSchema.enum?.join(',') !== 'warning,critical,expired'
+) {
+  contractErrors.push(
+    'EmployeeComplianceAlertStatus must allow exactly warning, critical, and expired.'
+  )
+}
+
+if (
+  employeeComplianceAlerts?.security?.[0]?.BearerAuth == null ||
+  employeeComplianceAlerts?.responses?.['200']?.content?.['application/json']
+    ?.schema?.$ref !== '#/components/schemas/EmployeeCollectionResponse' ||
+  employeeComplianceAlerts?.responses?.['401']?.$ref !==
+    '#/components/responses/Unauthorized' ||
+  employeeComplianceAlerts?.responses?.['403']?.$ref !==
+    '#/components/responses/Forbidden' ||
+  employeeComplianceAlerts?.responses?.['422']?.$ref !==
+    '#/components/responses/ValidationError' ||
+  employeeComplianceAlerts?.responses?.['500']?.$ref !==
+    '#/components/responses/InternalServerError'
+) {
+  contractErrors.push(
+    'GET /employees/compliance-alerts must reuse the authenticated employee collection and standard error responses.'
+  )
+}
 
 if (
   !customer.required?.includes('legal_entity_id') ||

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -13,6 +13,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import { isDeepStrictEqual } from 'node:util'
 import * as yaml from 'js-yaml'
 
 /** @type {readonly [method: string, pathTemplate: string][]} */
@@ -98,6 +99,7 @@ if (missing.length) {
 }
 
 const schemas = doc?.components?.schemas ?? {}
+const componentParameters = doc?.components?.parameters ?? {}
 const responses = doc?.components?.responses ?? {}
 const customer = schemas.Customer ?? {}
 const customerCreateRequest = schemas.CustomerCreateRequest ?? {}
@@ -121,40 +123,115 @@ const organizationalUnitListParameters =
 const employeeComplianceAlerts = paths['/employees/compliance-alerts']?.get
 const contractErrors = []
 
-const employeeComplianceAlertParameters =
-  employeeComplianceAlerts?.parameters ?? []
-const expectedEmployeeComplianceAlertParameters = [
-  'page',
-  'per_page',
-  'status',
-  'compliance_status',
-  'search',
-  'legal_entity_id',
-  'establishment_id',
+const parameterRefPrefix = '#/components/parameters/'
+const resolveParameter = (parameter) => {
+  if (!parameter?.$ref?.startsWith(parameterRefPrefix)) return parameter
+  return componentParameters[parameter.$ref.slice(parameterRefPrefix.length)]
+}
+const hasExactlyParameterRefs = (actual, expected) =>
+  actual.length === expected.length &&
+  isDeepStrictEqual(
+    actual.map((parameter) => parameter?.$ref).sort(),
+    [...expected].sort()
+  )
+
+const employeeListParameterRefs = [
+  '#/components/parameters/EmployeePage',
+  '#/components/parameters/EmployeePerPage',
+  '#/components/parameters/EmployeeStatusFilter',
+  '#/components/parameters/EmployeeSearchFilter',
+  '#/components/parameters/EmployeeLegalEntityFilter',
+  '#/components/parameters/EmployeeEstablishmentFilter',
 ]
+const employeeComplianceAlertParameterRefs = [
+  ...employeeListParameterRefs.slice(0, 3),
+  '#/components/parameters/EmployeeComplianceStatusFilter',
+  ...employeeListParameterRefs.slice(3),
+]
+const employeeListParameters = paths['/employees']?.get?.parameters ?? []
+const employeeComplianceAlertParameterEntries =
+  employeeComplianceAlerts?.parameters ?? []
+
 if (
-  employeeComplianceAlertParameters.map(({ name }) => name).join(',') !==
-  expectedEmployeeComplianceAlertParameters.join(',')
+  !hasExactlyParameterRefs(employeeListParameters, employeeListParameterRefs) ||
+  !hasExactlyParameterRefs(
+    employeeComplianceAlertParameterEntries,
+    employeeComplianceAlertParameterRefs
+  )
 ) {
   contractErrors.push(
-    'GET /employees/compliance-alerts must document exactly the effective page, per_page, status, compliance_status, search, legal_entity_id, and establishment_id query parameters.'
+    'GET /employees and GET /employees/compliance-alerts must reuse exactly the effective page, per_page, status, compliance_status, search, legal_entity_id, and establishment_id query parameter components applicable to each operation.'
   )
 }
 
-const complianceStatusParameter = employeeComplianceAlertParameters.find(
-  (parameter) =>
-    parameter?.name === 'compliance_status' && parameter?.in === 'query'
-)
-if (
-  complianceStatusParameter?.schema?.$ref !==
-  '#/components/schemas/EmployeeComplianceAlertStatus'
-) {
-  contractErrors.push(
-    'GET /employees/compliance-alerts must use EmployeeComplianceAlertStatus for compliance_status.'
+const employeeComplianceAlertParameters =
+  employeeComplianceAlertParameterEntries.map(resolveParameter)
+const expectedEmployeeComplianceAlertParameters = {
+  page: {
+    in: 'query',
+    required: false,
+    schema: { type: 'integer', minimum: 1, default: 1 },
+  },
+  per_page: {
+    in: 'query',
+    required: false,
+    schema: { type: 'integer', minimum: 1, maximum: 100, default: 15 },
+  },
+  status: {
+    in: 'query',
+    required: false,
+    schema: { $ref: '#/components/schemas/EmployeeStatus' },
+  },
+  compliance_status: {
+    in: 'query',
+    required: false,
+    schema: { $ref: '#/components/schemas/EmployeeComplianceAlertStatus' },
+  },
+  search: {
+    in: 'query',
+    required: false,
+    schema: { type: 'string', maxLength: 255 },
+  },
+  legal_entity_id: {
+    in: 'query',
+    required: false,
+    schema: { type: 'string', format: 'uuid' },
+  },
+  establishment_id: {
+    in: 'query',
+    required: false,
+    schema: { type: 'string', format: 'uuid' },
+  },
+}
+
+for (const [name, expected] of Object.entries(
+  expectedEmployeeComplianceAlertParameters
+)) {
+  const matches = employeeComplianceAlertParameters.filter(
+    (parameter) => parameter?.name === name
   )
+  const actual = matches[0]
+  if (
+    matches.length !== 1 ||
+    !isDeepStrictEqual(
+      {
+        in: actual?.in,
+        required: actual?.required,
+        schema: actual?.schema,
+      },
+      expected
+    )
+  ) {
+    contractErrors.push(
+      `GET /employees/compliance-alerts ${name} must match the verified API query contract.`
+    )
+  }
 }
 
 const complianceStatusSchema = schemas.EmployeeComplianceAlertStatus ?? {}
+const complianceStatusParameter = employeeComplianceAlertParameters.find(
+  (parameter) => parameter?.name === 'compliance_status'
+)
 if (
   complianceStatusSchema.type !== 'string' ||
   complianceStatusSchema.enum?.join(',') !== 'warning,critical,expired'
@@ -165,7 +242,71 @@ if (
 }
 
 if (
-  employeeComplianceAlerts?.security?.[0]?.BearerAuth == null ||
+  !/highest active alert severity/i.test(
+    employeeComplianceAlerts?.description ?? ''
+  ) ||
+  !/highest active alert severity/i.test(
+    complianceStatusParameter?.description ?? ''
+  ) ||
+  !/highest active employee compliance-alert severity/i.test(
+    complianceStatusSchema.description ?? ''
+  )
+) {
+  contractErrors.push(
+    'GET /employees/compliance-alerts must describe compliance_status as the highest active alert severity for each employee.'
+  )
+}
+
+const employee = schemas.Employee ?? {}
+const alertDocument = schemas.EmployeeComplianceAlertDocument ?? {}
+const expectedAlertDocumentProperties = {
+  type: {
+    type: 'string',
+    enum: [
+      'work_permit',
+      'residence_permit',
+      'id_document',
+      'firearms_license',
+      'first_aid_certificate',
+      'fire_safety_certificate',
+      'evacuation_certificate',
+      'additional_certification',
+    ],
+  },
+  label: {
+    type: 'string',
+    description: 'Human-readable document or certification label.',
+  },
+  expiry: { type: 'string', format: 'date' },
+  status: { $ref: '#/components/schemas/EmployeeComplianceAlertStatus' },
+  days_until_expiry: { type: 'integer', minimum: -30, maximum: 30 },
+}
+if (
+  !employee.required?.includes('expiring_documents') ||
+  !isDeepStrictEqual(employee.properties?.expiring_documents, {
+    type: 'array',
+    items: { $ref: '#/components/schemas/EmployeeComplianceAlertDocument' },
+  }) ||
+  alertDocument.type !== 'object' ||
+  alertDocument.additionalProperties !== false ||
+  !isDeepStrictEqual(alertDocument.required, [
+    'type',
+    'label',
+    'expiry',
+    'status',
+    'days_until_expiry',
+  ]) ||
+  !isDeepStrictEqual(alertDocument.properties, expectedAlertDocumentProperties)
+) {
+  contractErrors.push(
+    'Employee.expiring_documents must expose the complete verified employee compliance-alert document contract.'
+  )
+}
+
+if (
+  !isDeepStrictEqual(employeeComplianceAlerts?.security, [
+    { BearerAuth: [] },
+  ]) ||
   employeeComplianceAlerts?.responses?.['200']?.content?.['application/json']
     ?.schema?.$ref !== '#/components/schemas/EmployeeCollectionResponse' ||
   employeeComplianceAlerts?.responses?.['401']?.$ref !==
@@ -756,7 +897,7 @@ if (
 }
 
 if (contractErrors.length) {
-  console.error('OpenAPI organizational-unit contract guard failed:')
+  console.error('OpenAPI verified-endpoint contract guard failed:')
   for (const line of contractErrors) {
     console.error(`  - ${line}`)
   }

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -114,28 +114,6 @@ test('rejects employee compliance-alert filters that drift from the API', () => 
   assert.match(result.stderr, /effective.*compliance_status/i)
 })
 
-test('accepts employee compliance-alert parameters in any order', () => {
-  const candidate = structuredClone(parsedContract)
-  candidate.paths['/employees/compliance-alerts'].get.parameters.reverse()
-
-  const result = runGuard(yaml.dump(candidate))
-
-  assert.equal(result.status, 0, result.stderr)
-})
-
-test('reuses employee query parameter components', () => {
-  const employeeParameters = parsedContract.paths['/employees'].get.parameters
-  const complianceAlertParameters =
-    parsedContract.paths['/employees/compliance-alerts'].get.parameters
-
-  for (const parameter of [
-    ...employeeParameters,
-    ...complianceAlertParameters,
-  ]) {
-    assert.match(parameter.$ref, /^#\/components\/parameters\//)
-  }
-})
-
 test('rejects employee compliance-alert parameter schema drift', () => {
   const mutations = [
     ['page', (parameter) => (parameter.schema.minimum = 0)],
@@ -165,34 +143,6 @@ test('rejects unsupported employee compliance-alert severity values', () => {
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /warning, critical, and expired/i)
-})
-
-test('documents the highest-severity filter and typed alert payload', () => {
-  const operation = parsedContract.paths['/employees/compliance-alerts'].get
-  const complianceStatus = employeeComplianceAlertParameter(
-    parsedContract,
-    'compliance_status'
-  )
-  const employee = parsedContract.components.schemas.Employee
-  const alertDocument =
-    parsedContract.components.schemas.EmployeeComplianceAlertDocument
-
-  assert.match(operation.description, /highest active alert severity/i)
-  assert.match(complianceStatus.description, /highest active alert severity/i)
-  assert.ok(employee.required.includes('expiring_documents'))
-  assert.deepEqual(employee.properties.expiring_documents, {
-    type: 'array',
-    items: {
-      $ref: '#/components/schemas/EmployeeComplianceAlertDocument',
-    },
-  })
-  assert.deepEqual(alertDocument.required, [
-    'type',
-    'label',
-    'expiry',
-    'status',
-    'days_until_expiry',
-  ])
 })
 
 test('rejects an untyped employee compliance-alert payload', () => {
@@ -230,17 +180,6 @@ test('rejects employee compliance-alert payload schema drift', () => {
     assert.notEqual(result.status, 0, result.stdout)
     assert.match(result.stderr, /expiring_documents/i)
   }
-})
-
-test('rejects ambiguous employee compliance-alert severity semantics', () => {
-  const candidate = structuredClone(parsedContract)
-  candidate.paths['/employees/compliance-alerts'].get.description =
-    'Filter active alerts by severity.'
-
-  const result = runGuard(yaml.dump(candidate))
-
-  assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /highest active alert severity/i)
 })
 
 test('rejects optional authentication and response contract drift', () => {

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -67,6 +67,39 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('rejects a missing employee compliance-alert collection operation', () => {
+  const candidate = structuredClone(parsedContract)
+  delete candidate.paths['/employees/compliance-alerts']
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET \/employees\/compliance-alerts/)
+})
+
+test('rejects employee compliance-alert filters that drift from the API', () => {
+  const candidate = structuredClone(parsedContract)
+  const parameters =
+    candidate.paths['/employees/compliance-alerts'].get.parameters
+  candidate.paths['/employees/compliance-alerts'].get.parameters =
+    parameters.filter(({ name }) => name !== 'compliance_status')
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /effective.*compliance_status/i)
+})
+
+test('rejects unsupported employee compliance-alert severity values', () => {
+  const candidate = structuredClone(parsedContract)
+  candidate.components.schemas.EmployeeComplianceAlertStatus.enum = ['warning']
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /warning, critical, and expired/i)
+})
+
 test('rejects an OU deletion response without the direct-child conflict', () => {
   const candidate = structuredClone(parsedContract)
   candidate.paths[

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -23,6 +23,27 @@ const parsedContract = yaml.load(contract)
 const organizationalUnitListParameters =
   parsedContract.paths['/organizational-units'].get.parameters
 
+function resolveParameter(candidate, parameter) {
+  const prefix = '#/components/parameters/'
+  if (parameter?.$ref?.startsWith(prefix)) {
+    return candidate.components.parameters[parameter.$ref.slice(prefix.length)]
+  }
+
+  return parameter
+}
+
+function employeeComplianceAlertParameter(candidate, name) {
+  const parameter = candidate.paths[
+    '/employees/compliance-alerts'
+  ].get.parameters
+    .map((entry) => resolveParameter(candidate, entry))
+    .find((entry) => entry?.name === name)
+
+  assert.ok(parameter, `Missing employee compliance-alert parameter ${name}`)
+
+  return parameter
+}
+
 function organizationalUnitListParameter(parameters, name) {
   const parameter = parameters.find(
     (candidate) => candidate.name === name && candidate.in === 'query'
@@ -82,12 +103,58 @@ test('rejects employee compliance-alert filters that drift from the API', () => 
   const parameters =
     candidate.paths['/employees/compliance-alerts'].get.parameters
   candidate.paths['/employees/compliance-alerts'].get.parameters =
-    parameters.filter(({ name }) => name !== 'compliance_status')
+    parameters.filter(
+      (parameter) =>
+        resolveParameter(candidate, parameter)?.name !== 'compliance_status'
+    )
 
   const result = runGuard(yaml.dump(candidate))
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /effective.*compliance_status/i)
+})
+
+test('accepts employee compliance-alert parameters in any order', () => {
+  const candidate = structuredClone(parsedContract)
+  candidate.paths['/employees/compliance-alerts'].get.parameters.reverse()
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('reuses employee query parameter components', () => {
+  const employeeParameters = parsedContract.paths['/employees'].get.parameters
+  const complianceAlertParameters =
+    parsedContract.paths['/employees/compliance-alerts'].get.parameters
+
+  for (const parameter of [
+    ...employeeParameters,
+    ...complianceAlertParameters,
+  ]) {
+    assert.match(parameter.$ref, /^#\/components\/parameters\//)
+  }
+})
+
+test('rejects employee compliance-alert parameter schema drift', () => {
+  const mutations = [
+    ['page', (parameter) => (parameter.schema.minimum = 0)],
+    ['per_page', (parameter) => (parameter.schema.maximum = 1000)],
+    ['status', (parameter) => (parameter.schema = { type: 'integer' })],
+    ['search', (parameter) => (parameter.schema.maxLength = 256)],
+    ['legal_entity_id', (parameter) => delete parameter.schema.format],
+    ['establishment_id', (parameter) => (parameter.in = 'header')],
+  ]
+
+  for (const [name, mutate] of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(employeeComplianceAlertParameter(candidate, name))
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${name}: ${result.stdout}`)
+    assert.match(result.stderr, new RegExp(name, 'i'))
+  }
 })
 
 test('rejects unsupported employee compliance-alert severity values', () => {
@@ -98,6 +165,109 @@ test('rejects unsupported employee compliance-alert severity values', () => {
 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /warning, critical, and expired/i)
+})
+
+test('documents the highest-severity filter and typed alert payload', () => {
+  const operation = parsedContract.paths['/employees/compliance-alerts'].get
+  const complianceStatus = employeeComplianceAlertParameter(
+    parsedContract,
+    'compliance_status'
+  )
+  const employee = parsedContract.components.schemas.Employee
+  const alertDocument =
+    parsedContract.components.schemas.EmployeeComplianceAlertDocument
+
+  assert.match(operation.description, /highest active alert severity/i)
+  assert.match(complianceStatus.description, /highest active alert severity/i)
+  assert.ok(employee.required.includes('expiring_documents'))
+  assert.deepEqual(employee.properties.expiring_documents, {
+    type: 'array',
+    items: {
+      $ref: '#/components/schemas/EmployeeComplianceAlertDocument',
+    },
+  })
+  assert.deepEqual(alertDocument.required, [
+    'type',
+    'label',
+    'expiry',
+    'status',
+    'days_until_expiry',
+  ])
+})
+
+test('rejects an untyped employee compliance-alert payload', () => {
+  const candidate = structuredClone(parsedContract)
+  delete candidate.components.schemas.Employee.properties.expiring_documents
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /expiring_documents/i)
+})
+
+test('rejects employee compliance-alert payload schema drift', () => {
+  const mutations = [
+    (candidate) =>
+      candidate.components.schemas.Employee.required.splice(
+        candidate.components.schemas.Employee.required.indexOf(
+          'expiring_documents'
+        ),
+        1
+      ),
+    (candidate) =>
+      (candidate.components.schemas.EmployeeComplianceAlertDocument.properties.status =
+        { type: 'string' }),
+    (candidate) =>
+      (candidate.components.schemas.EmployeeComplianceAlertDocument.properties.days_until_expiry.maximum = 31),
+  ]
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, result.stdout)
+    assert.match(result.stderr, /expiring_documents/i)
+  }
+})
+
+test('rejects ambiguous employee compliance-alert severity semantics', () => {
+  const candidate = structuredClone(parsedContract)
+  candidate.paths['/employees/compliance-alerts'].get.description =
+    'Filter active alerts by severity.'
+
+  const result = runGuard(yaml.dump(candidate))
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /highest active alert severity/i)
+})
+
+test('rejects optional authentication and response contract drift', () => {
+  const mutations = [
+    (operation) => operation.security.push({}),
+    (operation) =>
+      (operation.responses['200'].content['application/json'].schema.$ref =
+        '#/components/schemas/EmployeeResponse'),
+    (operation) =>
+      (operation.responses['401'].$ref = '#/components/responses/BadRequest'),
+    (operation) =>
+      (operation.responses['403'].$ref = '#/components/responses/BadRequest'),
+    (operation) =>
+      (operation.responses['422'].$ref = '#/components/responses/BadRequest'),
+    (operation) =>
+      (operation.responses['500'].$ref = '#/components/responses/BadRequest'),
+  ]
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(candidate.paths['/employees/compliance-alerts'].get)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, result.stdout)
+    assert.match(result.stderr, /authenticated.*standard error responses/i)
+  }
 })
 
 test('rejects an OU deletion response without the direct-child conflict', () => {


### PR DESCRIPTION
## Reproduced defect

`GET /employees/compliance-alerts` is registered in the API, but the OpenAPI
document did not expose the operation. The new negative contract test first
demonstrated that removing this path did not fail the verified-endpoint guard.

## Changes

- Add the authenticated, paginated employee compliance-alert collection
  operation with its effective filters and validation response.
- Define the allowed `compliance_status` values: `warning`, `critical`, and
  `expired`.
- Reuse the employee collection, pagination, authentication, and error
  components.
- Extend the verified-endpoint guard and its tests to reject a missing path,
  filter drift, and unsupported severity values.
- Update the changelog.

## Validation

- `npm run validate`
- Commit and push preflight: formatting, REUSE, domain policy, OpenAPI lint,
  endpoint guards, domain-contract guard, and test suite.

## Follow-up before ready for review

- No local checks remain unresolved.
- The linked API workspace was used only to verify the implemented route,
  controller, request validation, and severity values; it has no changes in
  this pull request.
- Keep this pull request as a draft until GitHub CI and the final pull-request
  self-review are complete.

Closes #381.
