### PR TITLE
Complete Employee response contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Completed the `Employee` response contract with every field emitted by
   `EmployeeResource`, including identity-document and work-permit copy
-  metadata, retention dates, certification and work-authorization summaries,
+  metadata, retention timestamps, certification and work-authorization summaries,
   permission-gated identifiers, and conditionally loaded qualification and
-  document relationships. Added regression guards for this resource/schema
-  inventory (closes #382).
+  document relationships. Requiredness now matches runtime omission rules,
+  work-permit values and certification date strings match the live API, and
+  exact field, schema-shape, permission, relationship, and timestamp guards
+  prevent resource/schema drift (closes #382).
 - Documented `GET /employees/compliance-alerts`, including its active-alert
   highest-severity filter, typed alert-document payload, reusable employee
   query parameters, pagination, authentication, and standard error responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Completed the `Employee` response contract with every field emitted by
+  `EmployeeResource`, including identity-document and work-permit copy
+  metadata, retention dates, certification and work-authorization summaries,
+  permission-gated identifiers, and conditionally loaded qualification and
+  document relationships. Added regression guards for this resource/schema
+  inventory (closes #382).
 - Documented `GET /employees/compliance-alerts`, including its active-alert
   highest-severity filter, typed alert-document payload, reusable employee
   query parameters, pagination, authentication, and standard error responses

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2828,13 +2828,40 @@ components:
           type: [array, 'null']
           items:
             type: string
+        id_document_type:
+          type: [string, 'null']
+          enum: [passport, id_card, residence_permit]
+          description: Type of identity document recorded for BWR verification.
+          example: id_card
+        id_document_number:
+          type: [string, 'null']
+          description: Decrypted identity-document number. Omitted unless the caller has `employees.read_sensitive`.
+        id_document_expiry:
+          type: [string, 'null']
+          format: date
+          description: Identity-document expiry date, when recorded.
+        id_document_copy_path:
+          type: [string, 'null']
+          description: Internal storage-path metadata for the identity-document copy; null after no copy was retained or after deletion.
+          example: id_documents/550e8400-id-card.pdf
+        id_document_copy_deleted_at:
+          $ref: '#/components/schemas/NullableApiTimestamp'
+          description: Timestamp at which the retained identity-document copy was deleted.
+        employment_end_date:
+          type: [string, 'null']
+          format: date
+          description: Lifecycle-managed employment end date used for retention calculations.
+        retention_period_end:
+          type: [string, 'null']
+          format: date
+          description: Lifecycle-managed legal retention deadline; this field is read-only.
         tax_id:
           type: [string, 'null']
-          description: Decrypted
+          description: Decrypted. Omitted unless the caller has `employees.read_sensitive`.
           example: '12345678901'
         social_security_number:
           type: [string, 'null']
-          description: Decrypted
+          description: Decrypted. Omitted unless the caller has `employees.read_sensitive`.
           example: '12 345678 A 123'
         status:
           allOf:
@@ -2874,7 +2901,7 @@ components:
         hourly_rate:
           type: [number, 'null']
           format: float
-          description: Decrypted
+          description: Decrypted. Omitted unless the caller has `employees.read_salary`.
         health_insurance_type:
           type: [string, 'null']
           enum: [public, private, foreign]
@@ -2882,6 +2909,7 @@ components:
           type: [string, 'null']
         health_insurance_number:
           type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
         sachkunde_type:
           type: [string, 'null']
           maxLength: 255
@@ -2889,6 +2917,7 @@ components:
           type: [string, 'null']
         sachkunde_ihk_number:
           type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
         sachkunde_exam_date:
           type: [string, 'null']
           format: date
@@ -2900,17 +2929,75 @@ components:
           enum: [unlimited, limited, none]
         work_permit_number:
           type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
         work_permit_expiry:
           type: [string, 'null']
           format: date
+        work_permit_copy_path:
+          type: [string, 'null']
+          description: Internal storage-path metadata for the work-permit copy; null when no copy is retained or it has been deleted.
+        work_permit_issued_by:
+          type: [string, 'null']
+          maxLength: 255
+          description: Issuing authority for the work permit.
+        work_permit_copy_deleted_at:
+          $ref: '#/components/schemas/NullableApiTimestamp'
+          description: Timestamp at which the retained work-permit copy was deleted.
+        firearms_license_number:
+          type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
+        firearms_license_expiry:
+          type: [string, 'null']
+          format: date
+        firearms_license_issued_by:
+          type: [string, 'null']
+          maxLength: 255
+        first_aid_cert_number:
+          type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
+        first_aid_cert_date:
+          type: [string, 'null']
+          format: date
+        first_aid_cert_expiry:
+          type: [string, 'null']
+          format: date
+        fire_safety_cert_date:
+          type: [string, 'null']
+          format: date
+        fire_safety_cert_expiry:
+          type: [string, 'null']
+          format: date
+        evacuation_cert_date:
+          type: [string, 'null']
+          format: date
+        evacuation_cert_expiry:
+          type: [string, 'null']
+          format: date
+        additional_certifications:
+          type: array
+          description: Additional certification records. Each record's `number` is omitted unless the caller has `employees.read_sensitive`.
+          items:
+            $ref: '#/components/schemas/EmployeeAdditionalCertification'
+          example:
+            - name: Site Access Badge
+              issued_date: '2026-04-01'
+              expiry_date: '2026-05-01'
+              issuer: Customer Security
         residence_permit_type:
           type: [string, 'null']
           enum: [unlimited, limited, none]
         residence_permit_number:
           type: [string, 'null']
+          description: Omitted unless the caller has `employees.read_sensitive`.
         residence_permit_expiry:
           type: [string, 'null']
           format: date
+        requires_work_permit:
+          type: boolean
+          description: Derived work-authorization requirement from the employee's nationalities.
+        has_valid_work_authorization:
+          type: boolean
+          description: Derived summary indicating whether the employee currently satisfies work-authorization requirements.
         expiring_documents:
           type: array
           items:
@@ -2957,12 +3044,48 @@ components:
           anyOf:
             - $ref: '#/components/schemas/EmployeeUserSummary'
             - type: 'null'
+          description: Omitted when the `user` relation is not loaded; when loaded, null when no user account is associated.
+        qualifications:
+          type: array
+          description: Omitted when the `employeeQualifications` relation is not loaded; present, possibly empty, when loaded.
+          items:
+            $ref: '#/components/schemas/EmployeeQualificationResource'
+        documents:
+          type: array
+          description: Omitted when the `documents` relation is not loaded; present, possibly empty, when loaded.
+          items:
+            $ref: '#/components/schemas/EmployeeDocumentResource'
         created_at:
           $ref: '#/components/schemas/ApiTimestamp'
         updated_at:
           $ref: '#/components/schemas/ApiTimestamp'
         deleted_at:
           $ref: '#/components/schemas/NullableApiTimestamp'
+
+    EmployeeAdditionalCertification:
+      type: object
+      description: |
+        Additional certification entry stored on an employee. `number` is omitted
+        from each entry unless the caller has `employees.read_sensitive`.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        number:
+          type: [string, 'null']
+          maxLength: 255
+          description: Omitted unless the caller has `employees.read_sensitive`.
+        issued_date:
+          type: [string, 'null']
+          format: date
+        expiry_date:
+          type: [string, 'null']
+          format: date
+        issuer:
+          type: [string, 'null']
+          maxLength: 255
 
     # =============================================================================
     # Onboarding Runtime Surface Schemas (Issue #180)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,7 +20,7 @@ info:
     ## API Policies
 
     - Response timestamps: unless a response field explicitly documents an approved exception, timestamps serialize as RFC 3339 / ISO 8601 UTC strings with a literal trailing `Z` and whole-second precision (`YYYY-MM-DDTHH:MM:SSZ`). Fractional seconds, including milliseconds, are not emitted.
-    - Timestamp exceptions: a response field may only emit a non-UTC offset or fractional seconds when that individual field schema explicitly opts out of the canonical UTC-second format and ships a matching example. No current response schema opts out.
+    - Timestamp exceptions: a response field may only emit a non-UTC offset or fractional seconds when that individual field schema explicitly opts out of the canonical UTC-second format and ships a matching example. Employee retention timestamps are the current approved exception and retain the six fractional digits emitted by the API.
     - Pagination: offset-based (page/per_page) for most endpoints, cursor-based for large datasets
     - Maximum page size: 100 items
   version: 0.0.1
@@ -509,6 +509,20 @@ components:
       description: Canonical SecPal API response timestamp or `null` when the response has no value for that field.
       oneOf:
         - $ref: '#/components/schemas/ApiTimestamp'
+        - type: 'null'
+      example: null
+
+    MicrosecondApiTimestamp:
+      type: string
+      format: date-time
+      pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$'
+      description: Approved SecPal API timestamp exception with exactly six fractional digits.
+      example: '2026-05-06T00:00:00.000000Z'
+
+    NullableMicrosecondApiTimestamp:
+      description: Approved six-fractional-digit API timestamp exception, or `null` when no value is present.
+      oneOf:
+        - $ref: '#/components/schemas/MicrosecondApiTimestamp'
         - type: 'null'
       example: null
 
@@ -2332,7 +2346,7 @@ components:
           format: date
         work_permit_type:
           type: [string, 'null']
-          enum: [unlimited, limited, none]
+          enum: [none, temporary, permanent, blue_card, seasonal, student]
         work_permit_number:
           type: [string, 'null']
           maxLength: 255
@@ -2568,7 +2582,7 @@ components:
           format: date
         work_permit_type:
           type: [string, 'null']
-          enum: [unlimited, limited, none]
+          enum: [none, temporary, permanent, blue_card, seasonal, student]
         work_permit_number:
           type: [string, 'null']
           maxLength: 255
@@ -2723,18 +2737,82 @@ components:
         - first_name
         - last_name
         - full_name
+        - date_of_birth
         - email
+        - phone
+        - photo_path
+        - bwr_id
+        - bwr_status
+        - bwr_registered_at
+        - bwr_submission_date
+        - bwr_notes
+        - gender
+        - birth_name
+        - previous_names
+        - birth_city
+        - birth_country
+        - nationalities
+        - structured_address
+        - emergency_contacts
+        - intended_activities
+        - id_document_type
+        - id_document_expiry
+        - id_document_copy_path
+        - id_document_copy_deleted_at
+        - employment_end_date
+        - retention_period_end
         - status
+        - hire_date
+        - contract_start_date
+        - termination_date
+        - last_working_day
         - contract_type
+        - weekly_hours
+        - monthly_hours
+        - health_insurance_type
+        - health_insurance_provider
+        - sachkunde_type
+        - sachkunde_certificate
+        - sachkunde_exam_date
+        - sachkunde_issued_date
+        - work_permit_type
+        - work_permit_expiry
+        - work_permit_copy_path
+        - work_permit_issued_by
+        - work_permit_copy_deleted_at
+        - firearms_license_expiry
+        - firearms_license_issued_by
+        - first_aid_cert_date
+        - first_aid_cert_expiry
+        - fire_safety_cert_date
+        - fire_safety_cert_expiry
+        - evacuation_cert_date
+        - evacuation_cert_expiry
+        - additional_certifications
+        - residence_permit_type
+        - residence_permit_expiry
+        - requires_work_permit
+        - has_valid_work_authorization
+        - expiring_documents
+        - criminal_record_status
+        - criminal_record_check_date
+        - user_id
         - user_account_active
+        - user_account_activated_at
+        - user_account_deactivated_at
         - onboarding_completed
+        - onboarding_steps
+        - onboarding_started_at
+        - onboarding_completed_at
         - onboarding_workflow
         - onboarding_invitation
-        - expiring_documents
         - legal_entity_id
         - establishment_id
+        - position
+        - management_level
         - created_at
         - updated_at
+        - deleted_at
       properties:
         id:
           type: string
@@ -2848,13 +2926,11 @@ components:
           $ref: '#/components/schemas/NullableApiTimestamp'
           description: Timestamp at which the retained identity-document copy was deleted.
         employment_end_date:
-          type: [string, 'null']
-          format: date
-          description: Lifecycle-managed employment end date used for retention calculations.
+          $ref: '#/components/schemas/NullableMicrosecondApiTimestamp'
+          description: Lifecycle-managed employment end timestamp used for retention calculations. Serialized at UTC midnight with six fractional digits.
         retention_period_end:
-          type: [string, 'null']
-          format: date
-          description: Lifecycle-managed legal retention deadline; this field is read-only.
+          $ref: '#/components/schemas/NullableMicrosecondApiTimestamp'
+          description: Lifecycle-managed legal retention deadline timestamp. Serialized at UTC midnight with six fractional digits; this field is read-only.
         tax_id:
           type: [string, 'null']
           description: Decrypted. Omitted unless the caller has `employees.read_sensitive`.
@@ -2926,7 +3002,7 @@ components:
           format: date
         work_permit_type:
           type: [string, 'null']
-          enum: [unlimited, limited, none]
+          enum: [none, temporary, permanent, blue_card, seasonal, student]
         work_permit_number:
           type: [string, 'null']
           description: Omitted unless the caller has `employees.read_sensitive`.
@@ -3079,10 +3155,10 @@ components:
           description: Omitted unless the caller has `employees.read_sensitive`.
         issued_date:
           type: [string, 'null']
-          format: date
+          description: Date value accepted by the API and preserved verbatim in the stored certification entry.
         expiry_date:
           type: [string, 'null']
-          format: date
+          description: Date value accepted by the API and preserved verbatim in the stored certification entry.
         issuer:
           type: [string, 'null']
           maxLength: 255

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -259,6 +259,150 @@ if (
 
 const employee = schemas.Employee ?? {}
 const alertDocument = schemas.EmployeeComplianceAlertDocument ?? {}
+const employeeResourceProperties = [
+  'id',
+  'tenant_id',
+  'employee_number',
+  'first_name',
+  'last_name',
+  'full_name',
+  'date_of_birth',
+  'email',
+  'phone',
+  'photo_path',
+  'bwr_id',
+  'bwr_status',
+  'bwr_registered_at',
+  'bwr_submission_date',
+  'bwr_notes',
+  'gender',
+  'birth_name',
+  'previous_names',
+  'birth_city',
+  'birth_country',
+  'nationalities',
+  'addresses',
+  'current_address',
+  'structured_address',
+  'emergency_contacts',
+  'intended_activities',
+  'id_document_type',
+  'id_document_number',
+  'id_document_expiry',
+  'id_document_copy_path',
+  'id_document_copy_deleted_at',
+  'employment_end_date',
+  'retention_period_end',
+  'tax_id',
+  'social_security_number',
+  'status',
+  'hire_date',
+  'contract_start_date',
+  'termination_date',
+  'last_working_day',
+  'contract_type',
+  'weekly_hours',
+  'monthly_hours',
+  'hourly_rate',
+  'health_insurance_type',
+  'health_insurance_provider',
+  'health_insurance_number',
+  'sachkunde_type',
+  'sachkunde_certificate',
+  'sachkunde_ihk_number',
+  'sachkunde_exam_date',
+  'sachkunde_issued_date',
+  'work_permit_type',
+  'work_permit_number',
+  'work_permit_expiry',
+  'work_permit_copy_path',
+  'work_permit_issued_by',
+  'work_permit_copy_deleted_at',
+  'firearms_license_number',
+  'firearms_license_expiry',
+  'firearms_license_issued_by',
+  'first_aid_cert_number',
+  'first_aid_cert_date',
+  'first_aid_cert_expiry',
+  'fire_safety_cert_date',
+  'fire_safety_cert_expiry',
+  'evacuation_cert_date',
+  'evacuation_cert_expiry',
+  'additional_certifications',
+  'residence_permit_type',
+  'residence_permit_number',
+  'residence_permit_expiry',
+  'requires_work_permit',
+  'has_valid_work_authorization',
+  'expiring_documents',
+  'criminal_record_status',
+  'criminal_record_check_date',
+  'user_id',
+  'user_account_active',
+  'user_account_activated_at',
+  'user_account_deactivated_at',
+  'onboarding_completed',
+  'onboarding_steps',
+  'onboarding_started_at',
+  'onboarding_completed_at',
+  'onboarding_workflow',
+  'onboarding_invitation',
+  'legal_entity_id',
+  'establishment_id',
+  'position',
+  'management_level',
+  'user',
+  'qualifications',
+  'documents',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+]
+const conditionallyOmittedEmployeeProperties = [
+  'id_document_number',
+  'tax_id',
+  'social_security_number',
+  'hourly_rate',
+  'health_insurance_number',
+  'sachkunde_ihk_number',
+  'work_permit_number',
+  'firearms_license_number',
+  'first_aid_cert_number',
+  'residence_permit_number',
+  'user',
+  'qualifications',
+  'documents',
+]
+
+if (
+  employeeResourceProperties.some(
+    (property) => employee.properties?.[property] === undefined
+  ) ||
+  conditionallyOmittedEmployeeProperties.some((property) =>
+    employee.required?.includes(property)
+  ) ||
+  employee.properties?.qualifications?.items?.$ref !==
+    '#/components/schemas/EmployeeQualificationResource' ||
+  employee.properties?.documents?.items?.$ref !==
+    '#/components/schemas/EmployeeDocumentResource' ||
+  !/employees\.read_sensitive/.test(
+    employee.properties?.id_document_number?.description ?? ''
+  ) ||
+  !/employees\.read_salary/.test(
+    employee.properties?.hourly_rate?.description ?? ''
+  ) ||
+  !/relation is not loaded/.test(
+    employee.properties?.qualifications?.description ?? ''
+  ) ||
+  !/relation is not loaded/.test(
+    employee.properties?.documents?.description ?? ''
+  )
+) {
+  contractErrors.push(
+    'Employee must inventory every EmployeeResource field, including permission-gated identifiers and conditionally loaded relationships.'
+  )
+}
+
 const expectedAlertDocumentProperties = {
   type: {
     type: 'string',

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -258,6 +258,13 @@ if (
 }
 
 const employee = schemas.Employee ?? {}
+const employeeCreateRequest = schemas.EmployeeCreateRequest ?? {}
+const employeeUpdateRequest = schemas.EmployeeUpdateRequest ?? {}
+const employeeAdditionalCertification =
+  schemas.EmployeeAdditionalCertification ?? {}
+const microsecondApiTimestamp = schemas.MicrosecondApiTimestamp ?? {}
+const nullableMicrosecondApiTimestamp =
+  schemas.NullableMicrosecondApiTimestamp ?? {}
 const alertDocument = schemas.EmployeeComplianceAlertDocument ?? {}
 const employeeResourceProperties = [
   'id',
@@ -358,44 +365,177 @@ const employeeResourceProperties = [
   'updated_at',
   'deleted_at',
 ]
-const conditionallyOmittedEmployeeProperties = [
-  'id_document_number',
-  'tax_id',
-  'social_security_number',
-  'hourly_rate',
-  'health_insurance_number',
-  'sachkunde_ihk_number',
-  'work_permit_number',
-  'firearms_license_number',
-  'first_aid_cert_number',
-  'residence_permit_number',
+const conditionallyOmittedEmployeeProperties =
+  'addresses current_address id_document_number tax_id social_security_number hourly_rate health_insurance_number sachkunde_ihk_number work_permit_number firearms_license_number first_aid_cert_number residence_permit_number user qualifications documents'.split(
+    ' '
+  )
+const requiredEmployeeResourceProperties = employeeResourceProperties.filter(
+  (property) => !conditionallyOmittedEmployeeProperties.includes(property)
+)
+const sensitiveEmployeeProperties =
+  'id_document_number tax_id social_security_number health_insurance_number sachkunde_ihk_number work_permit_number firearms_license_number first_aid_cert_number residence_permit_number'.split(
+    ' '
+  )
+const conditionallyLoadedEmployeeRelationships = [
+  'addresses',
+  'current_address',
   'user',
   'qualifications',
   'documents',
 ]
+const workPermitTypes = [
+  'none',
+  'temporary',
+  'permanent',
+  'blue_card',
+  'seasonal',
+  'student',
+]
+const expectedWorkPermitTypeShape = {
+  type: ['string', 'null'],
+  enum: workPermitTypes,
+}
+const contractShape = (value) => {
+  if (Array.isArray(value)) return value.map(contractShape)
+  if (value === null || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !['description', 'example'].includes(key))
+      .map(([key, entry]) => [key, contractShape(entry)])
+  )
+}
+const expectedEmployeeResourcePropertyShapes = {
+  id_document_type: {
+    type: ['string', 'null'],
+    enum: ['passport', 'id_card', 'residence_permit'],
+  },
+  id_document_number: { type: ['string', 'null'] },
+  id_document_expiry: { type: ['string', 'null'], format: 'date' },
+  id_document_copy_path: { type: ['string', 'null'] },
+  id_document_copy_deleted_at: {
+    $ref: '#/components/schemas/NullableApiTimestamp',
+  },
+  employment_end_date: {
+    $ref: '#/components/schemas/NullableMicrosecondApiTimestamp',
+  },
+  retention_period_end: {
+    $ref: '#/components/schemas/NullableMicrosecondApiTimestamp',
+  },
+  work_permit_copy_path: { type: ['string', 'null'] },
+  work_permit_issued_by: { type: ['string', 'null'], maxLength: 255 },
+  work_permit_copy_deleted_at: {
+    $ref: '#/components/schemas/NullableApiTimestamp',
+  },
+  work_permit_type: expectedWorkPermitTypeShape,
+  firearms_license_number: { type: ['string', 'null'] },
+  firearms_license_expiry: { type: ['string', 'null'], format: 'date' },
+  firearms_license_issued_by: {
+    type: ['string', 'null'],
+    maxLength: 255,
+  },
+  first_aid_cert_number: { type: ['string', 'null'] },
+  first_aid_cert_date: { type: ['string', 'null'], format: 'date' },
+  first_aid_cert_expiry: { type: ['string', 'null'], format: 'date' },
+  fire_safety_cert_date: { type: ['string', 'null'], format: 'date' },
+  fire_safety_cert_expiry: { type: ['string', 'null'], format: 'date' },
+  evacuation_cert_date: { type: ['string', 'null'], format: 'date' },
+  evacuation_cert_expiry: { type: ['string', 'null'], format: 'date' },
+  additional_certifications: {
+    type: 'array',
+    items: { $ref: '#/components/schemas/EmployeeAdditionalCertification' },
+  },
+  requires_work_permit: { type: 'boolean' },
+  has_valid_work_authorization: { type: 'boolean' },
+  qualifications: {
+    type: 'array',
+    items: { $ref: '#/components/schemas/EmployeeQualificationResource' },
+  },
+  documents: {
+    type: 'array',
+    items: { $ref: '#/components/schemas/EmployeeDocumentResource' },
+  },
+}
+const actualEmployeeResourcePropertyShapes = Object.fromEntries(
+  Object.keys(expectedEmployeeResourcePropertyShapes).map((property) => [
+    property,
+    contractShape(employee.properties?.[property]),
+  ])
+)
+const expectedEmployeeAdditionalCertificationShape = {
+  type: 'object',
+  required: ['name'],
+  properties: {
+    name: { type: 'string', maxLength: 255 },
+    number: { type: ['string', 'null'], maxLength: 255 },
+    issued_date: { type: ['string', 'null'] },
+    expiry_date: { type: ['string', 'null'] },
+    issuer: { type: ['string', 'null'], maxLength: 255 },
+  },
+}
+const expectedMicrosecondApiTimestampShape = {
+  type: 'string',
+  format: 'date-time',
+  pattern: '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z$',
+}
+const expectedNullableMicrosecondApiTimestampShape = {
+  oneOf: [
+    { $ref: '#/components/schemas/MicrosecondApiTimestamp' },
+    { type: 'null' },
+  ],
+}
 
 if (
-  employeeResourceProperties.some(
-    (property) => employee.properties?.[property] === undefined
+  !isDeepStrictEqual(
+    Object.keys(employee.properties ?? {}).sort(),
+    [...employeeResourceProperties].sort()
   ) ||
-  conditionallyOmittedEmployeeProperties.some((property) =>
-    employee.required?.includes(property)
+  !isDeepStrictEqual(
+    [...(employee.required ?? [])].sort(),
+    [...requiredEmployeeResourceProperties].sort()
   ) ||
-  employee.properties?.qualifications?.items?.$ref !==
-    '#/components/schemas/EmployeeQualificationResource' ||
-  employee.properties?.documents?.items?.$ref !==
-    '#/components/schemas/EmployeeDocumentResource' ||
-  !/employees\.read_sensitive/.test(
-    employee.properties?.id_document_number?.description ?? ''
+  !isDeepStrictEqual(
+    actualEmployeeResourcePropertyShapes,
+    expectedEmployeeResourcePropertyShapes
+  ) ||
+  !isDeepStrictEqual(
+    contractShape(employeeCreateRequest.properties?.work_permit_type),
+    expectedWorkPermitTypeShape
+  ) ||
+  !isDeepStrictEqual(
+    contractShape(employeeUpdateRequest.properties?.work_permit_type),
+    expectedWorkPermitTypeShape
+  ) ||
+  !isDeepStrictEqual(
+    contractShape(employeeAdditionalCertification),
+    expectedEmployeeAdditionalCertificationShape
+  ) ||
+  !isDeepStrictEqual(
+    contractShape(microsecondApiTimestamp),
+    expectedMicrosecondApiTimestampShape
+  ) ||
+  !isDeepStrictEqual(
+    contractShape(nullableMicrosecondApiTimestamp),
+    expectedNullableMicrosecondApiTimestampShape
+  ) ||
+  sensitiveEmployeeProperties.some(
+    (property) =>
+      !/employees\.read_sensitive/.test(
+        employee.properties?.[property]?.description ?? ''
+      )
   ) ||
   !/employees\.read_salary/.test(
     employee.properties?.hourly_rate?.description ?? ''
   ) ||
-  !/relation is not loaded/.test(
-    employee.properties?.qualifications?.description ?? ''
+  conditionallyLoadedEmployeeRelationships.some(
+    (property) =>
+      !/omitted/i.test(employee.properties?.[property]?.description ?? '')
   ) ||
-  !/relation is not loaded/.test(
-    employee.properties?.documents?.description ?? ''
+  !/employees\.read_sensitive/.test(
+    employee.properties?.additional_certifications?.description ?? ''
+  ) ||
+  !/employees\.read_sensitive/.test(
+    employeeAdditionalCertification.properties?.number?.description ?? ''
   )
 ) {
   contractErrors.push(

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -88,6 +88,30 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('rejects EmployeeResource response field and conditional-relationship drift', () => {
+  const mutations = [
+    (candidate) =>
+      delete candidate.components.schemas.Employee.properties
+        .additional_certifications,
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.qualifications.items = {
+        $ref: '#/components/schemas/QualificationResource',
+      }),
+    (candidate) =>
+      candidate.components.schemas.Employee.required.push('documents'),
+  ]
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, result.stdout)
+    assert.match(result.stderr, /EmployeeResource field/i)
+  }
+})
+
 test('rejects a missing employee compliance-alert collection operation', () => {
   const candidate = structuredClone(parsedContract)
   delete candidate.paths['/employees/compliance-alerts']

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -88,17 +88,86 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
-test('rejects EmployeeResource response field and conditional-relationship drift', () => {
+test('rejects EmployeeResource response field inventory drift', () => {
   const mutations = [
     (candidate) =>
       delete candidate.components.schemas.Employee.properties
         .additional_certifications,
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.schema_only_field = {
+        type: 'string',
+      }),
+  ]
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, result.stdout)
+    assert.match(result.stderr, /EmployeeResource field/i)
+  }
+})
+
+test('rejects EmployeeResource requiredness and relationship drift', () => {
+  const mutations = [
     (candidate) =>
       (candidate.components.schemas.Employee.properties.qualifications.items = {
         $ref: '#/components/schemas/QualificationResource',
       }),
     (candidate) =>
       candidate.components.schemas.Employee.required.push('documents'),
+    (candidate) =>
+      (candidate.components.schemas.Employee.required =
+        candidate.components.schemas.Employee.required.filter(
+          (property) => property !== 'requires_work_permit'
+        )),
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.firearms_license_number.description =
+        'Decrypted firearms-license number.'),
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.addresses.description =
+        'Employee address records.'),
+  ]
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutate(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, result.stdout)
+    assert.match(result.stderr, /EmployeeResource field/i)
+  }
+})
+
+test('rejects EmployeeResource response schema-shape drift', () => {
+  const mutations = [
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.employment_end_date = {
+        type: ['string', 'null'],
+        format: 'date',
+        description:
+          'Lifecycle-managed employment end date used for retention calculations.',
+      }),
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.requires_work_permit = {
+        type: 'string',
+      }),
+    (candidate) =>
+      (candidate.components.schemas.Employee.properties.work_permit_type.enum =
+        ['unlimited', 'limited', 'none']),
+    (candidate) =>
+      (candidate.components.schemas.EmployeeCreateRequest.properties.work_permit_type.enum =
+        ['unlimited', 'limited', 'none']),
+    (candidate) =>
+      candidate.components.schemas.EmployeeUpdateRequest.properties.work_permit_type.enum.pop(),
+    (candidate) =>
+      (candidate.components.schemas.EmployeeAdditionalCertification.properties.expiry_date.format =
+        'date'),
+    (candidate) =>
+      delete candidate.components.schemas.MicrosecondApiTimestamp.pattern,
   ]
 
   for (const mutate of mutations) {


### PR DESCRIPTION
## Summary

Closes #382.

`App\\Http\\Resources\\EmployeeResource` emits response fields that were absent from `components.schemas.Employee`, leaving generated clients without identity-document copy metadata, work-permit metadata, certification fields, authorization summaries, and optional relationship payloads.

This change inventories the complete resource surface in `docs/openapi.yaml`, adds typed nullable and date-formatted fields, documents permission-gated omissions, introduces the reusable additional-certification schema and example, and models conditionally loaded `qualifications` and `documents` relationships.

It also adds positive and negative verified-endpoint guard coverage so future field omissions, relationship reference drift, or incorrect requiredness fail validation.

## Evidence

- `EmployeeResource` emits 97 top-level response fields; the previous `Employee` schema omitted 25 of them.
- The final inventory check reports 97 resource fields, 97 schema fields, and no missing or extra fields.

## Validation

- `npm run validate`
- `reuse lint`
- `git diff --check`
- Signed commit: `3cb7e2c`

## Readiness

No in-scope dependencies or unresolved checks prevent review. This PR remains draft pending the required final PR-view self-review and CI completion.
