### PR TITLE
Complete Customer and Site response contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Completed the `Customer` and `Site` response contracts for every field
+  emitted by their resources. Conditional relationships and counts now use
+  reusable schemas and document their eager-loading/counting presence rules;
+  Site `access_instructions` and `notes` now explicitly document their
+  update-authorization gate. Customer and Site endpoint descriptions and
+  examples distinguish eager-loaded fields from omitted fields (closes #383).
 - Replaced the unsupported Employee access activity example with the runtime
   `employee_changes` update event and its metadata-free API representation.
   Contract validation rejects unsupported categories/events, automatic diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitted by their resources. Conditional relationships and counts now use
   reusable schemas and document their eager-loading/counting presence rules;
   Site `access_instructions` and `notes` now explicitly document their
-  update-authorization gate. Customer and Site endpoint descriptions and
-  examples distinguish eager-loaded fields from omitted fields (closes #383).
+  update-authorization gate. Customer and Site endpoint descriptions, examples,
+  and semantic validation distinguish eager-loaded fields from omitted fields,
+  superseding the earlier always-present `customer_establishments` description.
+  Embedded and dedicated assignment schemas and collection role filters now
+  match their distinct runtime resources, including preserved null-user
+  history, and the unsupported Site `include` parameter and `is_primary`
+  assignment field were removed (closes #383).
 - Replaced the unsupported Employee access activity example with the runtime
   `employee_changes` update event and its metadata-free API representation.
   Contract validation rejects unsupported categories/events, automatic diffs

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5643,6 +5643,8 @@ components:
       additionalProperties: false
       description: |
         Customer (client organization) entity with an explicit Legal Entity assignment.
+        Relationship and count fields are emitted only when the corresponding relationship
+        is eager loaded or counted by the endpoint; clients must tolerate their omission.
 
         No default Legal Entity assignment is permitted for existing customers. A customer
         may be backfilled only after a product-approved deterministic tenant-consistent rule
@@ -5654,7 +5656,6 @@ components:
         - name
         - billing_address
         - is_active
-        - customer_establishments
         - created_at
         - updated_at
       properties:
@@ -5693,14 +5694,13 @@ components:
           description: Whether customer is active
           example: true
         sites_count:
-          type: integer
-          minimum: 0
-          description: Number of the customer's sites visible to the current caller. Present on customer list and detail responses.
+          $ref: '#/components/schemas/NonNegativeRelationshipCount'
+        sites:
+          $ref: '#/components/schemas/CustomerSitesRelationship'
+        assignments:
+          $ref: '#/components/schemas/CustomerAssignmentsRelationship'
         customer_establishments:
-          type: array
-          description: Customer-to-establishment assignments with local contact data that are visible to the current caller. Always present; empty when the customer has no visible assignments. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.
-          items:
-            $ref: '#/components/schemas/CustomerEstablishment'
+          $ref: '#/components/schemas/CustomerEstablishmentRelationship'
         created_at:
           allOf:
             - $ref: '#/components/schemas/ApiTimestamp'
@@ -5716,6 +5716,29 @@ components:
             - $ref: '#/components/schemas/NullableApiTimestamp'
           description: Soft deletion timestamp
           example: null
+
+    NonNegativeRelationshipCount:
+      type: integer
+      minimum: 0
+      description: Non-negative relationship count emitted only when that relationship is counted; omitted otherwise.
+
+    CustomerSitesRelationship:
+      type: array
+      description: Sites visible to the current caller, emitted only when the `sites` relationship is eager loaded; omitted otherwise.
+      items:
+        $ref: '#/components/schemas/Site'
+
+    CustomerAssignmentsRelationship:
+      type: array
+      description: Customer assignments emitted only when the `assignments` relationship is eager loaded; omitted otherwise.
+      items:
+        $ref: '#/components/schemas/CustomerAssignment'
+
+    CustomerEstablishmentRelationship:
+      type: array
+      description: Customer-to-establishment assignments with local contact data that are visible to the current caller, emitted only when the `customerEstablishments` relationship is eager loaded; omitted otherwise. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.
+      items:
+        $ref: '#/components/schemas/CustomerEstablishment'
 
     LegalEntityLookup:
       type: object
@@ -6064,7 +6087,8 @@ components:
 
     Site:
       type: object
-      description: Site (physical location/object) where services are provided
+      additionalProperties: false
+      description: Site (physical location/object) where services are provided. Relationship and count fields are emitted only when the corresponding relationship is eager loaded or counted by the endpoint; clients must tolerate their omission.
       required:
         - id
         - customer_id
@@ -6123,11 +6147,11 @@ components:
             - type: 'null'
         access_instructions:
           type: [string, 'null']
-          description: Instructions for accessing the site (conditionally visible)
+          description: Instructions for accessing the site. Emitted only when the current caller is authorized to update this site; omitted for other callers. When emitted, the value may be null.
           example: 'Gate 5, Security Check, Badge required'
         notes:
           type: [string, 'null']
-          description: Internal notes (conditionally visible)
+          description: Internal site notes. Emitted only when the current caller is authorized to update this site; omitted for other callers. When emitted, the value may be null.
           example: 'High security area'
         metadata:
           type: [object, 'null']
@@ -6148,6 +6172,14 @@ components:
           format: date
           description: Contract end date (for temporary sites)
           example: '2025-12-31'
+        customer:
+          $ref: '#/components/schemas/SiteCustomerRelationship'
+        assignments:
+          $ref: '#/components/schemas/SiteAssignmentsRelationship'
+        assigned_users_count:
+          $ref: '#/components/schemas/NonNegativeRelationshipCount'
+        cost_centers_count:
+          $ref: '#/components/schemas/NonNegativeRelationshipCount'
         is_expired:
           type: boolean
           description: Whether validity period has expired (computed)
@@ -6171,6 +6203,17 @@ components:
             - $ref: '#/components/schemas/NullableApiTimestamp'
           description: Soft deletion timestamp
           example: null
+
+    SiteCustomerRelationship:
+      description: Customer emitted only when the `customer` relationship is eager loaded; omitted otherwise.
+      allOf:
+        - $ref: '#/components/schemas/Customer'
+
+    SiteAssignmentsRelationship:
+      type: array
+      description: Site assignments emitted only when the `assignments` relationship is eager loaded; omitted otherwise.
+      items:
+        $ref: '#/components/schemas/SiteAssignment'
 
     SiteCreateRequest:
       type: object
@@ -10271,7 +10314,7 @@ paths:
     get:
       summary: List Customers
       description: |
-        Retrieve a paginated list of customers with optional filtering.
+        Retrieve a paginated list of customers with optional filtering. The list eager loads a caller-visible `sites_count`; it does not eager load relationship fields, which are omitted.
         Full collection access requires `customers.read` without organizational scopes. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no customer-record access, so it yields an empty authorized collection.
       operationId: listCustomers
       tags:
@@ -10327,8 +10370,8 @@ paths:
                   meta:
                     $ref: '#/components/schemas/PaginationMeta'
               examples:
-                withCustomerEstablishment:
-                  summary: Customer with an embedded establishment assignment
+                withVisibleSitesCount:
+                  summary: Customer list item with the caller-visible site count
                   value:
                     data:
                       - id: '550e8400-e29b-41d4-a716-446655440000'
@@ -10342,24 +10385,14 @@ paths:
                           country: DE
                         is_active: true
                         sites_count: 2
-                        customer_establishments:
-                          - id: '790e8400-e29b-41d4-a716-446655440000'
-                            customer_id: '550e8400-e29b-41d4-a716-446655440000'
-                            establishment_id: '780e8400-e29b-41d4-a716-446655440000'
-                            contact_name: Max Mustermann
-                            phone: '+49 30 12345678'
-                            email: 'max.mustermann@secpal.dev'
-                            comments: Use the service entrance after 18:00.
-                            created_at: '2025-12-05T10:00:00Z'
-                            updated_at: '2025-12-15T14:30:00Z'
                         created_at: '2025-12-05T10:00:00Z'
                         updated_at: '2025-12-15T14:30:00Z'
                     meta:
                       current_page: 1
                       per_page: 15
                       total: 1
-                withoutCustomerEstablishments:
-                  summary: Customer without a caller-visible establishment assignment
+                withZeroVisibleSites:
+                  summary: Customer list item with no caller-visible sites
                   value:
                     data:
                       - id: '550e8400-e29b-41d4-a716-446655440001'
@@ -10373,7 +10406,6 @@ paths:
                           country: DE
                         is_active: true
                         sites_count: 0
-                        customer_establishments: []
                         created_at: '2025-12-05T10:00:00Z'
                         updated_at: '2025-12-15T14:30:00Z'
                     meta:
@@ -10721,7 +10753,7 @@ paths:
     get:
       summary: Get Customer
       description: |
-        Retrieve a single customer's Legal-Entity-wide master data.
+        Retrieve a single customer's Legal-Entity-wide master data. The response eager loads caller-visible `sites`, `assignments`, and `customer_establishments`, and counts visible sites. Embedded relationships remain omitted on endpoints that do not eager load them.
         Requires an active customer or site assignment, or `customers.read` without organizational scopes. OU scopes alone do not grant record access.
       operationId: getCustomer
       tags:
@@ -10749,8 +10781,8 @@ paths:
                   data:
                     $ref: '#/components/schemas/Customer'
               examples:
-                withCustomerEstablishment:
-                  summary: Customer with an embedded establishment assignment
+                withExpandedRelationships:
+                  summary: Customer with all relationships eager loaded by this endpoint
                   value:
                     data:
                       id: '550e8400-e29b-41d4-a716-446655440000'
@@ -10764,6 +10796,8 @@ paths:
                         country: DE
                       is_active: true
                       sites_count: 2
+                      sites: []
+                      assignments: []
                       customer_establishments:
                         - id: '790e8400-e29b-41d4-a716-446655440000'
                           customer_id: '550e8400-e29b-41d4-a716-446655440000'
@@ -10776,8 +10810,8 @@ paths:
                           updated_at: '2025-12-15T14:30:00Z'
                       created_at: '2025-12-05T10:00:00Z'
                       updated_at: '2025-12-15T14:30:00Z'
-                withoutCustomerEstablishments:
-                  summary: Customer without a caller-visible establishment assignment
+                withNoVisibleRelationships:
+                  summary: Customer whose eager-loaded relationships are empty for this caller
                   value:
                     data:
                       id: '550e8400-e29b-41d4-a716-446655440001'
@@ -10792,6 +10826,8 @@ paths:
                       is_active: true
                       sites_count: 0
                       customer_establishments: []
+                      sites: []
+                      assignments: []
                       created_at: '2025-12-05T10:00:00Z'
                       updated_at: '2025-12-15T14:30:00Z'
         '401':
@@ -10968,7 +11004,7 @@ paths:
     get:
       summary: List Sites
       description: |
-        Retrieve a paginated list of sites with comprehensive filtering.
+        Retrieve a paginated list of sites with comprehensive filtering. Each item eager loads `customer` and `assignments`; relationship counts are omitted because they are not counted by this endpoint. `access_instructions` and `notes` are included only for callers authorized to update the individual site.
         `sites.read` grants tenant-wide access. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no site-record access, so it yields an empty authorized collection.
       operationId: listSites
       tags:
@@ -11052,7 +11088,7 @@ paths:
     post:
       summary: Create Site
       description: |
-        Create a new site. The optional `site_number` is accepted as supplied; when omitted or null, the API generates an OBJ-YYYY-#### value.
+        Create a new site. The optional `site_number` is accepted as supplied; when omitted or null, the API generates an OBJ-YYYY-#### value. The creation response does not eager load relationship or count fields. `access_instructions` and `notes` are included only when the caller is authorized to update the created site.
         Requires `sites.create`, an active, non-deleted customer, an active, non-deleted Legal Entity and establishment, and a tenant- and Legal-Entity-consistent combination with an existing customer-establishment link for the selected customer and establishment. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `sites.create`. Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createSite
       tags:
@@ -11094,7 +11130,7 @@ paths:
     get:
       summary: Get Site
       description: |
-        Retrieve a single site by ID with optional relationships.
+        Retrieve a single site by ID. The response eager loads `customer` and `assignments`; relationship counts are omitted because they are not counted by this endpoint. `access_instructions` and `notes` are included only for callers authorized to update this site.
         Requires `sites.read` or an active customer or site assignment. OU scopes alone do not grant record access.
       operationId: getSite
       tags:
@@ -11109,13 +11145,6 @@ paths:
             type: string
             format: uuid
           description: Site UUID
-        - name: include
-          in: query
-          required: false
-          schema:
-            type: string
-            enum: [customer, assignments, costCenters, customer.assignments]
-          description: Comma-separated list of relationships to include
       responses:
         '200':
           description: Site retrieved successfully
@@ -11140,7 +11169,7 @@ paths:
     patch:
       summary: Update Site
       description: |
-        Update site fields (PATCH semantics - all fields optional).
+        Update site fields (PATCH semantics - all fields optional). The update response does not eager load relationship or count fields. `access_instructions` and `notes` are included only when the caller is authorized to update the site.
         Requires `sites.update` and view access to the site. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `sites.update` and view access.
       operationId: updateSite
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5732,7 +5732,7 @@ components:
       type: array
       description: Customer assignments emitted only when the `assignments` relationship is eager loaded; omitted otherwise.
       items:
-        $ref: '#/components/schemas/CustomerAssignment'
+        $ref: '#/components/schemas/EmbeddedCustomerAssignment'
 
     CustomerEstablishmentRelationship:
       type: array
@@ -6213,7 +6213,7 @@ components:
       type: array
       description: Site assignments emitted only when the `assignments` relationship is eager loaded; omitted otherwise.
       items:
-        $ref: '#/components/schemas/SiteAssignment'
+        $ref: '#/components/schemas/EmbeddedSiteAssignment'
 
     SiteCreateRequest:
       type: object
@@ -6379,14 +6379,42 @@ components:
               establishment_id: '780e8400-e29b-41d4-a716-446655440000'
             status: 422
 
-    CustomerAssignment:
+    AssignmentUser:
       type: object
-      description: Flexible user-to-customer role assignment
+      additionalProperties: false
+      description: Minimal user data embedded in assignment responses. Historical assignments preserve this property with a null value after user deletion.
+      required:
+        - id
+        - name
+        - email
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        created_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+        updated_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+
+    EmbeddedCustomerAssignment:
+      type: object
+      additionalProperties: false
+      description: Customer assignment embedded by CustomerResource. The user relationship is eager loaded by customer list and detail endpoints and is null for preserved history after user deletion.
       required:
         - id
         - customer_id
         - user_id
         - role
+        - valid_from
+        - valid_until
+        - notes
+        - is_active
+        - user
         - created_at
         - updated_at
       properties:
@@ -6401,49 +6429,46 @@ components:
           description: Customer being assigned
           example: '550e8400-e29b-41d4-a716-446655440000'
         user_id:
-          type: string
+          type: [string, 'null']
           format: uuid
-          description: User being assigned
-          example: '990e8400-e29b-41d4-a716-446655440000'
+          description: Assigned user identifier. Null when the user was deleted but assignment history is preserved.
         role:
           type: string
           maxLength: 100
-          description: Flexible role name (e.g., "Key Account Manager", "Billing Contact")
           example: 'Key Account Manager'
         valid_from:
           type: [string, 'null']
           format: date
-          description: Assignment start date
-          example: '2025-01-01'
         valid_until:
           type: [string, 'null']
           format: date
-          description: Assignment end date
-          example: '2025-12-31'
         notes:
           type: [string, 'null']
-          description: Optional assignment notes
-          example: 'Primary contact for escalations'
+        is_active:
+          type: boolean
+        user:
+          anyOf:
+            - $ref: '#/components/schemas/AssignmentUser'
+            - type: 'null'
         created_at:
-          allOf:
-            - $ref: '#/components/schemas/ApiTimestamp'
-          description: Creation timestamp
-          example: '2025-12-05T12:00:00Z'
+          $ref: '#/components/schemas/ApiTimestamp'
         updated_at:
-          allOf:
-            - $ref: '#/components/schemas/ApiTimestamp'
-          description: Last update timestamp
-          example: '2025-12-15T16:00:00Z'
+          $ref: '#/components/schemas/ApiTimestamp'
 
-    SiteAssignment:
+    EmbeddedSiteAssignment:
       type: object
-      description: Flexible user-to-site role assignment
+      additionalProperties: false
+      description: Site assignment embedded by SiteResource. The user relationship is eager loaded by site list and detail endpoints and is null for preserved history after user deletion.
       required:
         - id
         - site_id
         - user_id
         - role
-        - is_primary
+        - valid_from
+        - valid_until
+        - notes
+        - is_active
+        - user
         - created_at
         - updated_at
       properties:
@@ -6458,19 +6483,113 @@ components:
           description: Site being assigned
           example: '660e8400-e29b-41d4-a716-446655440000'
         user_id:
+          type: [string, 'null']
+          format: uuid
+          description: Assigned user identifier. Null when the user was deleted but assignment history is preserved.
+        role:
+          type: string
+          maxLength: 100
+          example: 'Site Manager'
+        valid_from:
+          type: [string, 'null']
+          format: date
+        valid_until:
+          type: [string, 'null']
+          format: date
+        notes:
+          type: [string, 'null']
+        is_active:
+          type: boolean
+        user:
+          anyOf:
+            - $ref: '#/components/schemas/AssignmentUser'
+            - type: 'null'
+        created_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+        updated_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+
+    CustomerAssignment:
+      type: object
+      additionalProperties: false
+      description: Customer assignment returned by the dedicated assignment endpoints. User and customer relationships are eager loaded; user is null for preserved history after user deletion.
+      required:
+        - id
+        - role
+        - is_active
+        - valid_from
+        - valid_until
+        - notes
+        - user
+        - customer
+        - created_at
+        - updated_at
+      properties:
+        id:
           type: string
           format: uuid
-          description: User being assigned
-          example: '990e8400-e29b-41d4-a716-446655440000'
+          description: Unique assignment identifier
+          example: '880e8400-e29b-41d4-a716-446655440000'
+        role:
+          type: string
+          maxLength: 100
+          description: Flexible role name (e.g., "Key Account Manager", "Billing Contact")
+          example: 'Key Account Manager'
+        is_active:
+          type: boolean
+        valid_from:
+          type: [string, 'null']
+          format: date
+          description: Assignment start date
+          example: '2025-01-01'
+        valid_until:
+          type: [string, 'null']
+          format: date
+          description: Assignment end date
+          example: '2025-12-31'
+        notes:
+          type: [string, 'null']
+          description: Optional assignment notes
+          example: 'Primary contact for escalations'
+        user:
+          anyOf:
+            - $ref: '#/components/schemas/AssignmentUser'
+            - type: 'null'
+        customer:
+          $ref: '#/components/schemas/Customer'
+        created_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+        updated_at:
+          $ref: '#/components/schemas/ApiTimestamp'
+
+    SiteAssignment:
+      type: object
+      additionalProperties: false
+      description: Site assignment returned by the dedicated assignment endpoints. User and site relationships are eager loaded; user is null for preserved history after user deletion.
+      required:
+        - id
+        - role
+        - is_active
+        - valid_from
+        - valid_until
+        - notes
+        - user
+        - site
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique assignment identifier
+          example: 'aa0e8400-e29b-41d4-a716-446655440000'
         role:
           type: string
           maxLength: 100
           description: Flexible role name (e.g., "Site Manager", "Account Manager")
           example: 'Site Manager'
-        is_primary:
+        is_active:
           type: boolean
-          description: Whether this is the primary contact for the site
-          example: true
         valid_from:
           type: [string, 'null']
           format: date
@@ -6485,16 +6604,16 @@ components:
           type: [string, 'null']
           description: Optional assignment notes
           example: 'On-site presence required'
+        user:
+          anyOf:
+            - $ref: '#/components/schemas/AssignmentUser'
+            - type: 'null'
+        site:
+          $ref: '#/components/schemas/Site'
         created_at:
-          allOf:
-            - $ref: '#/components/schemas/ApiTimestamp'
-          description: Creation timestamp
-          example: '2025-12-05T13:00:00Z'
+          $ref: '#/components/schemas/ApiTimestamp'
         updated_at:
-          allOf:
-            - $ref: '#/components/schemas/ApiTimestamp'
-          description: Last update timestamp
-          example: '2025-12-15T17:00:00Z'
+          $ref: '#/components/schemas/ApiTimestamp'
 
     CostCenter:
       type: object
@@ -10314,7 +10433,7 @@ paths:
     get:
       summary: List Customers
       description: |
-        Retrieve a paginated list of customers with optional filtering. The list eager loads a caller-visible `sites_count`; it does not eager load relationship fields, which are omitted.
+        Retrieve a paginated list of customers with optional filtering. The list eager loads a caller-visible `sites_count`, `assignments` with their users, and caller-visible `customer_establishments`; it does not eager load `sites`, which is omitted.
         Full collection access requires `customers.read` without organizational scopes. Otherwise, records are visible only through an active customer or site assignment. An OU scope alone may authorize opening the collection but grants no customer-record access, so it yields an empty authorized collection.
       operationId: listCustomers
       tags:
@@ -10385,6 +10504,17 @@ paths:
                           country: DE
                         is_active: true
                         sites_count: 2
+                        assignments: []
+                        customer_establishments:
+                          - id: '790e8400-e29b-41d4-a716-446655440000'
+                            customer_id: '550e8400-e29b-41d4-a716-446655440000'
+                            establishment_id: '780e8400-e29b-41d4-a716-446655440000'
+                            contact_name: Max Mustermann
+                            phone: '+49 30 12345678'
+                            email: 'max.mustermann@secpal.dev'
+                            comments: Use the service entrance after 18:00.
+                            created_at: '2025-12-05T10:00:00Z'
+                            updated_at: '2025-12-15T14:30:00Z'
                         created_at: '2025-12-05T10:00:00Z'
                         updated_at: '2025-12-15T14:30:00Z'
                     meta:
@@ -10406,6 +10536,8 @@ paths:
                           country: DE
                         is_active: true
                         sites_count: 0
+                        assignments: []
+                        customer_establishments: []
                         created_at: '2025-12-05T10:00:00Z'
                         updated_at: '2025-12-15T14:30:00Z'
                     meta:
@@ -10422,7 +10554,7 @@ paths:
     post:
       summary: Create Customer
       description: |
-        Create a new customer. The optional `customer_number` is accepted as supplied; when omitted or null, the API generates a KD-YYYY-#### value.
+        Create a new customer. The optional `customer_number` is accepted as supplied; when omitted or null, the API generates a KD-YYYY-#### value. The response eager loads caller-visible `customer_establishments`; `sites`, `assignments`, and relationship count fields are omitted.
         Requires `customers.create` and a same-tenant, active, non-deleted Legal Entity. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.create`.
         Duplicate identification is evaluated atomically in the same transaction as creation. Every duplicate case returns the neutral `DuplicateConflict` response without disclosing which identifying field matched.
       operationId: createCustomer
@@ -10795,7 +10927,7 @@ paths:
                         postal_code: '10115'
                         country: DE
                       is_active: true
-                      sites_count: 2
+                      sites_count: 0
                       sites: []
                       assignments: []
                       customer_establishments:
@@ -10842,7 +10974,7 @@ paths:
     patch:
       summary: Update Customer
       description: |
-        Update customer fields (PATCH semantics - all fields optional).
+        Update customer fields (PATCH semantics - all fields optional). The response eager loads caller-visible `customer_establishments`; `sites`, `assignments`, and relationship count fields are omitted.
         Requires `customers.update` and view access to the customer. **Authorization boundary:** OU scopes do not grant access to customer or site domain writes. Callers with any organizational scopes receive HTTP **403**; unscoped callers require `customers.update` and view access. If `legal_entity_id` differs from the customer's current value, it must identify a same-tenant, active, non-deleted Legal Entity. Reassignment is allowed only when the customer has no customer-establishment links or sites; clients must migrate or delete dependent records first.
       operationId: updateCustomer
       tags:
@@ -10926,7 +11058,7 @@ paths:
     get:
       summary: List Customer Sites
       description: |
-        Retrieve all sites belonging to a specific customer.
+        Retrieve all sites belonging to a specific customer. Each item eager loads `assignments` with their users; `customer` and relationship counts are omitted. `access_instructions` and `notes` are included only for callers authorized to update the individual site.
         Paginated with same filters as /sites endpoint.
       operationId: listCustomerSites
       tags:
@@ -11279,6 +11411,13 @@ paths:
             type: boolean
             default: false
           description: Filter to currently active assignments only
+        - name: role
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 100
+          description: Filter by the exact flexible role name
       responses:
         '200':
           description: Assignments retrieved successfully
@@ -11339,15 +11478,15 @@ paths:
                   maxLength: 100
                   example: 'Key Account Manager'
                 valid_from:
-                  type: string
+                  type: [string, 'null']
                   format: date
                   example: '2025-01-01'
                 valid_until:
-                  type: string
+                  type: [string, 'null']
                   format: date
                   example: '2025-12-31'
                 notes:
-                  type: string
+                  type: [string, 'null']
                   example: 'Primary escalation contact'
       responses:
         '201':
@@ -11402,13 +11541,13 @@ paths:
                   type: string
                   maxLength: 100
                 valid_from:
-                  type: string
+                  type: [string, 'null']
                   format: date
                 valid_until:
-                  type: string
+                  type: [string, 'null']
                   format: date
                 notes:
-                  type: string
+                  type: [string, 'null']
       responses:
         '200':
           description: Assignment updated successfully
@@ -11490,6 +11629,13 @@ paths:
             type: boolean
             default: false
           description: Filter to currently active assignments only
+        - name: role
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 100
+          description: Filter by the exact flexible role name
       responses:
         '200':
           description: Assignments retrieved successfully
@@ -11549,20 +11695,16 @@ paths:
                   type: string
                   maxLength: 100
                   example: 'Site Manager'
-                is_primary:
-                  type: boolean
-                  default: false
-                  example: true
                 valid_from:
-                  type: string
+                  type: [string, 'null']
                   format: date
                   example: '2025-01-01'
                 valid_until:
-                  type: string
+                  type: [string, 'null']
                   format: date
                   example: '2025-12-31'
                 notes:
-                  type: string
+                  type: [string, 'null']
                   example: 'On-site presence required'
       responses:
         '201':
@@ -11592,7 +11734,7 @@ paths:
   /site-assignments/{siteAssignment}:
     patch:
       summary: Update Site Assignment
-      description: Update site assignment fields (role, is_primary, validity dates, notes).
+      description: Update site assignment fields (role, validity dates, notes).
       operationId: updateSiteAssignment
       tags:
         - Assignments
@@ -11616,16 +11758,14 @@ paths:
                 role:
                   type: string
                   maxLength: 100
-                is_primary:
-                  type: boolean
                 valid_from:
-                  type: string
+                  type: [string, 'null']
                   format: date
                 valid_until:
-                  type: string
+                  type: [string, 'null']
                   format: date
                 notes:
-                  type: string
+                  type: [string, 'null']
       responses:
         '200':
           description: Assignment updated successfully

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5736,7 +5736,7 @@ components:
 
     CustomerEstablishmentRelationship:
       type: array
-      description: Customer-to-establishment assignments with local contact data that are visible to the current caller, emitted only when the `customerEstablishments` relationship is eager loaded; omitted otherwise. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.
+      description: Customer-to-establishment assignments with local contact data that are visible to the current caller, emitted only when the `customer_establishments` relationship is eager loaded; omitted otherwise. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.
       items:
         $ref: '#/components/schemas/CustomerEstablishment'
 
@@ -6396,10 +6396,6 @@ components:
         email:
           type: string
           format: email
-        created_at:
-          $ref: '#/components/schemas/ApiTimestamp'
-        updated_at:
-          $ref: '#/components/schemas/ApiTimestamp'
 
     EmbeddedCustomerAssignment:
       type: object

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -660,6 +660,8 @@ for (const schemaName of [
 if (
   schemas.AssignmentUser?.type !== 'object' ||
   schemas.AssignmentUser.additionalProperties !== false ||
+  JSON.stringify(Object.keys(schemas.AssignmentUser.properties ?? {})) !==
+    JSON.stringify(['id', 'name', 'email']) ||
   JSON.stringify(schemas.AssignmentUser.required) !==
     JSON.stringify(['id', 'name', 'email'])
 ) {

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -453,11 +453,59 @@ const customerAllowedProperties = new Set([
   'billing_address',
   'is_active',
   'sites_count',
+  'sites',
+  'assignments',
   'customer_establishments',
   'created_at',
   'updated_at',
   'deleted_at',
 ])
+const resourceSchemaInventories = {
+  Customer: customerAllowedProperties,
+  Site: new Set([
+    'id',
+    'customer_id',
+    'legal_entity_id',
+    'establishment_id',
+    'site_number',
+    'name',
+    'type',
+    'address',
+    'full_address',
+    'contact',
+    'access_instructions',
+    'notes',
+    'metadata',
+    'is_active',
+    'is_expired',
+    'valid_from',
+    'valid_until',
+    'customer',
+    'assignments',
+    'assigned_users_count',
+    'cost_centers_count',
+    'created_at',
+    'updated_at',
+    'deleted_at',
+  ]),
+}
+for (const [schemaName, expectedProperties] of Object.entries(
+  resourceSchemaInventories
+)) {
+  const actualProperties = new Set(
+    Object.keys(schemas[schemaName]?.properties ?? {})
+  )
+  if (
+    actualProperties.size !== expectedProperties.size ||
+    [...expectedProperties].some(
+      (propertyName) => !actualProperties.has(propertyName)
+    )
+  ) {
+    errors.push(
+      `${schemaName} must inventory every field emitted by its resource.`
+    )
+  }
+}
 if (schemas.Customer?.additionalProperties !== false) {
   errors.push('Customer must remain a closed master-data response schema.')
 }
@@ -468,32 +516,68 @@ for (const propertyName of Object.keys(schemas.Customer?.properties ?? {})) {
     )
   }
 }
-const customerSitesCount = schemas.Customer?.properties?.sites_count
+const conditionalResourceFields = {
+  Customer: {
+    sites_count: 'NonNegativeRelationshipCount',
+    sites: 'CustomerSitesRelationship',
+    assignments: 'CustomerAssignmentsRelationship',
+    customer_establishments: 'CustomerEstablishmentRelationship',
+  },
+  Site: {
+    customer: 'SiteCustomerRelationship',
+    assignments: 'SiteAssignmentsRelationship',
+    assigned_users_count: 'NonNegativeRelationshipCount',
+    cost_centers_count: 'NonNegativeRelationshipCount',
+  },
+}
+for (const [schemaName, fields] of Object.entries(conditionalResourceFields)) {
+  for (const [fieldName, componentName] of Object.entries(fields)) {
+    const property = schemas[schemaName]?.properties?.[fieldName]
+    if (
+      property?.$ref !== `#/components/schemas/${componentName}` ||
+      schemas[schemaName]?.required?.includes(fieldName)
+    ) {
+      errors.push(
+        `${schemaName}.${fieldName} must be an optional reusable conditional-resource field.`
+      )
+    }
+  }
+}
+
+const relationshipSchemas = [
+  'CustomerSitesRelationship',
+  'CustomerAssignmentsRelationship',
+  'CustomerEstablishmentRelationship',
+  'SiteCustomerRelationship',
+  'SiteAssignmentsRelationship',
+]
+for (const schemaName of relationshipSchemas) {
+  if (
+    !/eager loaded.*omitted otherwise/i.test(
+      schemas[schemaName]?.description ?? ''
+    )
+  ) {
+    errors.push(
+      `${schemaName} must document eager-loading presence and omission.`
+    )
+  }
+}
+
+const relationshipCount = schemas.NonNegativeRelationshipCount
 if (
-  customerSitesCount?.type !== 'integer' ||
-  customerSitesCount.minimum !== 0 ||
-  schemas.Customer?.required?.includes('sites_count')
+  relationshipCount?.type !== 'integer' ||
+  relationshipCount.minimum !== 0 ||
+  !/counted.*omitted otherwise/i.test(relationshipCount?.description ?? '')
 ) {
   errors.push(
-    'Customer.sites_count must remain an optional non-negative visible-site count.'
+    'NonNegativeRelationshipCount must be a non-negative count emitted only when counted.'
   )
 }
 
-const customerEstablishments =
-  schemas.Customer?.properties?.customer_establishments
+const customerEstablishments = schemas.CustomerEstablishmentRelationship
 if (
-  customerEstablishments?.type !== 'array' ||
   customerEstablishments?.items?.$ref !==
     '#/components/schemas/CustomerEstablishment' ||
-  !schemas.Customer?.required?.includes('customer_establishments') ||
-  !/always present.*empty/i.test(customerEstablishments?.description ?? '')
-) {
-  errors.push(
-    'Customer.customer_establishments must be a required, always-present CustomerEstablishment array.'
-  )
-}
-
-if (
   !/visible to the current caller/i.test(
     customerEstablishments?.description ?? ''
   ) ||
@@ -502,80 +586,21 @@ if (
   )
 ) {
   errors.push(
-    'Customer must preserve caller-visible customer_establishments filtering for customer and site assignments.'
+    'CustomerEstablishmentRelationship must preserve caller-visible assignment filtering.'
   )
 }
 
-for (const [label, response] of [
-  [
-    'GET /customers',
-    paths['/customers']?.get?.responses?.['200']?.content?.['application/json'],
-  ],
-  [
-    'GET /customers/{customer}',
-    paths['/customers/{customer}']?.get?.responses?.['200']?.content?.[
-      'application/json'
-    ],
-  ],
-]) {
-  const data = response?.examples?.withCustomerEstablishment?.value?.data
-  const customers = Array.isArray(data) ? data : [data]
-  const hasValidAssignments =
-    customers.length > 0 &&
-    customers.every(
-      (customer) =>
-        Number.isInteger(customer?.sites_count) &&
-        customer.sites_count >= 0 &&
-        Array.isArray(customer?.customer_establishments) &&
-        customer.customer_establishments.length > 0 &&
-        customer.customer_establishments.every(
-          (assignment) =>
-            uuidValue(assignment?.id) &&
-            uuidValue(assignment?.customer_id) &&
-            uuidValue(assignment?.establishment_id) &&
-            assignment.customer_id === customer.id &&
-            !Object.hasOwn(assignment, 'organizational_unit_id') &&
-            !Object.hasOwn(assignment, 'organizational_unit')
-        )
-    )
-
-  if (!hasValidAssignments) {
-    errors.push(
-      `${label} must include a non-negative sites_count and OU-free customer_establishments with matching customer_id values.`
-    )
-  }
-
-  const emptyData =
-    response?.examples?.withoutCustomerEstablishments?.value?.data
-  const customersWithoutAssignments = Array.isArray(emptyData)
-    ? emptyData
-    : [emptyData]
+for (const fieldName of ['access_instructions', 'notes']) {
+  const field = schemas.Site?.properties?.[fieldName]
   if (
-    customersWithoutAssignments.length === 0 ||
-    customersWithoutAssignments.some(
-      (customer) =>
-        !Number.isInteger(customer?.sites_count) ||
-        customer.sites_count < 0 ||
-        !Array.isArray(customer?.customer_establishments) ||
-        customer.customer_establishments.length !== 0
-    )
+    JSON.stringify(field?.type) !== JSON.stringify(['string', 'null']) ||
+    schemas.Site?.required?.includes(fieldName) ||
+    !/authorized to update.*omitted/i.test(field?.description ?? '')
   ) {
     errors.push(
-      `${label} must include a non-negative sites_count and an empty customer_establishments response example.`
+      `Site.${fieldName} must remain nullable, update-authorized, and omitted for unauthorized callers.`
     )
   }
-}
-
-const customerGet = paths['/customers/{customer}']?.get
-if (
-  (customerGet?.parameters ?? []).some(
-    (parameter) => parameter?.name === 'include'
-  ) ||
-  /optional relationships/i.test(customerGet?.description ?? '')
-) {
-  errors.push(
-    'GET /customers/{customer} must not advertise relationships that the closed Customer response cannot represent.'
-  )
 }
 
 for (const schemaName of [

--- a/scripts/check-domain-contracts.mjs
+++ b/scripts/check-domain-contracts.mjs
@@ -563,6 +563,109 @@ for (const schemaName of relationshipSchemas) {
   }
 }
 
+for (const [schemaName, itemSchemaName] of [
+  ['CustomerAssignmentsRelationship', 'EmbeddedCustomerAssignment'],
+  ['SiteAssignmentsRelationship', 'EmbeddedSiteAssignment'],
+]) {
+  if (
+    schemas[schemaName]?.items?.$ref !==
+    `#/components/schemas/${itemSchemaName}`
+  ) {
+    errors.push(`${schemaName} must use ${itemSchemaName} items.`)
+  }
+}
+
+const assignmentSchemaProperties = {
+  EmbeddedCustomerAssignment: [
+    'id',
+    'customer_id',
+    'user_id',
+    'role',
+    'valid_from',
+    'valid_until',
+    'notes',
+    'is_active',
+    'user',
+    'created_at',
+    'updated_at',
+  ],
+  EmbeddedSiteAssignment: [
+    'id',
+    'site_id',
+    'user_id',
+    'role',
+    'valid_from',
+    'valid_until',
+    'notes',
+    'is_active',
+    'user',
+    'created_at',
+    'updated_at',
+  ],
+  CustomerAssignment: [
+    'id',
+    'role',
+    'is_active',
+    'valid_from',
+    'valid_until',
+    'notes',
+    'user',
+    'customer',
+    'created_at',
+    'updated_at',
+  ],
+  SiteAssignment: [
+    'id',
+    'role',
+    'is_active',
+    'valid_from',
+    'valid_until',
+    'notes',
+    'user',
+    'site',
+    'created_at',
+    'updated_at',
+  ],
+}
+for (const [schemaName, expectedProperties] of Object.entries(
+  assignmentSchemaProperties
+)) {
+  const schema = schemas[schemaName]
+  if (
+    schema?.type !== 'object' ||
+    schema.additionalProperties !== false ||
+    JSON.stringify(Object.keys(schema.properties ?? {})) !==
+      JSON.stringify(expectedProperties) ||
+    JSON.stringify(schema.required) !== JSON.stringify(expectedProperties) ||
+    Object.hasOwn(schema.properties ?? {}, 'is_primary')
+  ) {
+    errors.push(`${schemaName} must match its runtime assignment resource.`)
+  }
+}
+for (const schemaName of [
+  'EmbeddedCustomerAssignment',
+  'EmbeddedSiteAssignment',
+]) {
+  const userId = schemas[schemaName]?.properties?.user_id
+  if (
+    JSON.stringify(userId?.type) !== JSON.stringify(['string', 'null']) ||
+    userId?.format !== 'uuid' ||
+    !/user was deleted.*history is preserved/i.test(userId?.description ?? '')
+  ) {
+    errors.push(
+      `${schemaName}.user_id must preserve nullable deleted-user history.`
+    )
+  }
+}
+if (
+  schemas.AssignmentUser?.type !== 'object' ||
+  schemas.AssignmentUser.additionalProperties !== false ||
+  JSON.stringify(schemas.AssignmentUser.required) !==
+    JSON.stringify(['id', 'name', 'email'])
+) {
+  errors.push('AssignmentUser must remain a closed minimal user response.')
+}
+
 const relationshipCount = schemas.NonNegativeRelationshipCount
 if (
   relationshipCount?.type !== 'integer' ||
@@ -587,6 +690,100 @@ if (
 ) {
   errors.push(
     'CustomerEstablishmentRelationship must preserve caller-visible assignment filtering.'
+  )
+}
+
+const customerList = paths['/customers']?.get
+const customerCreate = paths['/customers']?.post
+const customerDetail = paths['/customers/{customer}']?.get
+const customerUpdateOperation = paths['/customers/{customer}']?.patch
+const customerSites = paths['/customers/{customer}/sites']?.get
+if (
+  !/eager loads.*assignments.*customer_establishments.*does not eager load.*sites/is.test(
+    customerList?.description ?? ''
+  )
+) {
+  errors.push(
+    'GET /customers relationship presence must match its eager-loaded assignments and customer establishments.'
+  )
+}
+for (const [label, operation] of [
+  ['POST /customers', customerCreate],
+  ['PATCH /customers/{customer}', customerUpdateOperation],
+]) {
+  if (
+    !/eager loads.*customer_establishments.*sites.*assignments.*count.*omitted/is.test(
+      operation?.description ?? ''
+    )
+  ) {
+    errors.push(
+      `${label} relationship presence must document its customer-establishment-only expansion.`
+    )
+  }
+}
+if (
+  !/eager loads.*assignments.*customer.*counts.*omitted/is.test(
+    customerSites?.description ?? ''
+  )
+) {
+  errors.push(
+    'GET /customers/{customer}/sites relationship presence must match its eager-loaded assignments.'
+  )
+}
+
+function hasValidCustomerEstablishments(customer) {
+  return (
+    Array.isArray(customer?.customer_establishments) &&
+    customer.customer_establishments.every(
+      (assignment) =>
+        uuidValue(assignment?.id) &&
+        uuidValue(assignment?.customer_id) &&
+        uuidValue(assignment?.establishment_id) &&
+        assignment.customer_id === customer.id &&
+        !Object.hasOwn(assignment, 'organizational_unit_id') &&
+        !Object.hasOwn(assignment, 'organizational_unit')
+    )
+  )
+}
+
+const listCustomerExamples = Object.values(
+  customerList?.responses?.['200']?.content?.['application/json']?.examples ??
+    {}
+).flatMap((example) => example?.value?.data ?? [])
+if (
+  listCustomerExamples.length === 0 ||
+  listCustomerExamples.some(
+    (customer) =>
+      !Number.isInteger(customer?.sites_count) ||
+      customer.sites_count < 0 ||
+      !Array.isArray(customer?.assignments) ||
+      Object.hasOwn(customer, 'sites') ||
+      !hasValidCustomerEstablishments(customer)
+  )
+) {
+  errors.push(
+    'GET /customers response examples must include valid counts and eager-loaded assignments/customer establishments while omitting sites.'
+  )
+}
+
+const detailCustomerExamples = Object.values(
+  customerDetail?.responses?.['200']?.content?.['application/json']?.examples ??
+    {}
+).map((example) => example?.value?.data)
+if (
+  detailCustomerExamples.length === 0 ||
+  detailCustomerExamples.some(
+    (customer) =>
+      !Number.isInteger(customer?.sites_count) ||
+      customer.sites_count < 0 ||
+      !Array.isArray(customer?.sites) ||
+      customer.sites.length !== customer.sites_count ||
+      !Array.isArray(customer?.assignments) ||
+      !hasValidCustomerEstablishments(customer)
+  )
+) {
+  errors.push(
+    'GET /customers/{customer} response examples must keep expanded relationships and sites_count coherent.'
   )
 }
 
@@ -1437,13 +1634,47 @@ if (/role-downgraded or deleted.*conflict/is.test(changelog)) {
     'CHANGELOG must not couple tenant-local domain lifecycle to organizational-unit roles.'
   )
 }
-const siteIncludes = paths['/sites/{site}']?.get?.parameters?.find(
-  (parameter) => parameter?.name === 'include'
-)?.schema?.enum
-if (siteIncludes?.some((value) => /organizational/i.test(value))) {
-  errors.push(
-    'GET /sites/{site} must not expose an organizational-unit include.'
+const siteInclude = paths['/sites/{site}']?.get?.parameters?.find(
+  (parameter) => resolveParameter(parameter)?.name === 'include'
+)
+if (siteInclude) {
+  errors.push('GET /sites/{site} must not expose include.')
+}
+const siteAssignmentRequestSchemas = [
+  paths['/sites/{site}/assignments']?.post?.requestBody?.content?.[
+    'application/json'
+  ]?.schema,
+  paths['/site-assignments/{siteAssignment}']?.patch?.requestBody?.content?.[
+    'application/json'
+  ]?.schema,
+]
+if (
+  siteAssignmentRequestSchemas.some((schema) =>
+    Object.hasOwn(schema?.properties ?? {}, 'is_primary')
+  ) ||
+  /is_primary/i.test(
+    paths['/site-assignments/{siteAssignment}']?.patch?.description ?? ''
   )
+) {
+  errors.push('Site assignment requests must not advertise stale is_primary.')
+}
+for (const pathName of [
+  '/customers/{customer}/assignments',
+  '/sites/{site}/assignments',
+]) {
+  const role = paths[pathName]?.get?.parameters
+    ?.map(resolveParameter)
+    .find((parameter) => parameter?.name === 'role')
+  if (
+    role?.in !== 'query' ||
+    role.required !== false ||
+    role.schema?.type !== 'string' ||
+    role.schema.maxLength !== 100
+  ) {
+    errors.push(
+      'Customer and site assignment collection filters must expose the runtime role filter.'
+    )
+  }
 }
 
 const expectedCustomerEstablishmentRequired = [

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -407,6 +407,174 @@ test('models every conditional customer and site resource field', () => {
   }
 })
 
+test('models embedded and dedicated assignment resources without stale fields', () => {
+  assert.deepEqual(schemas.CustomerAssignmentsRelationship.items, {
+    $ref: '#/components/schemas/EmbeddedCustomerAssignment',
+  })
+  assert.deepEqual(schemas.SiteAssignmentsRelationship.items, {
+    $ref: '#/components/schemas/EmbeddedSiteAssignment',
+  })
+
+  const expectedProperties = {
+    EmbeddedCustomerAssignment: [
+      'id',
+      'customer_id',
+      'user_id',
+      'role',
+      'valid_from',
+      'valid_until',
+      'notes',
+      'is_active',
+      'user',
+      'created_at',
+      'updated_at',
+    ],
+    EmbeddedSiteAssignment: [
+      'id',
+      'site_id',
+      'user_id',
+      'role',
+      'valid_from',
+      'valid_until',
+      'notes',
+      'is_active',
+      'user',
+      'created_at',
+      'updated_at',
+    ],
+    CustomerAssignment: [
+      'id',
+      'role',
+      'is_active',
+      'valid_from',
+      'valid_until',
+      'notes',
+      'user',
+      'customer',
+      'created_at',
+      'updated_at',
+    ],
+    SiteAssignment: [
+      'id',
+      'role',
+      'is_active',
+      'valid_from',
+      'valid_until',
+      'notes',
+      'user',
+      'site',
+      'created_at',
+      'updated_at',
+    ],
+  }
+
+  for (const [schemaName, properties] of Object.entries(expectedProperties)) {
+    assert.equal(schemas[schemaName].additionalProperties, false)
+    assert.deepEqual(Object.keys(schemas[schemaName].properties), properties)
+    assert.equal(schemas[schemaName].required.includes('is_active'), true)
+    assert.equal(
+      Object.hasOwn(schemas[schemaName].properties, 'is_primary'),
+      false
+    )
+  }
+
+  for (const schemaName of [
+    'EmbeddedCustomerAssignment',
+    'EmbeddedSiteAssignment',
+  ]) {
+    assert.deepEqual(schemas[schemaName].properties.user_id, {
+      type: ['string', 'null'],
+      format: 'uuid',
+      description:
+        'Assigned user identifier. Null when the user was deleted but assignment history is preserved.',
+    })
+    assert.equal(schemas[schemaName].required.includes('user_id'), true)
+    assert.equal(schemas[schemaName].required.includes('user'), true)
+  }
+
+  const siteAssignmentPost =
+    paths['/sites/{site}/assignments'].post.requestBody.content[
+      'application/json'
+    ].schema
+  const siteAssignmentPatch =
+    paths['/site-assignments/{siteAssignment}'].patch.requestBody.content[
+      'application/json'
+    ].schema
+  assert.equal(
+    Object.hasOwn(siteAssignmentPost.properties, 'is_primary'),
+    false
+  )
+  assert.equal(
+    Object.hasOwn(siteAssignmentPatch.properties, 'is_primary'),
+    false
+  )
+  assert.doesNotMatch(
+    paths['/site-assignments/{siteAssignment}'].patch.description,
+    /is_primary/i
+  )
+
+  for (const pathName of [
+    '/customers/{customer}/assignments',
+    '/sites/{site}/assignments',
+  ]) {
+    const role = paths[pathName].get.parameters.find(
+      (parameter) => parameter.name === 'role'
+    )
+    assert.deepEqual(role.schema, {
+      type: 'string',
+      maxLength: 100,
+    })
+  }
+})
+
+test('documents endpoint-specific customer and site relationship presence', () => {
+  assert.match(
+    paths['/customers'].get.description,
+    /eager loads.*assignments.*customer_establishments.*does not eager load.*sites/is
+  )
+  assert.match(
+    paths['/customers'].post.description,
+    /eager loads.*customer_establishments.*sites.*assignments.*count.*omitted/is
+  )
+  assert.match(
+    paths['/customers/{customer}'].patch.description,
+    /eager loads.*customer_establishments.*sites.*assignments.*count.*omitted/is
+  )
+  assert.match(
+    paths['/customers/{customer}/sites'].get.description,
+    /eager loads.*assignments.*customer.*counts.*omitted/is
+  )
+
+  const listExamples = Object.values(
+    paths['/customers'].get.responses['200'].content['application/json']
+      .examples
+  )
+  for (const example of listExamples) {
+    for (const customer of example.value.data) {
+      assert.ok(Array.isArray(customer.assignments))
+      assert.ok(Array.isArray(customer.customer_establishments))
+      assert.equal(Object.hasOwn(customer, 'sites'), false)
+    }
+  }
+
+  const detailExamples = Object.values(
+    paths['/customers/{customer}'].get.responses['200'].content[
+      'application/json'
+    ].examples
+  )
+  for (const example of detailExamples) {
+    const customer = example.value.data
+    assert.equal(customer.sites.length, customer.sites_count)
+  }
+
+  assert.equal(
+    paths['/sites/{site}'].get.parameters.some(
+      (parameter) => parameter.name === 'include'
+    ),
+    false
+  )
+})
+
 test('limits customer-establishment uniqueness to the relationship pair', () => {
   assert.deepEqual(schemas.CustomerEstablishment['x-unique-by'], [
     'customer_id',
@@ -1468,6 +1636,78 @@ test('guard rejects weakened conditional count and relationship schemas', () => 
   assert.notEqual(result.status, 0, result.stdout)
   assert.match(result.stderr, /NonNegativeRelationshipCount/)
   assert.match(result.stderr, /CustomerEstablishmentRelationship/)
+})
+
+test('guard rejects assignment resource shapes that drift from runtime', () => {
+  const candidate = structuredClone(contract)
+  candidate.components.schemas.SiteAssignmentsRelationship.items = {
+    $ref: '#/components/schemas/SiteAssignment',
+  }
+  candidate.components.schemas.EmbeddedCustomerAssignment.properties.user_id = {
+    type: 'string',
+    format: 'uuid',
+  }
+  candidate.components.schemas.SiteAssignment.required.push('is_primary')
+  candidate.components.schemas.SiteAssignment.properties.is_primary = {
+    type: 'boolean',
+  }
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /SiteAssignmentsRelationship/)
+  assert.match(result.stderr, /EmbeddedCustomerAssignment/)
+  assert.match(result.stderr, /SiteAssignment/)
+})
+
+test('guard rejects customer endpoint presence and example drift', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/customers'].get.description =
+    'Retrieve a paginated list of customers.'
+  const listCustomer =
+    candidate.paths['/customers'].get.responses['200'].content[
+      'application/json'
+    ].examples.withVisibleSitesCount.value.data[0]
+  delete listCustomer.assignments
+  listCustomer.customer_establishments[0].customer_id =
+    '550e8400-e29b-41d4-a716-446655440001'
+  const detailCustomer =
+    candidate.paths['/customers/{customer}'].get.responses['200'].content[
+      'application/json'
+    ].examples.withExpandedRelationships.value.data
+  detailCustomer.sites_count = detailCustomer.sites.length + 1
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET \/customers relationship presence/)
+  assert.match(result.stderr, /GET \/customers response examples/)
+  assert.match(result.stderr, /GET \/customers\/{customer} response examples/)
+})
+
+test('guard rejects restored unsupported site includes and assignment fields', () => {
+  const candidate = structuredClone(contract)
+  candidate.paths['/sites/{site}'].get.parameters.push({
+    name: 'include',
+    in: 'query',
+    schema: {
+      type: 'string',
+      enum: ['customer', 'assignments'],
+    },
+  })
+  candidate.paths['/sites/{site}/assignments'].post.requestBody.content[
+    'application/json'
+  ].schema.properties.is_primary = { type: 'boolean' }
+  candidate.paths['/sites/{site}/assignments'].get.parameters = candidate.paths[
+    '/sites/{site}/assignments'
+  ].get.parameters.filter((parameter) => parameter.name !== 'role')
+
+  const result = runGuard(candidate)
+
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, /GET \/sites\/{site} must not expose include/)
+  assert.match(result.stderr, /site assignment requests.*is_primary/i)
+  assert.match(result.stderr, /assignment collection filters/i)
 })
 
 test('guard rejects unapproved contact example domains', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -478,6 +478,17 @@ test('models embedded and dedicated assignment resources without stale fields', 
     )
   }
 
+  assert.deepEqual(Object.keys(schemas.AssignmentUser.properties), [
+    'id',
+    'name',
+    'email',
+  ])
+  assert.deepEqual(schemas.AssignmentUser.required, ['id', 'name', 'email'])
+  assert.match(
+    schemas.CustomerEstablishmentRelationship.description,
+    /`customer_establishments` relationship/
+  )
+
   for (const schemaName of [
     'EmbeddedCustomerAssignment',
     'EmbeddedSiteAssignment',
@@ -1651,6 +1662,9 @@ test('guard rejects assignment resource shapes that drift from runtime', () => {
   candidate.components.schemas.SiteAssignment.properties.is_primary = {
     type: 'boolean',
   }
+  candidate.components.schemas.AssignmentUser.properties.created_at = {
+    $ref: '#/components/schemas/ApiTimestamp',
+  }
 
   const result = runGuard(candidate)
 
@@ -1658,6 +1672,7 @@ test('guard rejects assignment resource shapes that drift from runtime', () => {
   assert.match(result.stderr, /SiteAssignmentsRelationship/)
   assert.match(result.stderr, /EmbeddedCustomerAssignment/)
   assert.match(result.stderr, /SiteAssignment/)
+  assert.match(result.stderr, /AssignmentUser/)
 })
 
 test('guard rejects customer endpoint presence and example drift', () => {

--- a/scripts/check-domain-contracts.test.mjs
+++ b/scripts/check-domain-contracts.test.mjs
@@ -323,16 +323,11 @@ test('moves local customer data to a unique customer establishment contract', ()
   assert.equal(Object.hasOwn(schemas.Customer.properties, 'metadata'), false)
   assert.equal(
     schemas.Customer.required.includes('customer_establishments'),
-    true,
-    'customer responses must always include customer_establishments, including when empty'
+    false,
+    'customer_establishments must be omitted unless the relationship is eager loaded'
   )
   assert.deepEqual(schemas.Customer.properties.customer_establishments, {
-    type: 'array',
-    description:
-      "Customer-to-establishment assignments with local contact data that are visible to the current caller. Always present; empty when the customer has no visible assignments. Unrestricted customer readers and callers with an active customer assignment may see all links for that customer; site-only access returns only links matching the caller's active site assignments. No organizational-unit relationships are exposed.",
-    items: {
-      $ref: '#/components/schemas/CustomerEstablishment',
-    },
+    $ref: '#/components/schemas/CustomerEstablishmentRelationship',
   })
 
   assert.deepEqual(schemas.CustomerEstablishment.required, [
@@ -358,54 +353,57 @@ test('moves local customer data to a unique customer establishment contract', ()
   }
 })
 
-test('documents embedded customer-establishment assignments in customer responses', () => {
+test('models every conditional customer and site resource field', () => {
+  const conditionalFields = {
+    Customer: {
+      sites_count: 'NonNegativeRelationshipCount',
+      sites: 'CustomerSitesRelationship',
+      assignments: 'CustomerAssignmentsRelationship',
+      customer_establishments: 'CustomerEstablishmentRelationship',
+    },
+    Site: {
+      customer: 'SiteCustomerRelationship',
+      assignments: 'SiteAssignmentsRelationship',
+      assigned_users_count: 'NonNegativeRelationshipCount',
+      cost_centers_count: 'NonNegativeRelationshipCount',
+    },
+  }
+
+  for (const [schemaName, fields] of Object.entries(conditionalFields)) {
+    for (const [field, component] of Object.entries(fields)) {
+      assert.deepEqual(schemas[schemaName].properties[field], {
+        $ref: `#/components/schemas/${component}`,
+      })
+      assert.equal(
+        schemas[schemaName].required.includes(field),
+        false,
+        `${schemaName}.${field} must remain optional`
+      )
+    }
+  }
+
   assert.match(
-    schemas.Customer.properties.customer_establishments.description,
+    schemas.CustomerSitesRelationship.description,
+    /eager loaded.*omitted otherwise/i
+  )
+  assert.match(
+    schemas.CustomerEstablishmentRelationship.description,
     /visible to the current caller.*site-only access.*active site assignments/is
   )
-
-  const listResponse =
-    paths['/customers'].get.responses['200'].content['application/json']
-  const detailResponse =
-    paths['/customers/{customer}'].get.responses['200'].content[
-      'application/json'
-    ]
-
-  for (const response of [listResponse, detailResponse]) {
-    const customer = response.examples.withCustomerEstablishment.value.data
-    const customers = Array.isArray(customer) ? customer : [customer]
-
-    for (const item of customers) {
-      assert.equal(Number.isInteger(item.sites_count), true)
-      assert.ok(item.sites_count >= 0)
-      assert.ok(Array.isArray(item.customer_establishments))
-      assert.equal(
-        Object.hasOwn(
-          item.customer_establishments[0],
-          'organizational_unit_id'
-        ),
-        false
-      )
-      assert.equal(
-        Object.hasOwn(item.customer_establishments[0], 'organizational_unit'),
-        false
-      )
-      assert.equal(item.customer_establishments[0].customer_id, item.id)
-    }
-
-    const customerWithoutAssignments =
-      response.examples.withoutCustomerEstablishments.value.data
-    const customersWithoutAssignments = Array.isArray(
-      customerWithoutAssignments
+  assert.match(
+    schemas.SiteCustomerRelationship.description,
+    /eager loaded.*omitted otherwise/i
+  )
+  assert.match(
+    schemas.NonNegativeRelationshipCount.description,
+    /counted.*omitted otherwise/i
+  )
+  for (const field of ['access_instructions', 'notes']) {
+    assert.match(
+      schemas.Site.properties[field].description,
+      /authorized to update.*omitted/i
     )
-      ? customerWithoutAssignments
-      : [customerWithoutAssignments]
-
-    for (const item of customersWithoutAssignments) {
-      assert.equal(Number.isInteger(item.sites_count), true)
-      assert.ok(item.sites_count >= 0)
-      assert.deepEqual(item.customer_establishments, [])
-    }
+    assert.equal(schemas.Site.required.includes(field), false)
   }
 })
 
@@ -529,23 +527,14 @@ test('uses one neutral duplicate response for every domain create operation', ()
   )
 })
 
-test('keeps the closed customer response free of undeclared relationship includes', () => {
+test('keeps conditional customer fields reusable and documented', () => {
   assert.equal(schemas.Customer.additionalProperties, false)
   assert.deepEqual(schemas.Customer.properties.sites_count, {
-    type: 'integer',
-    minimum: 0,
-    description:
-      "Number of the customer's sites visible to the current caller. Present on customer list and detail responses.",
+    $ref: '#/components/schemas/NonNegativeRelationshipCount',
   })
-  assert.equal(
-    paths['/customers/{customer}'].get.parameters.some(
-      (parameter) => parameter.name === 'include'
-    ),
-    false
-  )
-  assert.doesNotMatch(
+  assert.match(
     paths['/customers/{customer}'].get.description,
-    /optional relationships/i
+    /eager loads.*sites.*assignments.*customer_establishments/is
   )
 })
 
@@ -1431,18 +1420,16 @@ test('guard rejects distinguishable duplicate responses', () => {
   assert.match(result.stderr, /neutral fixed shape/)
 })
 
-test('guard rejects customer includes that widen the closed response', () => {
+test('guard rejects a missing customer or site resource field', () => {
   const candidate = structuredClone(contract)
-  candidate.paths['/customers/{customer}'].get.parameters.push({
-    name: 'include',
-    in: 'query',
-    schema: { type: 'string', enum: ['sites'] },
-  })
+  delete candidate.components.schemas.Customer.properties.sites
+  delete candidate.components.schemas.Site.properties.metadata
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /closed Customer response/)
+  assert.match(result.stderr, /Customer\.sites/)
+  assert.match(result.stderr, /Site must inventory every field/)
 })
 
 test('guard rejects a closed customer response without its visible site count', () => {
@@ -1455,40 +1442,32 @@ test('guard rejects a closed customer response without its visible site count', 
   assert.match(result.stderr, /Customer\.sites_count/)
 })
 
-test('guard rejects weakened customer-establishment embedding visibility or empty-array evidence', () => {
+test('guard rejects weakened conditional relationship and sensitive-field documentation', () => {
   const candidate = structuredClone(contract)
-  candidate.components.schemas.Customer.properties.customer_establishments.description =
-    'Customer-to-establishment assignments with local contact data. Always present; empty when the customer has no assignments.'
-  delete candidate.paths['/customers'].get.responses['200'].content[
-    'application/json'
-  ].examples.withoutCustomerEstablishments
-  delete candidate.paths['/customers/{customer}'].get.responses['200'].content[
-    'application/json'
-  ].examples.withoutCustomerEstablishments
+  candidate.components.schemas.CustomerEstablishmentRelationship.description =
+    'Customer-to-establishment assignments.'
+  candidate.components.schemas.Site.properties.access_instructions.description =
+    'Instructions for accessing the site.'
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /caller-visible customer_establishments/)
-  assert.match(result.stderr, /empty customer_establishments response example/)
+  assert.match(result.stderr, /CustomerEstablishmentRelationship/)
+  assert.match(result.stderr, /Site\.access_instructions/)
 })
 
-test('guard rejects customer examples with invalid site counts or foreign assignments', () => {
+test('guard rejects weakened conditional count and relationship schemas', () => {
   const candidate = structuredClone(contract)
-  const listCustomer =
-    candidate.paths['/customers'].get.responses['200'].content[
-      'application/json'
-    ].examples.withCustomerEstablishment.value.data[0]
-
-  listCustomer.sites_count = -1
-  listCustomer.customer_establishments[0].customer_id =
-    '550e8400-e29b-41d4-a716-446655440001'
+  candidate.components.schemas.NonNegativeRelationshipCount.minimum = -1
+  candidate.components.schemas.CustomerEstablishmentRelationship.items = {
+    type: 'string',
+  }
 
   const result = runGuard(candidate)
 
   assert.notEqual(result.status, 0, result.stdout)
-  assert.match(result.stderr, /non-negative sites_count/)
-  assert.match(result.stderr, /matching customer_id/)
+  assert.match(result.stderr, /NonNegativeRelationshipCount/)
+  assert.match(result.stderr, /CustomerEstablishmentRelationship/)
 })
 
 test('guard rejects unapproved contact example domains', () => {


### PR DESCRIPTION
## Summary

Closes #383.

### Problem and evidence

`CustomerResource` can conditionally emit `sites`, `assignments`, and
`sites_count`; `SiteResource` can conditionally emit `customer`,
`assignments`, `assigned_users_count`, and `cost_centers_count`. The resource
implementations also make relationship and count presence depend on eager
loading and counting, while Site `access_instructions` and `notes` depend on
update authorization. The previous `Customer` and `Site` schemas did not
represent the complete conditional response surface.

Evidence: `app/Http/Resources/CustomerResource.php` and
`app/Http/Resources/SiteResource.php` in SecPal/api; `Customer` and `Site` in
`docs/openapi.yaml`.

### Change

- Add reusable relationship and non-negative count schemas to the Customer and
  Site response contracts.
- Document eager-loading, counting, and authorization-based omission rules.
- Align Customer examples and endpoint descriptions with actual loaded fields;
  remove the unsupported Site `include` parameter.
- Add inventory and regression guards for every Customer and Site resource
  field, conditional schema shape, and sensitive-field documentation.
- Update `CHANGELOG.md`.

### Validation

- `npm run validate`
- `reuse lint`
- Commit hooks: REUSE, Prettier, markdownlint, yamllint, YAML, whitespace, and
  domain-policy checks

### Readiness

No in-scope dependencies or unresolved local checks remain. Final self-review
found no additional issues. This PR remains a draft while required CI checks
are in progress.
