### PR TITLE
Fix custom YAML parse error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report the resolved custom input path when the Dependabot or PR-size workflow
+  policy guard cannot parse its YAML configuration (closes #388).
 - Completed the `Customer` and `Site` response contracts for every field
   emitted by their resources. Conditional relationships and counts now use
   reusable schemas and document their eager-loading/counting presence rules;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report the resolved custom input path when the Dependabot or PR-size workflow
   policy guard cannot parse its YAML configuration (closes #388).
+- Keep custom-path diagnostic tests independent of temporary-directory names.
 - Completed the `Customer` and `Site` response contracts for every field
   emitted by their resources. Conditional relationships and counts now use
   reusable schemas and document their eager-loading/counting presence rules;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Report the resolved custom input path when the Dependabot or PR-size workflow
-  policy guard cannot parse its YAML configuration (closes #388).
+  policy guard cannot parse its YAML configuration, including non-file URLs
+  that cannot be converted to filesystem paths (closes #388).
 - Keep custom-path diagnostic tests independent of temporary-directory names.
 - Completed the `Customer` and `Site` response contracts for every field
   emitted by their resources. Conditional relationships and counts now use

--- a/scripts/check-dependabot-config.mjs
+++ b/scripts/check-dependabot-config.mjs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import * as yaml from 'js-yaml'
 
 function fail(message) {
@@ -13,6 +14,7 @@ function fail(message) {
 const configPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
   : new URL('../.github/dependabot.yml', import.meta.url)
+const configPathDisplay = fileURLToPath(configPath)
 
 let config
 try {
@@ -20,7 +22,7 @@ try {
     schema: yaml.JSON_SCHEMA,
   })
 } catch (error) {
-  fail(`could not parse .github/dependabot.yml: ${error}`)
+  fail(`could not parse ${configPathDisplay}: ${error}`)
 }
 
 const updates = Array.isArray(config?.updates) ? config.updates : []

--- a/scripts/check-dependabot-config.mjs
+++ b/scripts/check-dependabot-config.mjs
@@ -14,10 +14,11 @@ function fail(message) {
 const configPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
   : new URL('../.github/dependabot.yml', import.meta.url)
-const configPathDisplay = fileURLToPath(configPath)
+let configPathDisplay = configPath.href
 
 let config
 try {
+  configPathDisplay = fileURLToPath(configPath)
   config = yaml.load(readFileSync(configPath, 'utf8'), {
     schema: yaml.JSON_SCHEMA,
   })

--- a/scripts/check-dependabot-config.test.mjs
+++ b/scripts/check-dependabot-config.test.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const guardPath = fileURLToPath(
+  new URL('./check-dependabot-config.mjs', import.meta.url)
+)
+
+test('reports the custom path when Dependabot YAML is malformed', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'check-dependabot-config-'))
+  const configPath = join(directory, 'invalid-dependabot.yml')
+  writeFileSync(configPath, 'updates: [\n')
+
+  try {
+    const result = spawnSync(process.execPath, [guardPath, configPath], {
+      encoding: 'utf8',
+    })
+
+    assert.notEqual(result.status, 0, result.stderr || result.stdout)
+    assert.match(result.stderr, new RegExp(configPath.replaceAll('\\', '\\\\')))
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/scripts/check-dependabot-config.test.mjs
+++ b/scripts/check-dependabot-config.test.mjs
@@ -30,3 +30,14 @@ test('reports the custom path when Dependabot YAML is malformed', () => {
     rmSync(directory, { recursive: true, force: true })
   }
 })
+
+test('reports non-file input URLs through the guard error path', () => {
+  const configPath = 'https://example.invalid/dependabot.yml'
+  const result = spawnSync(process.execPath, [guardPath, configPath], {
+    encoding: 'utf8',
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /^Error: could not parse /)
+  assert.ok(result.stderr.includes(configPath), result.stderr)
+})

--- a/scripts/check-dependabot-config.test.mjs
+++ b/scripts/check-dependabot-config.test.mjs
@@ -25,7 +25,7 @@ test('reports the custom path when Dependabot YAML is malformed', () => {
     })
 
     assert.notEqual(result.status, 0, result.stderr || result.stdout)
-    assert.match(result.stderr, new RegExp(configPath.replaceAll('\\', '\\\\')))
+    assert.ok(result.stderr.includes(configPath), result.stderr)
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import * as yaml from 'js-yaml'
 
 function fail(message) {
@@ -13,6 +14,7 @@ function fail(message) {
 const workflowPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
   : new URL('../.github/workflows/pr-size.yml', import.meta.url)
+const workflowPathDisplay = fileURLToPath(workflowPath)
 
 let workflow
 try {
@@ -20,7 +22,7 @@ try {
     schema: yaml.JSON_SCHEMA,
   })
 } catch (error) {
-  fail(`could not parse .github/workflows/pr-size.yml: ${error}`)
+  fail(`could not parse ${workflowPathDisplay}: ${error}`)
 }
 
 const expectedPermissions = {

--- a/scripts/check-pr-size-workflow.mjs
+++ b/scripts/check-pr-size-workflow.mjs
@@ -14,10 +14,11 @@ function fail(message) {
 const workflowPath = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
   : new URL('../.github/workflows/pr-size.yml', import.meta.url)
-const workflowPathDisplay = fileURLToPath(workflowPath)
+let workflowPathDisplay = workflowPath.href
 
 let workflow
 try {
+  workflowPathDisplay = fileURLToPath(workflowPath)
   workflow = yaml.load(readFileSync(workflowPath, 'utf8'), {
     schema: yaml.JSON_SCHEMA,
   })

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -103,3 +103,14 @@ test('rejects malformed YAML', () => {
     rmSync(directory, { recursive: true, force: true })
   }
 })
+
+test('reports non-file input URLs through the guard error path', () => {
+  const workflowPath = 'https://example.invalid/pr-size.yml'
+  const result = spawnSync(process.execPath, [guardPath, workflowPath], {
+    encoding: 'utf8',
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /^Error: could not parse /)
+  assert.ok(result.stderr.includes(workflowPath), result.stderr)
+})

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -88,7 +88,21 @@ jobs:
 })
 
 test('rejects malformed YAML', () => {
-  const result = runGuard('permissions: [\n')
+  const directory = mkdtempSync(join(tmpdir(), 'check-pr-size-workflow-'))
+  const workflowPath = join(directory, 'invalid-pr-size.yml')
+  writeFileSync(workflowPath, 'permissions: [\n')
 
-  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  try {
+    const result = spawnSync(process.execPath, [guardPath, workflowPath], {
+      encoding: 'utf8',
+    })
+
+    assert.notEqual(result.status, 0, result.stderr || result.stdout)
+    assert.match(
+      result.stderr,
+      new RegExp(workflowPath.replaceAll('\\', '\\\\'))
+    )
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
 })

--- a/scripts/check-pr-size-workflow.test.mjs
+++ b/scripts/check-pr-size-workflow.test.mjs
@@ -98,10 +98,7 @@ test('rejects malformed YAML', () => {
     })
 
     assert.notEqual(result.status, 0, result.stderr || result.stdout)
-    assert.match(
-      result.stderr,
-      new RegExp(workflowPath.replaceAll('\\', '\\\\'))
-    )
+    assert.ok(result.stderr.includes(workflowPath), result.stderr)
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Fixes #388.

Both policy guards accepted a custom input path but reported their repository-default file when YAML parsing failed. The supplied `/dev/stdin` reproductions demonstrated the mismatch.

The guards now convert their resolved input URLs to filesystem paths for parse-error messages. Regression tests verify each guard reports its custom malformed-YAML path, and the changelog records the fix.

## Validation

- `npm run validate`
- `printf 'updates: [\n' | node scripts/check-dependabot-config.mjs /dev/stdin`
- `printf 'on: [\n' | node scripts/check-pr-size-workflow.mjs /dev/stdin`

Both reproductions now identify `/dev/stdin`.

## Readiness

No in-scope dependencies are unresolved. Repository CI checks are queued and
must complete successfully before this draft can be marked ready for review.
