### PR TITLE
Pin brace-expansion to 5.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Pinned the transitive `brace-expansion` v5 dependency to 5.0.7 to remediate
+  its exponential-time expansion denial-of-service vulnerability (closes #50).
+
 ### Added
 
 - Completed the `Employee` response contract with every field emitted by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.7 to remediate
-  its exponential-time expansion denial-of-service vulnerability (closes #50).
+  its exponential-time expansion denial-of-service vulnerability.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       ".": "7.5.8"
     },
     "brace-expansion@^2": "2.0.3",
-    "brace-expansion@^5": "5.0.6",
+    "brace-expansion@^5": "5.0.7",
     "fast-uri@^3.0.1": "3.1.2",
     "fast-xml-builder@^1.1.5": "1.2.0",
     "postcss@^8": "8.5.10",


### PR DESCRIPTION
## Summary

Pins the transitive `brace-expansion` v5 dependency to 5.0.7 and refreshes its
lockfile resolution. Adds the corresponding Unreleased security changelog
entry.

## Problem and evidence

`npm audit --audit-level=high` reported the high-severity
`brace-expansion` exponential-time expansion denial-of-service advisory for
versions through 5.0.6. The affected package was reached through
`markdownlint-cli` and `minimatch`.

## Validation

- `npm audit --audit-level=high` (0 vulnerabilities after the update)
- `npm run validate` (129 tests, Redocly lint, contract guards, formatting)
- `npm ls brace-expansion` (resolves `brace-expansion@5.0.7 overridden`)
- `reuse lint`
- Git commit and pre-push hooks

## Readiness

No in-scope dependency issue remains. Local validation is complete, while the
GitHub Actions checks are still running; the PR remains a draft pending those
checks and final review.

Closes #50
