### PR TITLE
Clean up verified-endpoint temp directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Cleaned up verified-endpoint guard temporary directories when candidate-file
+  creation fails (closes #406).
 - **Breaking:** Removed the obsolete Android enrollment-session, provisioning
   QR/profile, and bootstrap-token exchange contracts from `docs/openapi.yaml`,
   including their enrollment-only `update_channel` fields and the public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Cleaned up verified-endpoint guard temporary directories when candidate-file
-  creation fails (closes #406).
 - **Breaking:** Removed the obsolete Android enrollment-session, provisioning
   QR/profile, and bootstrap-token exchange contracts from `docs/openapi.yaml`,
   including their enrollment-only `update_channel` fields and the public
@@ -122,6 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cleaned up verified-endpoint guard temporary directories when candidate-file
+  creation fails (closes #406).
 - Report the resolved custom input path when the Dependabot or PR-size workflow
   policy guard cannot parse its YAML configuration, including non-file URLs
   that cannot be converted to filesystem paths (closes #388).

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -4,9 +4,15 @@
 
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 import * as yaml from 'js-yaml'
@@ -68,12 +74,13 @@ function organizationalUnitWireExamples(parameter, name) {
   return wireExamples
 }
 
-function runGuard(source) {
+function runGuard(source, { writeCandidate = writeFileSync } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'verified-endpoints-'))
   const candidatePath = join(directory, 'openapi.yaml')
-  writeFileSync(candidatePath, source)
 
   try {
+    writeCandidate(candidatePath, source)
+
     return spawnSync(process.execPath, [guardPath, candidatePath], {
       encoding: 'utf8',
     })
@@ -81,6 +88,23 @@ function runGuard(source) {
     rmSync(directory, { recursive: true, force: true })
   }
 }
+
+test('removes the temporary directory when candidate creation fails', () => {
+  let candidatePath
+
+  assert.throws(
+    () =>
+      runGuard(contract, {
+        writeCandidate(path) {
+          candidatePath = path
+          throw new Error('simulated candidate write failure')
+        },
+      }),
+    /simulated candidate write failure/
+  )
+
+  assert.equal(existsSync(dirname(candidatePath)), false)
+})
 
 test('accepts the repository contract', () => {
   const result = runGuard(contract)

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -103,6 +103,7 @@ test('removes the temporary directory when candidate creation fails', () => {
     /simulated candidate write failure/
   )
 
+  assert.ok(candidatePath, 'expected runGuard to attempt candidate creation')
   assert.equal(existsSync(dirname(candidatePath)), false)
 })
 


### PR DESCRIPTION
## Summary

- Move verified-endpoint candidate-file creation inside `runGuard()`'s existing cleanup-protected block.
- Add a regression test that simulates candidate-file creation failure and verifies removal of the temporary directory.
- Record the fix in the unreleased changelog.

## Problem and evidence

`runGuard()` created its temporary `verified-endpoints-*` directory and wrote the candidate OpenAPI file before entering `try`/`finally`. A candidate write failure, including the reported `ENOSPC` failure, therefore bypassed cleanup and left the directory behind.

## Validation

- The new regression test failed before the control-flow change and passes with the fix.
- `node --test scripts/check-openapi-verified-endpoints.test.mjs`
- `npm run lint` (135 tests, Redocly validation, verified-endpoint guard, and domain-contract guard)
- `reuse lint`
- Pre-commit and pre-push validation, including formatting and domain-policy checks.

## Dependencies and readiness

No in-scope dependencies or unresolved checks prevent review. The repository's existing markdownlint dependency audit finding remains tracked by #399 and is unrelated to this fix.

Closes #406.
