### PR TITLE
Pin brace-expansion to 5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned the transitive `brace-expansion` v5 dependency to 5.0.7 to remediate
-  its exponential-time expansion denial-of-service vulnerability.
+- Pinned the transitive `brace-expansion` v5 dependency to 5.0.8 to remediate
+  its unbounded-expansion memory denial-of-service vulnerability.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,16 +90,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/character-entities": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       ".": "7.5.8"
     },
     "brace-expansion@^2": "2.0.3",
-    "brace-expansion@^5": "5.0.7",
+    "brace-expansion@^5": "5.0.8",
     "fast-uri@^3.0.1": "3.1.2",
     "fast-xml-builder@^1.1.5": "1.2.0",
     "postcss@^8": "8.5.10",

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -170,6 +170,21 @@ export function validateMarkdownlintVersion({ packageJson, packageLock }) {
   )
 }
 
+export function validateBraceExpansionOverride({ packageJson, packageLock }) {
+  const override = packageJson.overrides?.['brace-expansion@^5'] ?? ''
+  requireInvariant(
+    EXACT_VERSION_PATTERN.test(override),
+    `package.json must pin brace-expansion@^5 to an exact version, found ${override || 'missing'}.`
+  )
+
+  const lockedVersion =
+    packageLock.packages?.['node_modules/brace-expansion']?.version ?? ''
+  requireInvariant(
+    lockedVersion === override,
+    `package-lock.json must resolve brace-expansion to ${override}, found ${lockedVersion || 'missing'}.`
+  )
+}
+
 export function validateSetupScript(setupScript) {
   const rootDirChangeIndex = setupScript.search(/^cd "\$ROOT_DIR"$/m)
   requireInvariant(
@@ -211,6 +226,7 @@ const setupScript = readFileSync(
 
 try {
   validatePrettierToolchain({ packageJson, packageLock, preCommitConfig })
+  validateBraceExpansionOverride({ packageJson, packageLock })
   validateMarkdownlintVersion({ packageJson, packageLock })
   validateMarkdownlintToolchain(preCommitConfig)
   validateSetupScript(setupScript)

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -215,6 +215,33 @@ test('keeps the exact brace-expansion override aligned with the lockfile', () =>
   )
 })
 
+test('rejects a missing or non-exact brace-expansion override', () => {
+  const missingOverrideManifest = structuredClone(packageJson)
+  delete missingOverrideManifest.overrides['brace-expansion@^5']
+
+  assert.throws(
+    () =>
+      validateBraceExpansionOverride({
+        packageJson: missingOverrideManifest,
+        packageLock,
+      }),
+    /must pin brace-expansion@\^5 to an exact version/
+  )
+
+  const rangedOverrideManifest = structuredClone(packageJson)
+  rangedOverrideManifest.overrides['brace-expansion@^5'] =
+    `^${braceExpansionVersion}`
+
+  assert.throws(
+    () =>
+      validateBraceExpansionOverride({
+        packageJson: rangedOverrideManifest,
+        packageLock,
+      }),
+    /must pin brace-expansion@\^5 to an exact version/
+  )
+})
+
 test('rejects a commented-out repository-root change', () => {
   const setupScript = `#!/usr/bin/env bash
 ROOT_DIR="$(git rev-parse --show-toplevel)"

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -6,6 +6,7 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
+  validateBraceExpansionOverride,
   validateMarkdownlintToolchain,
   validateMarkdownlintVersion,
   validatePrettierToolchain,
@@ -19,6 +20,7 @@ const packageLock = JSON.parse(
   readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
 )
 const markdownlintVersion = packageJson.devDependencies['markdownlint-cli']
+const braceExpansionVersion = packageJson.overrides['brace-expansion@^5']
 const prettierRange = packageJson.devDependencies.prettier
 const lockedPrettierVersion =
   packageLock.packages['node_modules/prettier'].version
@@ -188,6 +190,28 @@ test('rejects a markdownlint lockfile version that differs from package.json', (
         packageLock: lockfile,
       }),
     /must match the package.json pin/
+  )
+})
+
+test('keeps the exact brace-expansion override aligned with the lockfile', () => {
+  assert.doesNotThrow(() =>
+    validateBraceExpansionOverride({
+      packageJson,
+      packageLock,
+    })
+  )
+
+  const mismatchedLockfile = structuredClone(packageLock)
+  mismatchedLockfile.packages['node_modules/brace-expansion'].version =
+    incrementPatch(braceExpansionVersion)
+
+  assert.throws(
+    () =>
+      validateBraceExpansionOverride({
+        packageJson,
+        packageLock: mismatchedLockfile,
+      }),
+    /must resolve brace-expansion/
   )
 })
 


### PR DESCRIPTION
## Problem and evidence

The development dependency chain still resolves `brace-expansion` through `markdownlint-cli` and `minimatch`. Although the earlier advisory tracked in #399 was addressed by the 5.0.7 pin, the current `npm audit --json` report identifies 5.0.7 as affected by the newer high-severity unbounded-expansion memory denial-of-service advisory (GHSA-mh99-v99m-4gvg). This propagates as three high-severity findings for `brace-expansion`, `minimatch`, and `markdownlint-cli`.

The automated audit fix continues to propose an incompatible `markdownlint-cli` downgrade. The current compatible upstream fix is `brace-expansion` 5.0.8.

## Change

- Pin the transitive `brace-expansion@^5` override to 5.0.8.
- Refresh `package-lock.json` while retaining `markdownlint-cli` 0.49.1 and its repository-local hook behavior.
- Validate that the override is an exact version and that the lockfile resolves the same version, without hard-coding a particular release in the test.
- Update the security changelog entry.

## Validation

- `npm ci`
- `npm run validate`
- `npm audit --json` — 0 vulnerabilities
- `reuse lint`
- `node node_modules/markdownlint-cli/markdownlint.js --version` — 0.49.1
- Commit hooks and the full pre-push preflight

## Readiness

No in-scope dependency or unresolved local check prevents readiness. This remains a draft until the remote checks complete and the final self-review in the pull request view finds no issues.

Closes #399
