### PR TITLE
Document passkey enrollment password step-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented the required current-password step-up request bodies for starting
+  and verifying passkey enrollment, including the challenge-start `422`
+  validation response and generated-client examples (closes #418).
 - Completed the `Employee` response contract with every field emitted by
   `EmployeeResource`, including identity-document and work-permit copy
   metadata, retention timestamps, certification and work-authorization summaries,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Corrected the passkey enrollment request contracts to require
+  the runtime-enforced current-password step-up when starting and verifying an
+  enrollment challenge. Consumers regenerating clients from earlier contracts
+  must provide the required JSON bodies and `current_password` property
+  (closes #418).
 - Removed the retired standalone changelog host from contract-repository domain
   policy and guidance.
 - Changed local and hosted pull-request size reporting to treat 600 changed
@@ -27,9 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Documented the required current-password step-up request bodies for starting
-  and verifying passkey enrollment, including the challenge-start `422`
-  validation response and generated-client examples (closes #418).
 - Completed the `Employee` response contract with every field emitted by
   `EmployeeResource`, including identity-document and work-permit copy
   metadata, retention timestamps, certification and work-authorization summaries,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1722,24 +1722,19 @@ components:
           example: CorrectHorseBatteryStaple!
 
     PasskeyRegistrationVerificationRequest:
-      type: object
-      required:
-        - current_password
-        - credential
-      properties:
-        current_password:
-          type: string
-          format: password
-          writeOnly: true
-          description: Current account password used for the enrollment step-up check.
-          example: CorrectHorseBatteryStaple!
-        credential:
-          $ref: '#/components/schemas/PasskeyRegistrationCredential'
-        label:
-          type: [string, 'null']
-          maxLength: 100
-          description: Optional caller-supplied label for the enrolled passkey.
-          example: Work MacBook Touch ID
+      allOf:
+        - $ref: '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+        - type: object
+          required:
+            - credential
+          properties:
+            credential:
+              $ref: '#/components/schemas/PasskeyRegistrationCredential'
+            label:
+              type: [string, 'null']
+              maxLength: 100
+              description: Optional caller-supplied label for the enrolled passkey.
+              example: Work MacBook Touch ID
 
     PasskeyRegistrationVerificationResponse:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1716,6 +1716,7 @@ components:
       properties:
         current_password:
           type: string
+          format: password
           writeOnly: true
           description: Current account password used for the enrollment step-up check.
           example: CorrectHorseBatteryStaple!
@@ -1728,6 +1729,7 @@ components:
       properties:
         current_password:
           type: string
+          format: password
           writeOnly: true
           description: Current account password used for the enrollment step-up check.
           example: CorrectHorseBatteryStaple!

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1708,11 +1708,29 @@ components:
             response:
               $ref: '#/components/schemas/PasskeyAssertionResponse'
 
+    PasskeyCurrentPasswordStepUpRequest:
+      type: object
+      description: Fresh current-password proof required before a sensitive passkey enrollment action.
+      required:
+        - current_password
+      properties:
+        current_password:
+          type: string
+          writeOnly: true
+          description: Current account password used for the enrollment step-up check.
+          example: CorrectHorseBatteryStaple!
+
     PasskeyRegistrationVerificationRequest:
       type: object
       required:
+        - current_password
         - credential
       properties:
+        current_password:
+          type: string
+          writeOnly: true
+          description: Current account password used for the enrollment step-up check.
+          example: CorrectHorseBatteryStaple!
         credential:
           $ref: '#/components/schemas/PasskeyRegistrationCredential'
         label:
@@ -7716,6 +7734,17 @@ paths:
         - BearerAuth: []
         - SessionAuth: []
           CsrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+            examples:
+              current_password_step_up:
+                summary: Confirm the current password before creating an enrollment challenge.
+                value:
+                  current_password: CorrectHorseBatteryStaple!
       responses:
         '201':
           description: Pending passkey registration challenge created successfully
@@ -7727,6 +7756,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationError'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -7760,6 +7791,20 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PasskeyRegistrationVerificationRequest'
+            examples:
+              verify_registration:
+                summary: Verify WebAuthn attestation with a current-password step-up.
+                value:
+                  current_password: CorrectHorseBatteryStaple!
+                  label: Work MacBook Touch ID
+                  credential:
+                    id: Ax9Yc0ZLQmN4V1V1S1cwVnI1Q0FyRkE
+                    raw_id: Ax9Yc0ZLQmN4V1V1S1cwVnI1Q0FyRkE
+                    type: public-key
+                    response:
+                      client_data_json: eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVzhrM3gweEx4dzBXbDByTTl2NFoxUW1aMko3TjRSOHMiLCJvcmlnaW4iOiJodHRwczovL2FwcC5zZWNwYWwuZGV2In0
+                      attestation_object: o2NmbXRkbm9uZWhhdXRoRGF0YVhYQk1vY2tBdHRlc3RhdGlvbk9iamVjdA
+                      transports: [internal]
       responses:
         '201':
           description: Passkey registration verified successfully

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -7,7 +7,8 @@
  * or regresses their critical contract invariants (email verification resend +
  * German address reference data + employee documents + qualification catalog +
  * employee qualifications + organizational units + employee compliance alerts +
- * canonical schema-4 bootstrap and notification runtime metadata).
+ * passkey enrollment password step-up + canonical schema-4 bootstrap and
+ * notification runtime metadata).
  *
  * Usage: node scripts/check-openapi-verified-endpoints.mjs <path-to-openapi.yaml>
  */
@@ -49,6 +50,8 @@ const REQUIRED_OPERATIONS = [
   ['post', '/organizational-units/{organizational_unit}/parent'],
   ['delete', '/organizational-units/{organizational_unit}/parent/{parent}'],
   ['get', '/lookups/legal-entities'],
+  ['post', '/me/passkeys/challenges/registration'],
+  ['post', '/me/passkeys/challenges/registration/{challengeId}/verify'],
 ]
 
 const target = process.argv[2]
@@ -122,7 +125,50 @@ const parentIdParameter = paths['/organizational-units']?.get?.parameters?.find(
 const organizationalUnitListParameters =
   paths['/organizational-units']?.get?.parameters ?? []
 const employeeComplianceAlerts = paths['/employees/compliance-alerts']?.get
+const passkeyRegistrationStart =
+  paths['/me/passkeys/challenges/registration']?.post
+const passkeyRegistrationVerification =
+  paths['/me/passkeys/challenges/registration/{challengeId}/verify']?.post
+const passkeyCurrentPasswordStepUp =
+  schemas.PasskeyCurrentPasswordStepUpRequest ?? {}
+const passkeyRegistrationVerificationRequest =
+  schemas.PasskeyRegistrationVerificationRequest ?? {}
 const contractErrors = []
+
+const passkeyRegistrationStartRequestBody =
+  passkeyRegistrationStart?.requestBody ?? {}
+const passkeyRegistrationVerificationRequestBody =
+  passkeyRegistrationVerification?.requestBody ?? {}
+const passkeyRegistrationVerificationStepUp =
+  passkeyRegistrationVerificationRequest.allOf?.find(
+    (schema) =>
+      schema?.$ref ===
+      '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+  )
+
+if (
+  !passkeyCurrentPasswordStepUp.required?.includes('current_password') ||
+  passkeyCurrentPasswordStepUp.properties?.current_password?.type !==
+    'string' ||
+  passkeyCurrentPasswordStepUp.properties?.current_password?.format !==
+    'password' ||
+  passkeyCurrentPasswordStepUp.properties?.current_password?.writeOnly !==
+    true ||
+  passkeyRegistrationStartRequestBody.required !== true ||
+  passkeyRegistrationStartRequestBody.content?.['application/json']?.schema
+    ?.$ref !== '#/components/schemas/PasskeyCurrentPasswordStepUpRequest' ||
+  passkeyRegistrationStart.responses?.['422']?.$ref !==
+    '#/components/responses/ValidationError' ||
+  passkeyRegistrationVerificationRequestBody.required !== true ||
+  passkeyRegistrationVerificationRequestBody.content?.['application/json']
+    ?.schema?.$ref !==
+    '#/components/schemas/PasskeyRegistrationVerificationRequest' ||
+  !passkeyRegistrationVerificationStepUp
+) {
+  contractErrors.push(
+    'Passkey enrollment must require the reusable current-password step-up schema for challenge creation and verification.'
+  )
+}
 
 const canonicalSchemaVersionComponents = [
   'NotificationRuntimeState',
@@ -787,6 +833,29 @@ function matchesSchema(schema, value) {
   }
 
   return true
+}
+
+const passkeyRegistrationStartExample =
+  passkeyRegistrationStartRequestBody.content?.['application/json']?.examples
+    ?.current_password_step_up?.value
+const passkeyRegistrationVerificationExample =
+  passkeyRegistrationVerificationRequestBody.content?.['application/json']
+    ?.examples?.verify_registration?.value
+
+if (
+  !matchesSchema(
+    passkeyRegistrationStartRequestBody.content?.['application/json']?.schema,
+    passkeyRegistrationStartExample
+  ) ||
+  !matchesSchema(
+    passkeyRegistrationVerificationRequestBody.content?.['application/json']
+      ?.schema,
+    passkeyRegistrationVerificationExample
+  )
+) {
+  contractErrors.push(
+    'Passkey enrollment request examples must include a valid current-password step-up.'
+  )
 }
 
 if (

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -145,9 +145,15 @@ const passkeyRegistrationVerificationStepUp =
       schema?.$ref ===
       '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
   )
+const passkeyRegistrationVerificationCredential =
+  passkeyRegistrationVerificationRequest.allOf?.find(
+    (schema) => schema?.properties?.credential
+  )
 
 if (
-  !passkeyCurrentPasswordStepUp.required?.includes('current_password') ||
+  !isDeepStrictEqual(passkeyCurrentPasswordStepUp.required, [
+    'current_password',
+  ]) ||
   passkeyCurrentPasswordStepUp.properties?.current_password?.type !==
     'string' ||
   passkeyCurrentPasswordStepUp.properties?.current_password?.format !==
@@ -163,10 +169,21 @@ if (
   passkeyRegistrationVerificationRequestBody.content?.['application/json']
     ?.schema?.$ref !==
     '#/components/schemas/PasskeyRegistrationVerificationRequest' ||
-  !passkeyRegistrationVerificationStepUp
+  !passkeyRegistrationVerificationStepUp ||
+  passkeyRegistrationVerificationCredential?.type !== 'object' ||
+  !isDeepStrictEqual(passkeyRegistrationVerificationCredential.required, [
+    'credential',
+  ]) ||
+  passkeyRegistrationVerificationCredential.properties?.credential?.$ref !==
+    '#/components/schemas/PasskeyRegistrationCredential' ||
+  !isDeepStrictEqual(
+    passkeyRegistrationVerificationCredential.properties?.label?.type,
+    ['string', 'null']
+  ) ||
+  passkeyRegistrationVerificationCredential.properties?.label?.maxLength !== 100
 ) {
   contractErrors.push(
-    'Passkey enrollment must require the reusable current-password step-up schema for challenge creation and verification.'
+    'Passkey enrollment must preserve the required bodies, validation response, password step-up, credential, and optional label contracts.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -124,6 +124,10 @@ test('documents the current-password step-up for passkey enrollment', () => {
     ].post
   const registrationVerification =
     parsedContract.components.schemas.PasskeyRegistrationVerificationRequest
+  const registrationVerificationStepUp = registrationVerification.allOf?.find(
+    (schema) =>
+      schema.$ref === '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+  )
 
   assert.deepEqual(passkeyStepUp.required, ['current_password'])
   assert.equal(passkeyStepUp.properties.current_password.type, 'string')
@@ -134,7 +138,10 @@ test('documents the current-password step-up for passkey enrollment', () => {
     registrationStart.requestBody.content['application/json'].schema.$ref,
     '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
   )
-  assert.ok(registrationStart.responses['422'])
+  assert.equal(
+    registrationStart.responses['422'].$ref,
+    '#/components/responses/ValidationError'
+  )
   assert.ok(registrationStart.requestBody.content['application/json'].examples)
   assert.equal(
     registrationVerificationOperation.requestBody.content['application/json']
@@ -147,20 +154,8 @@ test('documents the current-password step-up for passkey enrollment', () => {
       .examples
   )
   assert.ok(
-    registrationVerification.required.includes('current_password'),
-    'Passkey enrollment verification must require current_password'
-  )
-  assert.equal(
-    registrationVerification.properties.current_password.type,
-    'string'
-  )
-  assert.equal(
-    registrationVerification.properties.current_password.format,
-    'password'
-  )
-  assert.equal(
-    registrationVerification.properties.current_password.writeOnly,
-    true
+    registrationVerificationStepUp,
+    'Passkey enrollment verification must reuse the current-password step-up schema'
   )
 })
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -127,6 +127,9 @@ test('documents the current-password step-up for passkey enrollment', () => {
 
   assert.deepEqual(passkeyStepUp.required, ['current_password'])
   assert.equal(passkeyStepUp.properties.current_password.type, 'string')
+  assert.equal(passkeyStepUp.properties.current_password.format, 'password')
+  assert.equal(passkeyStepUp.properties.current_password.writeOnly, true)
+  assert.equal(registrationStart.requestBody.required, true)
   assert.equal(
     registrationStart.requestBody.content['application/json'].schema.$ref,
     '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
@@ -138,6 +141,7 @@ test('documents the current-password step-up for passkey enrollment', () => {
       .schema.$ref,
     '#/components/schemas/PasskeyRegistrationVerificationRequest'
   )
+  assert.equal(registrationVerificationOperation.requestBody.required, true)
   assert.ok(
     registrationVerificationOperation.requestBody.content['application/json']
       .examples
@@ -149,6 +153,14 @@ test('documents the current-password step-up for passkey enrollment', () => {
   assert.equal(
     registrationVerification.properties.current_password.type,
     'string'
+  )
+  assert.equal(
+    registrationVerification.properties.current_password.format,
+    'password'
+  )
+  assert.equal(
+    registrationVerification.properties.current_password.writeOnly,
+    true
   )
 })
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -113,6 +113,45 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('documents the current-password step-up for passkey enrollment', () => {
+  const passkeyStepUp =
+    parsedContract.components.schemas.PasskeyCurrentPasswordStepUpRequest
+  const registrationStart =
+    parsedContract.paths['/me/passkeys/challenges/registration'].post
+  const registrationVerificationOperation =
+    parsedContract.paths[
+      '/me/passkeys/challenges/registration/{challengeId}/verify'
+    ].post
+  const registrationVerification =
+    parsedContract.components.schemas.PasskeyRegistrationVerificationRequest
+
+  assert.deepEqual(passkeyStepUp.required, ['current_password'])
+  assert.equal(passkeyStepUp.properties.current_password.type, 'string')
+  assert.equal(
+    registrationStart.requestBody.content['application/json'].schema.$ref,
+    '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+  )
+  assert.ok(registrationStart.responses['422'])
+  assert.ok(registrationStart.requestBody.content['application/json'].examples)
+  assert.equal(
+    registrationVerificationOperation.requestBody.content['application/json']
+      .schema.$ref,
+    '#/components/schemas/PasskeyRegistrationVerificationRequest'
+  )
+  assert.ok(
+    registrationVerificationOperation.requestBody.content['application/json']
+      .examples
+  )
+  assert.ok(
+    registrationVerification.required.includes('current_password'),
+    'Passkey enrollment verification must require current_password'
+  )
+  assert.equal(
+    registrationVerification.properties.current_password.type,
+    'string'
+  )
+})
+
 test('omits retired Android enrollment and provisioning contracts', () => {
   const serialized = JSON.stringify(parsedContract)
   const retiredPaths = [

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -159,6 +159,57 @@ test('documents the current-password step-up for passkey enrollment', () => {
   )
 })
 
+test('rejects passkey enrollment contracts and examples that omit current_password', () => {
+  const mutations = [
+    {
+      endpoint: 'challenge creation',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/challenges/registration'
+        ].post.requestBody.content['application/json'].schema = {
+          type: 'object',
+        }
+      },
+    },
+    {
+      endpoint: 'verification',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf =
+          candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf.slice(
+            1
+          )
+      },
+    },
+    {
+      endpoint: 'challenge creation example',
+      apply(candidate) {
+        delete candidate.paths['/me/passkeys/challenges/registration'].post
+          .requestBody.content['application/json'].examples
+          .current_password_step_up.value.current_password
+      },
+    },
+    {
+      endpoint: 'verification example',
+      apply(candidate) {
+        delete candidate.paths[
+          '/me/passkeys/challenges/registration/{challengeId}/verify'
+        ].post.requestBody.content['application/json'].examples
+          .verify_registration.value.current_password
+      },
+    },
+  ]
+
+  for (const mutation of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutation.apply(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${mutation.endpoint}: ${result.stdout}`)
+    assert.match(result.stderr, /passkey enrollment/i)
+  }
+})
+
 test('omits retired Android enrollment and provisioning contracts', () => {
   const serialized = JSON.stringify(parsedContract)
   const retiredPaths = [

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -128,6 +128,10 @@ test('documents the current-password step-up for passkey enrollment', () => {
     (schema) =>
       schema.$ref === '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
   )
+  const registrationVerificationCredential =
+    registrationVerification.allOf?.find(
+      (schema) => schema.properties?.credential
+    )
 
   assert.deepEqual(passkeyStepUp.required, ['current_password'])
   assert.equal(passkeyStepUp.properties.current_password.type, 'string')
@@ -157,12 +161,69 @@ test('documents the current-password step-up for passkey enrollment', () => {
     registrationVerificationStepUp,
     'Passkey enrollment verification must reuse the current-password step-up schema'
   )
+  assert.equal(registrationVerificationCredential.type, 'object')
+  assert.deepEqual(registrationVerificationCredential.required, ['credential'])
+  assert.equal(
+    registrationVerificationCredential.properties.credential.$ref,
+    '#/components/schemas/PasskeyRegistrationCredential'
+  )
+  assert.deepEqual(registrationVerificationCredential.properties.label.type, [
+    'string',
+    'null',
+  ])
+  assert.equal(
+    registrationVerificationCredential.properties.label.maxLength,
+    100
+  )
 })
 
-test('rejects passkey enrollment contracts and examples that omit current_password', () => {
+test('rejects passkey enrollment contract invariant regressions', () => {
   const mutations = [
     {
-      endpoint: 'challenge creation',
+      invariant: 'current_password remains required',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyCurrentPasswordStepUpRequest.required =
+          []
+      },
+    },
+    {
+      invariant: 'only current_password is required by the step-up schema',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyCurrentPasswordStepUpRequest.required.push(
+          'unexpected'
+        )
+      },
+    },
+    {
+      invariant: 'current_password remains a string',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyCurrentPasswordStepUpRequest.properties.current_password.type =
+          'integer'
+      },
+    },
+    {
+      invariant: 'current_password retains the password format',
+      apply(candidate) {
+        delete candidate.components.schemas.PasskeyCurrentPasswordStepUpRequest
+          .properties.current_password.format
+      },
+    },
+    {
+      invariant: 'current_password remains write-only',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyCurrentPasswordStepUpRequest.properties.current_password.writeOnly = false
+      },
+    },
+    {
+      invariant: 'challenge creation request body remains required',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/challenges/registration'
+        ].post.requestBody.required = false
+      },
+    },
+    {
+      invariant: 'challenge creation reuses the password step-up schema',
       apply(candidate) {
         candidate.paths[
           '/me/passkeys/challenges/registration'
@@ -172,7 +233,32 @@ test('rejects passkey enrollment contracts and examples that omit current_passwo
       },
     },
     {
-      endpoint: 'verification',
+      invariant: 'challenge creation documents validation errors',
+      apply(candidate) {
+        candidate.paths['/me/passkeys/challenges/registration'].post.responses[
+          '422'
+        ].$ref = '#/components/responses/Conflict'
+      },
+    },
+    {
+      invariant: 'verification request body remains required',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/challenges/registration/{challengeId}/verify'
+        ].post.requestBody.required = false
+      },
+    },
+    {
+      invariant: 'verification reuses its canonical request schema',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/challenges/registration/{challengeId}/verify'
+        ].post.requestBody.content['application/json'].schema.$ref =
+          '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+      },
+    },
+    {
+      invariant: 'verification reuses the password step-up schema',
       apply(candidate) {
         candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf =
           candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf.slice(
@@ -181,7 +267,59 @@ test('rejects passkey enrollment contracts and examples that omit current_passwo
       },
     },
     {
-      endpoint: 'challenge creation example',
+      invariant: 'verification retains the credential object branch',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf =
+          candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf.slice(
+            0,
+            1
+          )
+      },
+    },
+    {
+      invariant: 'verification credential branch remains an object',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].type =
+          'array'
+      },
+    },
+    {
+      invariant: 'verification keeps credential required',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].required =
+          []
+      },
+    },
+    {
+      invariant: 'verification keeps label optional',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].required.push(
+          'label'
+        )
+      },
+    },
+    {
+      invariant: 'verification label remains nullable',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].properties.label.type =
+          'string'
+      },
+    },
+    {
+      invariant: 'verification label retains its maximum length',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].properties.label.maxLength = 255
+      },
+    },
+    {
+      invariant: 'verification reuses the registration credential schema',
+      apply(candidate) {
+        candidate.components.schemas.PasskeyRegistrationVerificationRequest.allOf[1].properties.credential.$ref =
+          '#/components/schemas/PasskeyAuthenticationCredential'
+      },
+    },
+    {
+      invariant: 'challenge creation example includes current_password',
       apply(candidate) {
         delete candidate.paths['/me/passkeys/challenges/registration'].post
           .requestBody.content['application/json'].examples
@@ -189,12 +327,21 @@ test('rejects passkey enrollment contracts and examples that omit current_passwo
       },
     },
     {
-      endpoint: 'verification example',
+      invariant: 'verification example includes current_password',
       apply(candidate) {
         delete candidate.paths[
           '/me/passkeys/challenges/registration/{challengeId}/verify'
         ].post.requestBody.content['application/json'].examples
           .verify_registration.value.current_password
+      },
+    },
+    {
+      invariant: 'verification example includes credential',
+      apply(candidate) {
+        delete candidate.paths[
+          '/me/passkeys/challenges/registration/{challengeId}/verify'
+        ].post.requestBody.content['application/json'].examples
+          .verify_registration.value.credential
       },
     },
   ]
@@ -205,7 +352,7 @@ test('rejects passkey enrollment contracts and examples that omit current_passwo
 
     const result = runGuard(yaml.dump(candidate))
 
-    assert.notEqual(result.status, 0, `${mutation.endpoint}: ${result.stdout}`)
+    assert.notEqual(result.status, 0, `${mutation.invariant}: ${result.stdout}`)
     assert.match(result.stderr, /passkey enrollment/i)
   }
 })


### PR DESCRIPTION
## Summary

Document the required current-password step-up for both passkey enrollment requests.

- Add the reusable `PasskeyCurrentPasswordStepUpRequest` schema and require it on `POST /me/passkeys/challenges/registration`.
- Require `current_password` on `PasskeyRegistrationVerificationRequest`.
- Add examples for both JSON request bodies and document the challenge-start `422` validation response.
- Add a regression test covering the schema, request bodies, examples, and response coverage.

Closes #418.

## Problem and evidence

The runtime endpoint accepts `PasskeyCurrentPasswordStepUpRequest` when creating an enrollment challenge, while the canonical contract previously declared no request body at `docs/openapi.yaml:7705`. The runtime verification request also validates `current_password`, but `PasskeyRegistrationVerificationRequest` previously required only `credential` at `docs/openapi.yaml:1711`. Generated clients therefore omitted a required field and received validation errors.

## Validation

- `npm run validate`
- Commit hooks: REUSE, Prettier, markdownlint, YAML validation, and merge-conflict checks
- Push preflight: REUSE, domain policy, `npm run lint`, and `npm test`

## Dependency and readiness

`SecPal/frontend#1566` depends on this contract change and can consume it after this PR is merged. No local validation is unresolved. The PR remains a draft pending its final pull-request review.