### PR TITLE
Pin brace-expansion to 5.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned the transitive `brace-expansion` v5 dependency to 5.0.8 to remediate
-  its unbounded-expansion memory denial-of-service vulnerability.
+- Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
+  the unbounded intermediate-array denial-of-service vulnerability
+  ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       ".": "7.5.8"
     },
     "brace-expansion@^2": "2.0.3",
-    "brace-expansion@^5": "5.0.8",
+    "brace-expansion@^5": "5.0.9",
     "fast-uri@^3.0.1": "3.1.2",
     "fast-xml-builder@^1.1.5": "1.2.0",
     "postcss@^8": "8.5.10",

--- a/scripts/check-markdownlint-toolchain.mjs
+++ b/scripts/check-markdownlint-toolchain.mjs
@@ -8,6 +8,9 @@ import { load as loadYaml } from 'js-yaml'
 
 const EXACT_VERSION_PATTERN =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+const BRACE_EXPANSION_SECURITY_FLOOR = [5, 0, 9]
+const VERSION_COMPONENTS_PATTERN =
+  /^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
 
 function fail(message) {
   console.error(`Error: ${message}`)
@@ -18,6 +21,22 @@ function requireInvariant(condition, message) {
   if (!condition) {
     throw new Error(message)
   }
+}
+
+function isVersionAtLeast(version, minimum) {
+  const match = VERSION_COMPONENTS_PATTERN.exec(version)
+  if (!match) {
+    return false
+  }
+
+  const components = match.slice(1, 4).map(Number)
+  for (let index = 0; index < components.length; index += 1) {
+    if (components[index] !== minimum[index]) {
+      return components[index] > minimum[index]
+    }
+  }
+
+  return match[4] === undefined
 }
 
 function parsePreCommitConfig(preCommitConfig) {
@@ -175,6 +194,10 @@ export function validateBraceExpansionOverride({ packageJson, packageLock }) {
   requireInvariant(
     EXACT_VERSION_PATTERN.test(override),
     `package.json must pin brace-expansion@^5 to an exact version, found ${override || 'missing'}.`
+  )
+  requireInvariant(
+    isVersionAtLeast(override, BRACE_EXPANSION_SECURITY_FLOOR),
+    `package.json must pin brace-expansion@^5 to 5.0.9 or later, found ${override}.`
   )
 
   const lockedVersion =

--- a/scripts/check-markdownlint-toolchain.test.mjs
+++ b/scripts/check-markdownlint-toolchain.test.mjs
@@ -242,6 +242,22 @@ test('rejects a missing or non-exact brace-expansion override', () => {
   )
 })
 
+test('rejects a brace-expansion override below the security floor', () => {
+  const vulnerableOverrideManifest = structuredClone(packageJson)
+  const vulnerableLockfile = structuredClone(packageLock)
+  vulnerableOverrideManifest.overrides['brace-expansion@^5'] = '5.0.8'
+  vulnerableLockfile.packages['node_modules/brace-expansion'].version = '5.0.8'
+
+  assert.throws(
+    () =>
+      validateBraceExpansionOverride({
+        packageJson: vulnerableOverrideManifest,
+        packageLock: vulnerableLockfile,
+      }),
+    /must pin brace-expansion@\^5 to 5\.0\.9 or later/
+  )
+})
+
 test('rejects a commented-out repository-root change', () => {
   const setupScript = `#!/usr/bin/env bash
 ROOT_DIR="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
## Problem and evidence

`npm audit` reported two high-severity findings in the transitive `brace-expansion` dependency chain. The `brace-expansion@^5` override resolved to version 5.0.8, while GHSA-rgw5-rvv9-x895 affects versions before 5.0.9.

## Change

- Pin the `brace-expansion@^5` override to 5.0.9.
- Refresh the lockfile resolution and integrity metadata.
- Record the remediation in the unreleased security changelog.

## Validation

- `npm audit --json` — 0 vulnerabilities.
- `npm run validate` — 146 tests passed; OpenAPI, domain-contract, verified-endpoint, and formatting checks passed.
- `reuse lint` — REUSE compliant.
- `git diff --check`.
- Pre-commit checks passed.

## Readiness

No in-scope dependency or unresolved local check prevents readiness. This pull request remains a draft pending the required final self-review in the pull request view.

Closes #426.