### PR TITLE
chore(deps-dev): bump @redocly/cli to 2.43.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `@redocly/cli` from `2.43.2` to `2.43.3` so local contract
+  validation uses the current Redocly CLI release without its update notice
+  (closes #422).
 - **Breaking:** Corrected the passkey enrollment request contracts to require
   the runtime-enforced current-password step-up when starting and verifying an
   enrollment challenge. Consumers regenerating clients from earlier contracts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.43.2",
+        "@redocly/cli": "^2.43.3",
         "js-yaml": "^5.2.2",
         "markdownlint-cli": "0.49.1",
         "prettier": "^3.9.6"
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.43.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.43.2.tgz",
-      "integrity": "sha512-0rPTyFiYWw4nDQgvGC/M0iwQSAuk+X42Bn3mFNTNLVllIsYDG2W3nFVkdNGqTBiR8C/8e7XrF0n3DZq8fDvZvg==",
+      "version": "2.43.3",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.43.3.tgz",
+      "integrity": "sha512-c6qQnH7N29FkpBAFDw+7cAsR+F5LXWWuS66BzHuC7zUsqqeZeUVxONRAAZHzwWG/N1zuqXMQZigVIh+ZC4OIFg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate": "npm run lint && npm run format:check"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.43.2",
+    "@redocly/cli": "^2.43.3",
     "js-yaml": "^5.2.2",
     "markdownlint-cli": "0.49.1",
     "prettier": "^3.9.6"


### PR DESCRIPTION
## Summary

Closes #422.

`npm outdated @redocly/cli --json` reported Redocly CLI 2.43.3 as both the wanted and latest release while the local toolchain resolved 2.43.2.

## Change

- Update `@redocly/cli` to `^2.43.3` in `package.json` (line 25).
- Refresh the resolved package and integrity data in `package-lock.json` (line 18).
- Record the validation-toolchain update in `CHANGELOG.md` (line 26).

## Validation

- `npm ci`
- `npm run validate`
- `npm ls @redocly/cli --depth=0` (`2.43.3`)
- `npm outdated @redocly/cli --json` (`{}`)
- `reuse lint`

## Draft status

The separate `brace-expansion` audit finding remains unresolved and is tracked in #426. Its security override is intentionally unchanged here because it requires its own dependency-security branch. No in-scope dependency or validation check remains unresolved.
