### PR TITLE
Pin GitHub Actions to full SHAs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,9 @@ At minimum verify:
 - Reuse schemas with `$ref`, keep security schemes and error responses consistent,
   and treat breaking changes as versioned API changes.
 - For policy scripts, keep discovery patterns narrow and verify both allowed and rejected examples after grep or regex changes.
+- Pin every external GitHub Action and reusable workflow to an immutable full
+  40-character commit SHA, preserve the existing release tag or branch, and
+  retain that source ref in a same-line comment for Dependabot.
 - Run the relevant validation for every change and keep examples, naming, and reusable components coherent.
 
 ## Scope Notes

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -16,7 +16,9 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
   `timeout-minutes` at this level, so enforce the timeout inside the
   called reusable workflow instead.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
-- Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
+- Pin every external action and reusable workflow to an immutable full
+  40-character commit SHA; retain its source tag or branch in a same-line
+  comment for Dependabot.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -17,8 +17,8 @@ Applies when editing GitHub Actions workflows and Dependabot configuration in th
   called reusable workflow instead.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
 - Pin every external action and reusable workflow to an immutable full
-  40-character commit SHA; retain its source tag or branch in a same-line
-  comment for Dependabot.
+  40-character commit SHA, preserve the existing release tag or branch, and
+  retain that source ref in a same-line comment for Dependabot.
 - Use reusable workflows from the organization templates when they fit the task.
 - Use `continue-on-error: true` only for intentional polling or wait steps, never for build or test steps.
 - Reference secrets via `${{ secrets.NAME }}` and vars via `${{ vars.NAME }}`. Never hardcode or echo secrets.

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Check for Merge Conflict Markers
@@ -14,4 +14,5 @@ permissions:
 
 jobs:
   check-conflicts:
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main

--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   check-conflicts:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependabot Auto-Merge Workflow (Contracts Repository)
@@ -29,7 +29,8 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
     with:
       phase: '1' # Phase 1: Only PATCH updates auto-merge
       merge-method: 'squash' # Use squash merge for cleaner history

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   auto-merge:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
     with:
       phase: '1' # Phase 1: Only PATCH updates auto-merge
       merge-method: 'squash' # Use squash merge for cleaner history

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   auto-merge:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     with:
       phase: '1' # Phase 1: Only PATCH updates auto-merge
       merge-method: 'squash' # Use squash merge for cleaner history

--- a/.github/workflows/local-openapi-lint.yml
+++ b/.github/workflows/local-openapi-lint.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/local-prettier.yml
+++ b/.github/workflows/local-prettier.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   pr-size:
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     with:
       max-lines: 600
       exclude-patterns: ''

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   pr-size:
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       max-lines: 600
       exclude-patterns: ''

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
 name: Project Board Automation
@@ -29,14 +29,16 @@ permissions:
 jobs:
   project-automation:
     name: Project automation
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   draft-reminder:
     name: Draft PR Reminder
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    # yamllint disable-line rule:line-length
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -30,7 +30,7 @@ jobs:
   project-automation:
     name: Project automation
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
@@ -38,7 +38,7 @@ jobs:
   draft-reminder:
     name: Draft PR Reminder
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,12 +22,12 @@ jobs:
   reuse:
     name: REUSE Compliance
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
 
   license-compatibility:
     name: License Compatibility
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
 
   prettier:
     name: Prettier Formatting
@@ -36,7 +36,7 @@ jobs:
   markdown-lint:
     name: Markdown Lint
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     with:
       # yamllint disable-line rule:line-length
       governance-ref: '6f8e13a7a62cee356811a7f58d6b92119941652f'
@@ -44,7 +44,7 @@ jobs:
   ai-instructions:
     name: AI Instructions
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main
     with:
       # yamllint disable-line rule:line-length
       governance-ref: '6f8e13a7a62cee356811a7f58d6b92119941652f'
@@ -56,4 +56,4 @@ jobs:
   actionlint:
     name: Actionlint
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
+    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@ffdfe1be8bbd8164d649f1c1d296e57ff4c6cc4a # main

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,12 +22,12 @@ jobs:
   reuse:
     name: REUSE Compliance
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   license-compatibility:
     name: License Compatibility
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
 
   prettier:
     name: Prettier Formatting
@@ -36,7 +36,7 @@ jobs:
   markdown-lint:
     name: Markdown Lint
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       # yamllint disable-line rule:line-length
       governance-ref: '6f8e13a7a62cee356811a7f58d6b92119941652f'
@@ -44,7 +44,7 @@ jobs:
   ai-instructions:
     name: AI Instructions
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main
     with:
       # yamllint disable-line rule:line-length
       governance-ref: '6f8e13a7a62cee356811a7f58d6b92119941652f'
@@ -56,4 +56,4 @@ jobs:
   actionlint:
     name: Actionlint
     # yamllint disable-line rule:line-length
-    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-actionlint.yml@480e66d1c9f287f9fbaa25a219c2cab8cadb6a83 # main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,9 @@ At minimum verify:
 - Reuse schemas with `$ref`, keep security schemes and error responses consistent,
   and treat breaking changes as versioned API changes.
 - For policy scripts, keep discovery patterns narrow and verify both allowed and rejected examples after grep or regex changes.
+- Pin every external GitHub Action and reusable workflow to an immutable full
+  40-character commit SHA, preserve the existing release tag or branch, and
+  retain that source ref in a same-line comment for Dependabot.
 - Run the relevant validation for every change and keep examples, naming, and reusable components coherent.
 
 ## Scope Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA while preserving its existing release channel for Dependabot;
   added a syntax-aware repository-wide guard against mutable, abbreviated,
-  undocumented, spoofed, or structurally aliased references in workflows and
-  referenced local composite actions, and wired it into the pull-request lint
-  path (closes #430).
+  undocumented, spoofed, structurally aliased, or symlinked references in
+  workflows and referenced local composite actions, and wired it into the
+  pull-request lint path (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA while preserving its existing release channel for Dependabot;
   added a syntax-aware repository-wide guard against mutable, abbreviated,
-  undocumented, or spoofed workflow references (closes #430).
+  undocumented, spoofed, or structurally aliased workflow references
+  (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned every external GitHub Action and reusable workflow to a verified full
+  commit SHA with its source tag or branch retained for Dependabot; added a
+  repository-wide guard against mutable, abbreviated, or undocumented workflow
+  references (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit SHA while preserving its existing release channel for Dependabot;
   added a syntax-aware repository-wide guard against mutable, abbreviated,
   undocumented, spoofed, or structurally aliased references in workflows and
-  composite actions (closes #430).
+  referenced local composite actions, and wired it into the pull-request lint
+  path (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Pinned every external GitHub Action and reusable workflow to a verified full
-  commit SHA with its source tag or branch retained for Dependabot; added a
-  repository-wide guard against mutable, abbreviated, or undocumented workflow
-  references (closes #430).
+  commit SHA while preserving its existing release channel for Dependabot;
+  added a syntax-aware repository-wide guard against mutable, abbreviated,
+  undocumented, or spoofed workflow references (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned every external GitHub Action and reusable workflow to a verified full
   commit SHA while preserving its existing release channel for Dependabot;
   added a syntax-aware repository-wide guard against mutable, abbreviated,
-  undocumented, spoofed, or structurally aliased workflow references
-  (closes #430).
+  undocumented, spoofed, or structurally aliased references in workflows and
+  composite actions (closes #430).
 - Pinned the transitive `brace-expansion` v5 dependency to 5.0.9 to remediate
   the unbounded intermediate-array denial-of-service vulnerability
   ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
-    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node scripts/check-workflow-action-pins.mjs",
+    "prelint": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node scripts/check-workflow-action-pins.mjs",
     "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml && node scripts/check-domain-contracts.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json,js,mjs}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,js,mjs}'",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/SecPal/contracts/issues"
   },
   "scripts": {
-    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs",
+    "prevalidate": "bash scripts/check-redocly-cli-sync.sh && node scripts/check-markdownlint-toolchain.mjs && node scripts/check-dependabot-config.mjs && node scripts/check-workflow-action-pins.mjs",
     "lint": "node --test && redocly lint docs/openapi.yaml && node scripts/check-openapi-verified-endpoints.mjs docs/openapi.yaml && node scripts/check-domain-contracts.mjs docs/openapi.yaml",
     "format": "prettier --write '**/*.{md,yml,yaml,json,js,mjs}'",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,js,mjs}'",

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import * as yaml from 'js-yaml'
 
@@ -11,16 +11,36 @@ function fail(message) {
   process.exit(1)
 }
 
-function workflowPaths(directory) {
+function yamlPaths(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = `${directory}/${entry.name}`
 
     if (entry.isDirectory()) {
-      return workflowPaths(path)
+      return yamlPaths(path)
     }
 
     return /\.ya?ml$/i.test(entry.name) ? [path] : []
   })
+}
+
+function manifestPaths(githubDirectory) {
+  const workflowsDirectory = `${githubDirectory}/workflows`
+  const actionsDirectory = `${githubDirectory}/actions`
+  const hasWorkflows = existsSync(workflowsDirectory)
+  const hasActions = existsSync(actionsDirectory)
+
+  if (!hasWorkflows && !hasActions) {
+    return yamlPaths(githubDirectory)
+  }
+
+  const workflows = hasWorkflows ? yamlPaths(workflowsDirectory) : []
+  const actions = hasActions
+    ? yamlPaths(actionsDirectory).filter((path) =>
+        /\/action\.ya?ml$/i.test(path)
+      )
+    : []
+
+  return [...workflows, ...actions]
 }
 
 function parseNode(events, eventIndex, source) {
@@ -99,6 +119,45 @@ function mappingValue(node, key) {
   )
 }
 
+function aliasKeyReference(node, context) {
+  if (
+    node?.kind === 'mapping' &&
+    node.items.some(({ key }) => key.kind === 'alias')
+  ) {
+    return { context, kind: 'alias-key' }
+  }
+
+  return null
+}
+
+function stepReferences(steps) {
+  if (steps?.kind === 'alias') {
+    return [{ context: 'steps', kind: 'alias-container' }]
+  }
+
+  if (steps?.kind !== 'sequence') {
+    return []
+  }
+
+  return steps.items.flatMap((step) => {
+    if (step.kind === 'alias') {
+      return [{ context: 'step', kind: 'alias-container' }]
+    }
+
+    if (step.kind !== 'mapping') {
+      return []
+    }
+
+    const aliasKey = aliasKeyReference(step, 'step')
+    if (aliasKey) {
+      return [aliasKey]
+    }
+
+    const action = mappingValue(step, 'uses')
+    return action ? [action] : []
+  })
+}
+
 function workflowReferences(document) {
   const jobs = mappingValue(document, 'jobs')
 
@@ -119,6 +178,11 @@ function workflowReferences(document) {
       return []
     }
 
+    const aliasKey = aliasKeyReference(job, 'job')
+    if (aliasKey) {
+      return [aliasKey]
+    }
+
     const references = []
     const reusableWorkflow = mappingValue(job, 'uses')
     if (reusableWorkflow) {
@@ -126,26 +190,41 @@ function workflowReferences(document) {
     }
 
     const steps = mappingValue(job, 'steps')
-    if (steps?.kind === 'alias') {
-      references.push({ context: 'steps', kind: 'alias-container' })
-    }
-
-    if (steps?.kind === 'sequence') {
-      for (const step of steps.items) {
-        if (step.kind === 'alias') {
-          references.push({ context: 'step', kind: 'alias-container' })
-          continue
-        }
-
-        const action = mappingValue(step, 'uses')
-        if (action) {
-          references.push(action)
-        }
-      }
-    }
+    references.push(...stepReferences(steps))
 
     return references
   })
+}
+
+function compositeActionReferences(document) {
+  const runs = mappingValue(document, 'runs')
+
+  if (runs?.kind === 'alias') {
+    return [{ context: 'runs', kind: 'alias-container' }]
+  }
+
+  if (runs?.kind !== 'mapping') {
+    return []
+  }
+
+  const aliasKey = aliasKeyReference(runs, 'composite action')
+  if (aliasKey) {
+    return [aliasKey]
+  }
+
+  return stepReferences(mappingValue(runs, 'steps'))
+}
+
+function manifestReferences(document) {
+  const aliasKey = aliasKeyReference(document, 'document')
+  if (aliasKey) {
+    return [aliasKey]
+  }
+
+  return [
+    ...workflowReferences(document),
+    ...compositeActionReferences(document),
+  ]
 }
 
 function sourceComment(source, scalarEvent) {
@@ -160,43 +239,49 @@ function sourceComment(source, scalarEvent) {
   return /^\s+#\s*([A-Za-z0-9][A-Za-z0-9._/-]*)\s*$/.exec(suffix)?.[1]
 }
 
-const workflowDirectory = process.argv[2]
+const githubDirectory = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
-  : new URL('../.github/workflows/', import.meta.url)
-let workflowDirectoryDisplay = workflowDirectory.href
+  : new URL('../.github/', import.meta.url)
+let githubDirectoryDisplay = githubDirectory.href
 
 let paths
 try {
-  workflowDirectoryDisplay = fileURLToPath(workflowDirectory)
-  if (!statSync(workflowDirectoryDisplay).isDirectory()) {
-    fail(`${workflowDirectoryDisplay} must be a workflow directory.`)
+  githubDirectoryDisplay = fileURLToPath(githubDirectory)
+  if (!statSync(githubDirectoryDisplay).isDirectory()) {
+    fail(`${githubDirectoryDisplay} must be a GitHub configuration directory.`)
   }
-  paths = workflowPaths(workflowDirectoryDisplay)
+  paths = manifestPaths(githubDirectoryDisplay)
 } catch (error) {
-  fail(`could not read ${workflowDirectoryDisplay}: ${error}`)
+  fail(`could not read ${githubDirectoryDisplay}: ${error}`)
 }
 
-for (const workflowPath of paths) {
+for (const manifestPath of paths) {
   let document
-  let workflowText
+  let manifestText
   try {
-    workflowText = readFileSync(workflowPath, 'utf8')
-    yaml.load(workflowText, { schema: yaml.JSON_SCHEMA })
-    document = parseDocument(workflowText)
+    manifestText = readFileSync(manifestPath, 'utf8')
+    yaml.load(manifestText, { schema: yaml.JSON_SCHEMA })
+    document = parseDocument(manifestText)
   } catch (error) {
-    fail(`could not parse ${workflowPath}: ${error}`)
+    fail(`could not parse ${manifestPath}: ${error}`)
   }
 
-  for (const referenceNode of workflowReferences(document)) {
+  for (const referenceNode of manifestReferences(document)) {
     if (referenceNode.kind === 'alias-container') {
       fail(
-        `${workflowPath} ${referenceNode.context} must not use a YAML alias because external uses references cannot be verified.`
+        `${manifestPath} ${referenceNode.context} must not use a YAML alias because external uses references cannot be verified.`
+      )
+    }
+
+    if (referenceNode.kind === 'alias-key') {
+      fail(
+        `${manifestPath} ${referenceNode.context} mapping key must not use a YAML alias because external uses references cannot be verified.`
       )
     }
 
     if (referenceNode.kind !== 'scalar') {
       fail(
-        `${workflowPath} uses reference must be an explicit string so its immutable pin and source comment can be verified.`
+        `${manifestPath} uses reference must be an explicit string so its immutable pin and source comment can be verified.`
       )
     }
 
@@ -207,16 +292,16 @@ for (const workflowPath of paths) {
 
     if (!/@[0-9a-f]{40}$/.test(reference)) {
       fail(
-        `${workflowPath} external uses reference must end with a lowercase full 40-character commit SHA: ${reference}.`
+        `${manifestPath} external uses reference must end with a lowercase full 40-character commit SHA: ${reference}.`
       )
     }
 
-    if (!sourceComment(workflowText, event)) {
+    if (!sourceComment(manifestText, event)) {
       fail(
-        `${workflowPath} external uses reference must retain its source tag or branch in a same-line comment: ${reference}.`
+        `${manifestPath} external uses reference must retain its source tag or branch in a same-line comment: ${reference}.`
       )
     }
   }
 }
 
-console.log('Workflow action pin guard OK.')
+console.log('GitHub action pin guard OK.')

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -3,6 +3,14 @@
 // SPDX-License-Identifier: CC0-1.0
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as yaml from 'js-yaml'
 
@@ -41,6 +49,48 @@ function manifestPaths(githubDirectory) {
     : []
 
   return [...workflows, ...actions]
+}
+
+function repositoryDirectory(githubDirectory) {
+  if (basename(githubDirectory) === '.github') {
+    return dirname(githubDirectory)
+  }
+
+  if (
+    basename(githubDirectory) === 'workflows' &&
+    basename(dirname(githubDirectory)) === '.github'
+  ) {
+    return dirname(dirname(githubDirectory))
+  }
+
+  return dirname(githubDirectory)
+}
+
+function localActionManifest(repositoryRoot, reference, sourcePath) {
+  const actionDirectory = resolve(repositoryRoot, reference)
+  const repositoryRelativePath = relative(repositoryRoot, actionDirectory)
+
+  if (
+    isAbsolute(repositoryRelativePath) ||
+    repositoryRelativePath === '..' ||
+    repositoryRelativePath.startsWith(`..${sep}`)
+  ) {
+    fail(
+      `${sourcePath} local action reference escapes the repository: ${reference}.`
+    )
+  }
+
+  const candidates = ['action.yml', 'action.yaml']
+    .map((name) => `${actionDirectory}/${name}`)
+    .filter((path) => existsSync(path) && statSync(path).isFile())
+
+  if (candidates.length !== 1) {
+    fail(
+      `${sourcePath} local action reference must resolve to exactly one action.yml or action.yaml manifest: ${reference}.`
+    )
+  }
+
+  return candidates[0]
 }
 
 function parseNode(events, eventIndex, source) {
@@ -154,7 +204,7 @@ function stepReferences(steps) {
     }
 
     const action = mappingValue(step, 'uses')
-    return action ? [action] : []
+    return action ? [{ ...action, referenceKind: 'action' }] : []
   })
 }
 
@@ -186,7 +236,7 @@ function workflowReferences(document) {
     const references = []
     const reusableWorkflow = mappingValue(job, 'uses')
     if (reusableWorkflow) {
-      references.push(reusableWorkflow)
+      references.push({ ...reusableWorkflow, referenceKind: 'workflow' })
     }
 
     const steps = mappingValue(job, 'steps')
@@ -245,17 +295,28 @@ const githubDirectory = process.argv[2]
 let githubDirectoryDisplay = githubDirectory.href
 
 let paths
+let repositoryRoot
 try {
   githubDirectoryDisplay = fileURLToPath(githubDirectory)
   if (!statSync(githubDirectoryDisplay).isDirectory()) {
     fail(`${githubDirectoryDisplay} must be a GitHub configuration directory.`)
   }
   paths = manifestPaths(githubDirectoryDisplay)
+  repositoryRoot = repositoryDirectory(githubDirectoryDisplay)
 } catch (error) {
   fail(`could not read ${githubDirectoryDisplay}: ${error}`)
 }
 
-for (const manifestPath of paths) {
+const pendingPaths = [...paths]
+const visitedPaths = new Set()
+
+for (let pathIndex = 0; pathIndex < pendingPaths.length; pathIndex += 1) {
+  const manifestPath = pendingPaths[pathIndex]
+  if (visitedPaths.has(manifestPath)) {
+    continue
+  }
+  visitedPaths.add(manifestPath)
+
   let document
   let manifestText
   try {
@@ -287,6 +348,16 @@ for (const manifestPath of paths) {
 
     const { event, value: reference } = referenceNode
     if (reference.startsWith('./')) {
+      if (referenceNode.referenceKind === 'action') {
+        const localManifest = localActionManifest(
+          repositoryRoot,
+          reference,
+          manifestPath
+        )
+        if (!visitedPaths.has(localManifest)) {
+          pendingPaths.push(localManifest)
+        }
+      }
       continue
     }
 

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -23,6 +23,126 @@ function workflowPaths(directory) {
   })
 }
 
+function parseNode(events, eventIndex, source) {
+  const event = events[eventIndex]
+
+  if (event.type === yaml.EVENT_SCALAR) {
+    return [
+      {
+        event,
+        kind: 'scalar',
+        value: yaml.getScalarValue(source, event),
+      },
+      eventIndex + 1,
+    ]
+  }
+
+  if (event.type === yaml.EVENT_ALIAS) {
+    return [{ kind: 'alias' }, eventIndex + 1]
+  }
+
+  if (event.type === yaml.EVENT_MAPPING) {
+    const items = []
+    let nextIndex = eventIndex + 1
+
+    while (events[nextIndex].type !== yaml.EVENT_POP) {
+      const [key, valueIndex] = parseNode(events, nextIndex, source)
+      const [value, followingIndex] = parseNode(events, valueIndex, source)
+      items.push({ key, value })
+      nextIndex = followingIndex
+    }
+
+    return [{ items, kind: 'mapping' }, nextIndex + 1]
+  }
+
+  if (event.type === yaml.EVENT_SEQUENCE) {
+    const items = []
+    let nextIndex = eventIndex + 1
+
+    while (events[nextIndex].type !== yaml.EVENT_POP) {
+      const [item, followingIndex] = parseNode(events, nextIndex, source)
+      items.push(item)
+      nextIndex = followingIndex
+    }
+
+    return [{ items, kind: 'sequence' }, nextIndex + 1]
+  }
+
+  throw new Error(`unsupported YAML event type ${event.type}`)
+}
+
+function parseDocument(source) {
+  const events = yaml.parseEvents(source)
+  const documentIndex = events.findIndex(
+    (event) => event.type === yaml.EVENT_DOCUMENT
+  )
+
+  if (
+    documentIndex === -1 ||
+    events[documentIndex + 1].type === yaml.EVENT_POP
+  ) {
+    return null
+  }
+
+  return parseNode(events, documentIndex + 1, source)[0]
+}
+
+function mappingValue(node, key) {
+  if (node?.kind !== 'mapping') {
+    return null
+  }
+
+  return (
+    node.items.find(
+      (item) => item.key.kind === 'scalar' && item.key.value === key
+    )?.value ?? null
+  )
+}
+
+function workflowReferences(document) {
+  const jobs = mappingValue(document, 'jobs')
+
+  if (jobs?.kind !== 'mapping') {
+    return []
+  }
+
+  return jobs.items.flatMap(({ value: job }) => {
+    if (job.kind !== 'mapping') {
+      return []
+    }
+
+    const references = []
+    const reusableWorkflow = mappingValue(job, 'uses')
+    if (reusableWorkflow) {
+      references.push(reusableWorkflow)
+    }
+
+    const steps = mappingValue(job, 'steps')
+    if (steps?.kind === 'sequence') {
+      for (const step of steps.items) {
+        const action = mappingValue(step, 'uses')
+        if (action) {
+          references.push(action)
+        }
+      }
+    }
+
+    return references
+  })
+}
+
+function sourceComment(source, scalarEvent) {
+  const quoted =
+    scalarEvent.style === yaml.SCALAR_STYLE_SINGLE_QUOTED ||
+    scalarEvent.style === yaml.SCALAR_STYLE_DOUBLE_QUOTED
+  const valueEnd = scalarEvent.valueEnd + (quoted ? 1 : 0)
+  const newline = source.indexOf('\n', valueEnd)
+  const lineEnd = newline === -1 ? source.length : newline
+  const suffix = source.slice(valueEnd, lineEnd)
+
+  return /^\s+#\s*([A-Za-z0-9][A-Za-z0-9._/-]*)\s*$/.exec(suffix)?.[1]
+}
+
 const workflowDirectory = process.argv[2]
   ? new URL(process.argv[2], `file://${process.cwd()}/`)
   : new URL('../.github/workflows/', import.meta.url)
@@ -40,43 +160,27 @@ try {
 }
 
 for (const workflowPath of paths) {
-  let workflow
+  let document
   let workflowText
   try {
     workflowText = readFileSync(workflowPath, 'utf8')
-    workflow = yaml.load(workflowText, { schema: yaml.JSON_SCHEMA })
+    yaml.load(workflowText, { schema: yaml.JSON_SCHEMA })
+    document = parseDocument(workflowText)
   } catch (error) {
     fail(`could not parse ${workflowPath}: ${error}`)
   }
 
-  const references = []
-  function collectUses(value) {
-    if (Array.isArray(value)) {
-      value.forEach(collectUses)
-      return
+  for (const referenceNode of workflowReferences(document)) {
+    if (referenceNode.kind !== 'scalar') {
+      fail(
+        `${workflowPath} uses reference must be an explicit string so its immutable pin and source comment can be verified.`
+      )
     }
 
-    if (!value || typeof value !== 'object') {
-      return
+    const { event, value: reference } = referenceNode
+    if (reference.startsWith('./')) {
+      continue
     }
-
-    for (const [key, nestedValue] of Object.entries(value)) {
-      if (key === 'uses' && typeof nestedValue === 'string') {
-        references.push(nestedValue)
-      }
-      collectUses(nestedValue)
-    }
-  }
-  collectUses(workflow)
-
-  for (const reference of references.filter(
-    (value) => !value.startsWith('./')
-  )) {
-    const escapedReference = reference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const referenceLine = new RegExp(
-      `^\\s*(?:-\\s+)?uses:\\s*(?:"${escapedReference}"|'${escapedReference}'|${escapedReference})\\s+#\\s*([A-Za-z0-9][A-Za-z0-9._/-]*)\\s*$`,
-      'm'
-    )
 
     if (!/@[0-9a-f]{40}$/.test(reference)) {
       fail(
@@ -84,7 +188,7 @@ for (const workflowPath of paths) {
       )
     }
 
-    if (!referenceLine.test(workflowText)) {
+    if (!sourceComment(workflowText, event)) {
       fail(
         `${workflowPath} external uses reference must retain its source tag or branch in a same-line comment: ${reference}.`
       )

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
+
+function fail(message) {
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}
+
+function workflowPaths(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${directory}/${entry.name}`
+
+    if (entry.isDirectory()) {
+      return workflowPaths(path)
+    }
+
+    return /\.ya?ml$/i.test(entry.name) ? [path] : []
+  })
+}
+
+const workflowDirectory = process.argv[2]
+  ? new URL(process.argv[2], `file://${process.cwd()}/`)
+  : new URL('../.github/workflows/', import.meta.url)
+let workflowDirectoryDisplay = workflowDirectory.href
+
+let paths
+try {
+  workflowDirectoryDisplay = fileURLToPath(workflowDirectory)
+  if (!statSync(workflowDirectoryDisplay).isDirectory()) {
+    fail(`${workflowDirectoryDisplay} must be a workflow directory.`)
+  }
+  paths = workflowPaths(workflowDirectoryDisplay)
+} catch (error) {
+  fail(`could not read ${workflowDirectoryDisplay}: ${error}`)
+}
+
+for (const workflowPath of paths) {
+  let workflow
+  let workflowText
+  try {
+    workflowText = readFileSync(workflowPath, 'utf8')
+    workflow = yaml.load(workflowText, { schema: yaml.JSON_SCHEMA })
+  } catch (error) {
+    fail(`could not parse ${workflowPath}: ${error}`)
+  }
+
+  const references = []
+  function collectUses(value) {
+    if (Array.isArray(value)) {
+      value.forEach(collectUses)
+      return
+    }
+
+    if (!value || typeof value !== 'object') {
+      return
+    }
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (key === 'uses' && typeof nestedValue === 'string') {
+        references.push(nestedValue)
+      }
+      collectUses(nestedValue)
+    }
+  }
+  collectUses(workflow)
+
+  for (const reference of references.filter(
+    (value) => !value.startsWith('./')
+  )) {
+    const escapedReference = reference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const referenceLine = new RegExp(
+      `^\\s*(?:-\\s+)?uses:\\s*(?:"${escapedReference}"|'${escapedReference}'|${escapedReference})\\s+#\\s*([A-Za-z0-9][A-Za-z0-9._/-]*)\\s*$`,
+      'm'
+    )
+
+    if (!/@[0-9a-f]{40}$/.test(reference)) {
+      fail(
+        `${workflowPath} external uses reference must end with a lowercase full 40-character commit SHA: ${reference}.`
+      )
+    }
+
+    if (!referenceLine.test(workflowText)) {
+      fail(
+        `${workflowPath} external uses reference must retain its source tag or branch in a same-line comment: ${reference}.`
+      )
+    }
+  }
+}
+
+console.log('Workflow action pin guard OK.')

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -102,11 +102,19 @@ function mappingValue(node, key) {
 function workflowReferences(document) {
   const jobs = mappingValue(document, 'jobs')
 
+  if (jobs?.kind === 'alias') {
+    return [{ context: 'jobs', kind: 'alias-container' }]
+  }
+
   if (jobs?.kind !== 'mapping') {
     return []
   }
 
   return jobs.items.flatMap(({ value: job }) => {
+    if (job.kind === 'alias') {
+      return [{ context: 'job', kind: 'alias-container' }]
+    }
+
     if (job.kind !== 'mapping') {
       return []
     }
@@ -118,8 +126,17 @@ function workflowReferences(document) {
     }
 
     const steps = mappingValue(job, 'steps')
+    if (steps?.kind === 'alias') {
+      references.push({ context: 'steps', kind: 'alias-container' })
+    }
+
     if (steps?.kind === 'sequence') {
       for (const step of steps.items) {
+        if (step.kind === 'alias') {
+          references.push({ context: 'step', kind: 'alias-container' })
+          continue
+        }
+
         const action = mappingValue(step, 'uses')
         if (action) {
           references.push(action)
@@ -171,6 +188,12 @@ for (const workflowPath of paths) {
   }
 
   for (const referenceNode of workflowReferences(document)) {
+    if (referenceNode.kind === 'alias-container') {
+      fail(
+        `${workflowPath} ${referenceNode.context} must not use a YAML alias because external uses references cannot be verified.`
+      )
+    }
+
     if (referenceNode.kind !== 'scalar') {
       fail(
         `${workflowPath} uses reference must be an explicit string so its immutable pin and source comment can be verified.`

--- a/scripts/check-workflow-action-pins.mjs
+++ b/scripts/check-workflow-action-pins.mjs
@@ -2,11 +2,12 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: CC0-1.0
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs'
 import {
   basename,
   dirname,
   isAbsolute,
+  join,
   relative,
   resolve,
   sep,
@@ -20,8 +21,16 @@ function fail(message) {
 }
 
 function yamlPaths(directory) {
+  if (lstatSync(directory).isSymbolicLink()) {
+    fail(`${directory} must not be a symbolic link.`)
+  }
+
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = `${directory}/${entry.name}`
+
+    if (entry.isSymbolicLink()) {
+      fail(`${path} must not be a symbolic link.`)
+    }
 
     if (entry.isDirectory()) {
       return yamlPaths(path)
@@ -29,6 +38,20 @@ function yamlPaths(directory) {
 
     return /\.ya?ml$/i.test(entry.name) ? [path] : []
   })
+}
+
+function symbolicLinkInPath(root, target) {
+  const parts = relative(root, target).split(sep).filter(Boolean)
+  let path = root
+
+  for (const part of parts) {
+    path = join(path, part)
+    if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      return path
+    }
+  }
+
+  return null
 }
 
 function manifestPaths(githubDirectory) {
@@ -82,7 +105,19 @@ function localActionManifest(repositoryRoot, reference, sourcePath) {
 
   const candidates = ['action.yml', 'action.yaml']
     .map((name) => `${actionDirectory}/${name}`)
-    .filter((path) => existsSync(path) && statSync(path).isFile())
+    .filter((path) => {
+      if (!existsSync(path)) {
+        return false
+      }
+
+      if (symbolicLinkInPath(repositoryRoot, path)) {
+        fail(
+          `${sourcePath} local action reference must not traverse symbolic links: ${reference}.`
+        )
+      }
+
+      return lstatSync(path).isFile()
+    })
 
   if (candidates.length !== 1) {
     fail(
@@ -298,7 +333,10 @@ let paths
 let repositoryRoot
 try {
   githubDirectoryDisplay = fileURLToPath(githubDirectory)
-  if (!statSync(githubDirectoryDisplay).isDirectory()) {
+  if (
+    lstatSync(githubDirectoryDisplay).isSymbolicLink() ||
+    !lstatSync(githubDirectoryDisplay).isDirectory()
+  ) {
     fail(`${githubDirectoryDisplay} must be a GitHub configuration directory.`)
   }
   paths = manifestPaths(githubDirectoryDisplay)

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -9,6 +9,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -28,7 +29,7 @@ const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8')
 )
 
-function runGuard(manifests, { direct = false } = {}) {
+function runGuard(manifests, { direct = false, symlinks = {} } = {}) {
   const repositoryDirectory = mkdtempSync(
     join(tmpdir(), 'check-workflow-action-pins-')
   )
@@ -40,6 +41,12 @@ function runGuard(manifests, { direct = false } = {}) {
     const path = join(repositoryDirectory, relativePath)
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(path, content)
+  }
+
+  for (const [name, target] of Object.entries(symlinks)) {
+    const path = join(repositoryDirectory, name)
+    mkdirSync(dirname(path), { recursive: true })
+    symlinkSync(target, path)
   }
 
   try {
@@ -161,6 +168,44 @@ test('keeps scanning a directly supplied workflow directory', () => {
 
   assert.notEqual(result.status, 0, result.stderr || result.stdout)
   assert.match(result.stderr, /must end with a lowercase full 40-character/)
+})
+
+test('rejects symbolic links in the scanned workflow tree', () => {
+  const result = runGuard(
+    {
+      '.github/linked-workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${fullSha} # v7
+`,
+    },
+    {
+      symlinks: {
+        '.github/workflows/workflow.yml': '../linked-workflow.yml',
+      },
+    }
+  )
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must not be a symbolic link/)
+})
+
+test('rejects a symbolic workflow directory', () => {
+  const result = runGuard(
+    {
+      '.github/linked-workflows/workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${fullSha} # v7
+`,
+    },
+    { symlinks: { '.github/workflows': 'linked-workflows' } }
+  )
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must not be a symbolic link/)
 })
 
 test('rejects an uncommented duplicate of a documented reference', () => {
@@ -305,6 +350,54 @@ runs:
   })
 
   assert.equal(result.status, 0, result.stderr)
+})
+
+test('rejects a symbolic link in a referenced local action path', () => {
+  const result = runGuard(
+    {
+      'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/linked
+`,
+      'tools/target/action.yml': `name: CI action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@${fullSha} # v7
+`,
+    },
+    { symlinks: { 'tools/linked': 'target' } }
+  )
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must not traverse symbolic links/)
+})
+
+test('rejects a symbolic local action manifest', () => {
+  const result = runGuard(
+    {
+      'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/linked
+`,
+      'tools/target/action.yml': `name: CI action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@${fullSha} # v7
+`,
+    },
+    { symlinks: { 'tools/linked/action.yml': '../target/action.yml' } }
+  )
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must not traverse symbolic links/)
 })
 
 test('follows nested referenced local action manifests', () => {

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -24,29 +24,48 @@ const dependabotAutoMergeWorkflow = readFileSync(
   new URL('../.github/workflows/dependabot-auto-merge.yml', import.meta.url),
   'utf8'
 )
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+)
 
 function runGuard(manifests, { direct = false } = {}) {
-  const directory = mkdtempSync(join(tmpdir(), 'check-workflow-action-pins-'))
+  const repositoryDirectory = mkdtempSync(
+    join(tmpdir(), 'check-workflow-action-pins-')
+  )
+  const githubDirectory = join(repositoryDirectory, '.github')
 
   for (const [name, content] of Object.entries(manifests)) {
     const relativePath =
-      direct || name.includes('/') ? name : `workflows/${name}`
-    const path = join(directory, relativePath)
+      direct || name.includes('/') ? name : `.github/workflows/${name}`
+    const path = join(repositoryDirectory, relativePath)
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(path, content)
   }
 
   try {
-    return spawnSync(process.execPath, [guardPath, directory], {
-      encoding: 'utf8',
-    })
+    return spawnSync(
+      process.execPath,
+      [guardPath, direct ? repositoryDirectory : githubDirectory],
+      {
+        encoding: 'utf8',
+      }
+    )
   } finally {
-    rmSync(directory, { recursive: true, force: true })
+    rmSync(repositoryDirectory, { recursive: true, force: true })
   }
 }
 
+test('runs the pin guard from the lint script used by pull-request CI', () => {
+  assert.match(
+    packageJson.scripts.prelint,
+    /node scripts\/check-workflow-action-pins\.mjs/
+  )
+})
+
 test('accepts the repository workflows', () => {
-  const result = spawnSync(process.execPath, [guardPath], { encoding: 'utf8' })
+  const result = spawnSync(process.execPath, [guardPath], {
+    encoding: 'utf8',
+  })
 
   assert.equal(result.status, 0, result.stderr)
 })
@@ -209,7 +228,7 @@ test('rejects an alias used as the jobs mapping key', () => {
 
 test('rejects mutable external uses in a composite action manifest', () => {
   const result = runGuard({
-    'actions/example/action.yml': `name: Example action
+    '.github/actions/example/action.yml': `name: Example action
 description: Example composite action
 runs:
   using: composite
@@ -224,7 +243,7 @@ runs:
 
 test('accepts pinned external uses in a composite action manifest', () => {
   const result = runGuard({
-    'actions/example/action.yml': `name: Example action
+    '.github/actions/example/action.yml': `name: Example action
 description: Example composite action
 runs:
   using: composite
@@ -238,9 +257,105 @@ runs:
 
 test('ignores non-action YAML files beside composite action manifests', () => {
   const result = runGuard({
-    'actions/example/metadata.yml': `runs:
+    '.github/actions/example/metadata.yml': `runs:
   steps:
     - uses: actions/checkout@main
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('follows referenced local action manifests outside .github/actions', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/ci
+`,
+    'tools/ci/action.yml': `name: CI action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@main
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must end with a lowercase full 40-character/)
+})
+
+test('accepts pinned referenced local actions outside .github/actions', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/ci
+`,
+    'tools/ci/action.yml': `name: CI action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@${fullSha} # v7
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('follows nested referenced local action manifests', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/outer
+`,
+    'tools/outer/action.yml': `name: Outer action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: ./tools/inner
+`,
+    'tools/inner/action.yml': `name: Inner action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@main
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must end with a lowercase full 40-character/)
+})
+
+test('terminates local action reference cycles', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./tools/one
+`,
+    'tools/one/action.yml': `name: First action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: ./tools/two
+`,
+    'tools/two/action.yml': `name: Second action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: ./tools/one
 `,
   })
 

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const guardPath = fileURLToPath(
+  new URL('./check-workflow-action-pins.mjs', import.meta.url)
+)
+const fullSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+function runGuard(workflows) {
+  const directory = mkdtempSync(join(tmpdir(), 'check-workflow-action-pins-'))
+
+  for (const [name, content] of Object.entries(workflows)) {
+    writeFileSync(join(directory, name), content)
+  }
+
+  try {
+    return spawnSync(process.execPath, [guardPath, directory], {
+      encoding: 'utf8',
+    })
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+test('accepts the repository workflows', () => {
+  const result = spawnSync(process.execPath, [guardPath], { encoding: 'utf8' })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('accepts external actions and reusable workflows pinned to full SHAs', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${fullSha} # v7
+  reusable:
+    uses: octo-org/workflows/.github/workflows/check.yml@${fullSha} # main
+  local:
+    uses: ./.github/workflows/local.yml
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+for (const [name, reference] of [
+  ['a mutable major tag', 'actions/checkout@v7 # v7'],
+  [
+    'a mutable branch',
+    'octo-org/workflows/.github/workflows/check.yml@main # main',
+  ],
+  ['an abbreviated SHA', 'actions/checkout@abcdef0 # v7'],
+  ['a reference without a SHA', 'actions/checkout # v7'],
+  ['an uppercase SHA', `actions/checkout@${fullSha.toUpperCase()} # v7`],
+  ['a missing Dependabot source comment', `actions/checkout@${fullSha}`],
+]) {
+  test(`rejects ${name}`, () => {
+    const result = runGuard({
+      'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${reference}
+`,
+    })
+
+    assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  })
+}
+
+test('rejects malformed YAML', () => {
+  const result = runGuard({ 'workflow.yml': 'jobs: [\n' })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /^Error: could not parse /)
+})

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -4,9 +4,15 @@
 
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
@@ -19,11 +25,15 @@ const dependabotAutoMergeWorkflow = readFileSync(
   'utf8'
 )
 
-function runGuard(workflows) {
+function runGuard(manifests, { direct = false } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'check-workflow-action-pins-'))
 
-  for (const [name, content] of Object.entries(workflows)) {
-    writeFileSync(join(directory, name), content)
+  for (const [name, content] of Object.entries(manifests)) {
+    const relativePath =
+      direct || name.includes('/') ? name : `workflows/${name}`
+    const path = join(directory, relativePath)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, content)
   }
 
   try {
@@ -117,6 +127,23 @@ test('rejects malformed YAML', () => {
   assert.match(result.stderr, /^Error: could not parse /)
 })
 
+test('keeps scanning a directly supplied workflow directory', () => {
+  const result = runGuard(
+    {
+      'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+`,
+    },
+    { direct: true }
+  )
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must end with a lowercase full 40-character/)
+})
+
 test('rejects an uncommented duplicate of a documented reference', () => {
   const result = runGuard({
     'workflow.yml': `jobs:
@@ -162,6 +189,62 @@ jobs:
 
   assert.notEqual(result.status, 0, result.stderr || result.stdout)
   assert.match(result.stderr, /uses reference must be an explicit string/)
+})
+
+test('rejects an alias used as the jobs mapping key', () => {
+  const result = runGuard({
+    'workflow.yml': `env:
+  JOBS_KEY: &jobs-key jobs
+*jobs-key :
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /mapping key must not use a YAML alias/)
+})
+
+test('rejects mutable external uses in a composite action manifest', () => {
+  const result = runGuard({
+    'actions/example/action.yml': `name: Example action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@main
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must end with a lowercase full 40-character/)
+})
+
+test('accepts pinned external uses in a composite action manifest', () => {
+  const result = runGuard({
+    'actions/example/action.yml': `name: Example action
+description: Example composite action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@${fullSha} # v7
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('ignores non-action YAML files beside composite action manifests', () => {
+  const result = runGuard({
+    'actions/example/metadata.yml': `runs:
+  steps:
+    - uses: actions/checkout@main
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
 })
 
 test('rejects an aliased job that bypasses job traversal', () => {

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -14,6 +14,10 @@ const guardPath = fileURLToPath(
   new URL('./check-workflow-action-pins.mjs', import.meta.url)
 )
 const fullSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const dependabotAutoMergeWorkflow = readFileSync(
+  new URL('../.github/workflows/dependabot-auto-merge.yml', import.meta.url),
+  'utf8'
+)
 
 function runGuard(workflows) {
   const directory = mkdtempSync(join(tmpdir(), 'check-workflow-action-pins-'))
@@ -48,10 +52,37 @@ test('accepts external actions and reusable workflows pinned to full SHAs', () =
     uses: octo-org/workflows/.github/workflows/check.yml@${fullSha} # main
   local:
     uses: ./.github/workflows/local.yml
+  quoted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/checkout@${fullSha}' # v7
+      - uses: "actions/setup-node@${fullSha}" # v7
 `,
   })
 
   assert.equal(result.status, 0, result.stderr)
+})
+
+test('accepts unrelated uses keys outside jobs and steps', () => {
+  const result = runGuard({
+    'workflow.yml': `env:
+  uses: ordinary-environment-value
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`,
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('keeps the Dependabot auto-merge workflow on the v1 release channel', () => {
+  assert.match(
+    dependabotAutoMergeWorkflow,
+    /reusable-dependabot-auto-merge\.yml@[0-9a-f]{40} # v1$/m
+  )
 })
 
 for (const [name, reference] of [
@@ -84,4 +115,62 @@ test('rejects malformed YAML', () => {
 
   assert.notEqual(result.status, 0, result.stderr || result.stdout)
   assert.match(result.stderr, /^Error: could not parse /)
+})
+
+test('rejects an uncommented duplicate of a documented reference', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${fullSha} # v7
+      - uses: actions/checkout@${fullSha}
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must retain its source tag or branch/)
+})
+
+test('rejects a source comment spoofed inside a block scalar', () => {
+  const result = runGuard({
+    'workflow.yml': `jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${fullSha}
+      - run: |
+          uses: actions/checkout@${fullSha} # v7
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must retain its source tag or branch/)
+})
+
+test('rejects an aliased uses value that bypasses literal pin inspection', () => {
+  const result = runGuard({
+    'workflow.yml': `env:
+  ACTION: &checkout actions/checkout@v7
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: *checkout
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /uses reference must be an explicit string/)
+})
+
+test('rejects one trailing comment shared by flow-style references', () => {
+  const result = runGuard({
+    'workflow.yml': `on: push
+jobs: { one: { uses: octo-org/workflows/.github/workflows/check.yml@${fullSha} }, two: { uses: octo-org/workflows/.github/workflows/check.yml@${fullSha} } } # main
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /must retain its source tag or branch/)
 })

--- a/scripts/check-workflow-action-pins.test.mjs
+++ b/scripts/check-workflow-action-pins.test.mjs
@@ -164,6 +164,67 @@ jobs:
   assert.match(result.stderr, /uses reference must be an explicit string/)
 })
 
+test('rejects an aliased job that bypasses job traversal', () => {
+  const result = runGuard({
+    'workflow.yml': `job-template: &job
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v7
+jobs:
+  action: *job
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /job must not use a YAML alias/)
+})
+
+test('rejects an aliased jobs mapping that bypasses job traversal', () => {
+  const result = runGuard({
+    'workflow.yml': `job-templates: &jobs
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+jobs: *jobs
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /jobs must not use a YAML alias/)
+})
+
+test('rejects an aliased steps sequence that bypasses step traversal', () => {
+  const result = runGuard({
+    'workflow.yml': `step-template: &steps
+  - uses: actions/checkout@v7
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps: *steps
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /steps must not use a YAML alias/)
+})
+
+test('rejects an aliased step that bypasses uses traversal', () => {
+  const result = runGuard({
+    'workflow.yml': `step-template: &step
+  uses: actions/checkout@v7
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - *step
+`,
+  })
+
+  assert.notEqual(result.status, 0, result.stderr || result.stdout)
+  assert.match(result.stderr, /step must not use a YAML alias/)
+})
+
 test('rejects one trailing comment shared by flow-style references', () => {
   const result = runGuard({
     'workflow.yml': `on: push


### PR DESCRIPTION
## Summary

Closes #430.

External GitHub Actions and reusable workflows used mutable tags or branches, while existing SHA pins did not preserve the source version for Dependabot updates. A mutable reference can change after review.

## Changes

- Pinned every external reference under `.github/workflows` to a verified, full 40-character commit SHA.
- Retained the corresponding `main`, `v1`, or `v7` source reference in same-line comments for Dependabot.
- Added a syntax-aware repository-wide guard and regression tests for workflows and referenced local composite actions. The guard rejects mutable references, abbreviated or uppercase SHAs, missing source comments, structural YAML aliases, comment spoofing, path escapes, ambiguous manifests, and symbolic links without depending on production SHA values.
- Integrated the guard into `prelint`, which runs automatically before the pull-request lint path and therefore during `npm run validate`.
- Kept the grouped GitHub Actions Dependabot configuration and aligned workflow guidance with the enforced policy.
- Updated the changelog.

## Validation

- `npm run validate`
- `node --test scripts/check-workflow-action-pins.test.mjs` (33 tests)
- `yamllint .github/workflows .github/dependabot.yml`
- `actionlint .github/workflows/*.yml`
- `reuse lint`
- Signed commits and local pre-commit hooks

## Dependencies and follow-up

No in-scope dependency or unresolved local check prevents review. The Redocly CLI update notice observed during validation is tracked separately in #432.
