### PR TITLE
chore(deps): update Redocly CLI to 2.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `@redocly/cli` from `2.43.3` to `2.46.0` in the local contract
+  validation toolchain and reproducible lockfile (closes #432).
 - Updated `@redocly/cli` from `2.43.2` to `2.43.3` so local contract
   validation uses the current Redocly CLI release without its update notice
   (closes #422).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.43.3",
+        "@redocly/cli": "^2.46.0",
         "js-yaml": "^5.2.3",
         "markdownlint-cli": "0.49.1",
         "prettier": "^3.9.6"
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.43.3",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.43.3.tgz",
-      "integrity": "sha512-c6qQnH7N29FkpBAFDw+7cAsR+F5LXWWuS66BzHuC7zUsqqeZeUVxONRAAZHzwWG/N1zuqXMQZigVIh+ZC4OIFg==",
+      "version": "2.46.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.46.0.tgz",
+      "integrity": "sha512-Hx4dIYwFhMkE6fZXDl0TwuVsvE8INX7dzEOgAcEhl0mhTkHC95o/rhUTlVLbNRg4mWHQ27jbdgKXPZBJJANWYA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate": "npm run lint && npm run format:check"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.43.3",
+    "@redocly/cli": "^2.46.0",
     "js-yaml": "^5.2.3",
     "markdownlint-cli": "0.49.1",
     "prettier": "^3.9.6"


### PR DESCRIPTION
## Summary

Closes #432.

Local contract validation was using `@redocly/cli` 2.43.3 while the npm
registry published a newer stable release. The dependency is now updated to
2.46.0, including the reproducible lockfile resolution and the Unreleased
changelog entry.

## Validation

- `npm ci`
- `npm run validate` — 180 tests, Redocly lint, endpoint and domain guards,
  and formatting passed.
- `npm audit` — no vulnerabilities found.
- REUSE compliance passed in the commit hook.

## Readiness

There are no in-scope dependency or validation blockers. One transient
`js-yaml` resolution failure in negative test child processes was observed
immediately after a clean install; an unchanged rerun passed. It is tracked
separately in #436 and does not change this dependency update.
