### PR TITLE
Fix transient js-yaml resolution after npm ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a bounded 50/100/200 ms retry backoff for transient
+  `ERR_MODULE_NOT_FOUND` failures resolving `js-yaml` in the verified-endpoint
+  guard test harness, without masking other guard failures (closes #436).
 - Made the PR-size workflow guard accept routine Dependabot updates while still
   requiring the approved reusable workflow to use a full immutable commit SHA.
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -24,6 +24,8 @@ const contractPath = fileURLToPath(
   new URL('../docs/openapi.yaml', import.meta.url)
 )
 const contract = readFileSync(contractPath, 'utf8')
+const YAML_RESOLUTION_RETRY_DELAYS = [50, 100, 200]
+const retrySignal = new Int32Array(new SharedArrayBuffer(4))
 
 const parsedContract = yaml.load(contract)
 const organizationalUnitListParameters =
@@ -74,16 +76,47 @@ function organizationalUnitWireExamples(parameter, name) {
   return wireExamples
 }
 
-function runGuard(source, { writeCandidate = writeFileSync } = {}) {
+function isTransientYamlResolutionFailure(result) {
+  return (
+    result.status !== 0 &&
+    /ERR_MODULE_NOT_FOUND/.test(result.stderr) &&
+    /js-yaml/.test(result.stderr)
+  )
+}
+
+function waitForYamlResolutionRetry(delay) {
+  Atomics.wait(retrySignal, 0, 0, delay)
+}
+
+function runGuard(
+  source,
+  {
+    spawn = spawnSync,
+    waitForRetry = waitForYamlResolutionRetry,
+    writeCandidate = writeFileSync,
+  } = {}
+) {
   const directory = mkdtempSync(join(tmpdir(), 'verified-endpoints-'))
   const candidatePath = join(directory, 'openapi.yaml')
 
   try {
     writeCandidate(candidatePath, source)
 
-    return spawnSync(process.execPath, [guardPath, candidatePath], {
+    const options = {
       encoding: 'utf8',
-    })
+    }
+    let result = spawn(process.execPath, [guardPath, candidatePath], options)
+
+    for (const delay of YAML_RESOLUTION_RETRY_DELAYS) {
+      if (!isTransientYamlResolutionFailure(result)) {
+        break
+      }
+
+      waitForRetry(delay)
+      result = spawn(process.execPath, [guardPath, candidatePath], options)
+    }
+
+    return result
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }
@@ -105,6 +138,72 @@ test('removes the temporary directory when candidate creation fails', () => {
 
   assert.ok(candidatePath, 'expected runGuard to attempt candidate creation')
   assert.equal(existsSync(dirname(candidatePath)), false)
+})
+
+test('retries a transient js-yaml module resolution failure', () => {
+  let calls = 0
+  const retryDelays = []
+  const result = runGuard(contract, {
+    spawn() {
+      calls += 1
+
+      if (calls < 3) {
+        return {
+          status: 1,
+          stderr:
+            "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'js-yaml' imported from guard.mjs",
+        }
+      }
+
+      return { status: 0, stderr: '', stdout: '' }
+    },
+    waitForRetry(delay) {
+      retryDelays.push(delay)
+    },
+  })
+
+  assert.equal(result.status, 0)
+  assert.equal(calls, 3)
+  assert.deepEqual(retryDelays, [50, 100])
+})
+
+test('stops retrying after the bounded js-yaml backoff', () => {
+  let calls = 0
+  const retryDelays = []
+  const result = runGuard(contract, {
+    spawn() {
+      calls += 1
+      return {
+        status: 1,
+        stderr:
+          "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'js-yaml' imported from guard.mjs",
+      }
+    },
+    waitForRetry(delay) {
+      retryDelays.push(delay)
+    },
+  })
+
+  assert.equal(result.status, 1)
+  assert.equal(calls, 4)
+  assert.deepEqual(retryDelays, [50, 100, 200])
+})
+
+test('does not retry other guard failures', () => {
+  let calls = 0
+  const result = runGuard(contract, {
+    spawn() {
+      calls += 1
+      return {
+        status: 1,
+        stderr:
+          "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'unrelated-package' imported from guard.mjs",
+      }
+    },
+  })
+
+  assert.equal(result.status, 1)
+  assert.equal(calls, 1)
 })
 
 test('accepts the repository contract', () => {

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -91,6 +92,7 @@ function waitForYamlResolutionRetry(delay) {
 function runGuard(
   source,
   {
+    guard = guardPath,
     spawn = spawnSync,
     waitForRetry = waitForYamlResolutionRetry,
     writeCandidate = writeFileSync,
@@ -105,7 +107,7 @@ function runGuard(
     const options = {
       encoding: 'utf8',
     }
-    let result = spawn(process.execPath, [guardPath, candidatePath], options)
+    let result = spawn(process.execPath, [guard, candidatePath], options)
 
     for (const delay of YAML_RESOLUTION_RETRY_DELAYS) {
       if (!isTransientYamlResolutionFailure(result)) {
@@ -113,7 +115,7 @@ function runGuard(
       }
 
       waitForRetry(delay)
-      result = spawn(process.execPath, [guardPath, candidatePath], options)
+      result = spawn(process.execPath, [guard, candidatePath], options)
     }
 
     return result
@@ -204,6 +206,41 @@ test('does not retry other guard failures', () => {
 
   assert.equal(result.status, 1)
   assert.equal(calls, 1)
+})
+
+test('recovers from a real js-yaml ESM resolution failure', () => {
+  const fixtureDirectory = mkdtempSync(join(tmpdir(), 'yaml-resolution-'))
+  const fixtureGuardPath = join(fixtureDirectory, 'guard.mjs')
+  const fixturePackagePath = join(fixtureDirectory, 'node_modules', 'js-yaml')
+  const retryDelays = []
+
+  try {
+    writeFileSync(fixtureGuardPath, "import 'js-yaml'\n")
+
+    const result = runGuard(contract, {
+      guard: fixtureGuardPath,
+      waitForRetry(delay) {
+        retryDelays.push(delay)
+        mkdirSync(fixturePackagePath, { recursive: true })
+        writeFileSync(
+          join(fixturePackagePath, 'package.json'),
+          JSON.stringify({
+            name: 'js-yaml',
+            version: '0.0.0',
+            type: 'module',
+            exports: './index.mjs',
+          })
+        )
+        writeFileSync(join(fixturePackagePath, 'index.mjs'), '')
+        waitForYamlResolutionRetry(delay)
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.deepEqual(retryDelays, [50])
+  } finally {
+    rmSync(fixtureDirectory, { recursive: true, force: true })
+  }
 })
 
 test('accepts the repository contract', () => {


### PR DESCRIPTION
Closes #436.

## Problem and evidence

Immediately after a successful clean `npm ci`, some negative cases in
`scripts/check-openapi-verified-endpoints.test.mjs` intermittently failed when
their child process could not resolve the direct `js-yaml@5.2.3` dependency.
The failures reported `ERR_MODULE_NOT_FOUND` for `js-yaml` or its ESM entry
point, while an unchanged subsequent validation run passed.

## Change

- Retry only child-process failures that match both `ERR_MODULE_NOT_FOUND` and
  `js-yaml`.
- Use a bounded 50/100/200 ms backoff, for at most four total guard attempts.
- Preserve unrelated guard failures without retrying them.
- Cover successful recovery, retry bounds, and non-matching failure behavior.

## Validation

- `npm ci && npm run validate`
  - 183 Node tests passed.
  - Redocly OpenAPI lint, verified-endpoint and domain contract guards, and
    Prettier checks passed.
- Commit hooks passed: REUSE lint, Prettier, Markdownlint, and whitespace
  checks.

## Readiness

No in-scope dependency or unresolved local validation check blocks readiness.
The PR remains draft pending the required final review.
