### PR TITLE
Document passkey deletion password step-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enrollment challenge. Consumers regenerating clients from earlier contracts
   must provide the required JSON bodies and `current_password` property
   (closes #418).
+- **Breaking:** Corrected passkey deletion to require the runtime-enforced
+  current-password step-up JSON body and document its validation and throttling
+  responses. Consumers regenerating clients from earlier contracts must provide
+  `current_password` when calling `DELETE /me/passkeys/{credentialId}`.
 - Removed the retired standalone changelog host from contract-repository domain
   policy and guidance.
 - Changed local and hosted pull-request size reporting to treat 600 changed

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7871,7 +7871,7 @@ paths:
         '422':
           $ref: '#/components/responses/ValidationError'
         '429':
-          $ref: '#/components/responses/TooManyRequests'
+          $ref: '#/components/responses/SimpleTooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7829,6 +7829,8 @@ paths:
         Remove one enrolled passkey from the authenticated user's account.
 
         This endpoint affects only the selected passkey credential. It does not disable the existing phase-1 TOTP factor or invalidate recovery codes.
+
+        **Note on request body:** This `DELETE` operation requires a JSON body carrying the current-password step-up proof. Some HTTP clients and middleware drop bodies on `DELETE` requests. Integrators must ensure the `Content-Type: application/json` header is set and the body is transmitted; verify behaviour with your HTTP client before deploying.
       operationId: deleteMyPasskey
       tags:
         - Me

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1710,7 +1710,7 @@ components:
 
     PasskeyCurrentPasswordStepUpRequest:
       type: object
-      description: Fresh current-password proof required before a sensitive passkey enrollment action.
+      description: Fresh current-password proof required before a sensitive passkey enrollment or deletion action.
       required:
         - current_password
       properties:
@@ -1718,7 +1718,7 @@ components:
           type: string
           format: password
           writeOnly: true
-          description: Current account password used for the enrollment step-up check.
+          description: Current account password used for the passkey enrollment or deletion step-up check.
           example: CorrectHorseBatteryStaple!
 
     PasskeyRegistrationVerificationRequest:
@@ -7844,6 +7844,17 @@ paths:
           schema:
             type: string
             example: 'Ax9Yc0ZLQmN4V1V1S1cwVnI1Q0FyRkE'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+            examples:
+              current_password_step_up:
+                summary: Confirm the current password before deleting the passkey.
+                value:
+                  current_password: CorrectHorseBatteryStaple!
       responses:
         '200':
           description: Passkey deleted successfully
@@ -7857,6 +7868,10 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -199,10 +199,10 @@ if (
   passkeyDeletion.responses?.['422']?.$ref !==
     '#/components/responses/ValidationError' ||
   passkeyDeletion.responses?.['429']?.$ref !==
-    '#/components/responses/TooManyRequests'
+    '#/components/responses/SimpleTooManyRequests'
 ) {
   contractErrors.push(
-    'Passkey deletion must preserve its required current-password step-up body, example, validation response, and throttling response.'
+    'Passkey deletion must preserve its required current-password step-up body, example, validation response, and message-only throttling response.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -142,6 +142,9 @@ const passkeyRegistrationStartRequestBody =
 const passkeyRegistrationVerificationRequestBody =
   passkeyRegistrationVerification?.requestBody ?? {}
 const passkeyDeletionRequestBody = passkeyDeletion?.requestBody ?? {}
+const passkeyDeletionExample =
+  passkeyDeletionRequestBody.content?.['application/json']?.examples
+    ?.current_password_step_up?.value
 const passkeyRegistrationVerificationStepUp =
   passkeyRegistrationVerificationRequest.allOf?.find(
     (schema) =>
@@ -194,15 +197,21 @@ if (
   passkeyDeletionRequestBody.required !== true ||
   passkeyDeletionRequestBody.content?.['application/json']?.schema?.$ref !==
     '#/components/schemas/PasskeyCurrentPasswordStepUpRequest' ||
-  !passkeyDeletionRequestBody.content?.['application/json']?.examples
-    ?.current_password_step_up?.value?.current_password ||
+  !matchesSchema(
+    passkeyDeletionRequestBody.content?.['application/json']?.schema,
+    passkeyDeletionExample
+  ) ||
+  !/drop bodies on `DELETE` requests/i.test(
+    passkeyDeletion?.description ?? ''
+  ) ||
+  !/Content-Type: application\/json/.test(passkeyDeletion?.description ?? '') ||
   passkeyDeletion.responses?.['422']?.$ref !==
     '#/components/responses/ValidationError' ||
   passkeyDeletion.responses?.['429']?.$ref !==
     '#/components/responses/SimpleTooManyRequests'
 ) {
   contractErrors.push(
-    'Passkey deletion must preserve its required current-password step-up body, example, validation response, and message-only throttling response.'
+    'Passkey deletion must preserve its required current-password step-up body, schema-valid example, DELETE-body transport guidance, validation response, and message-only throttling response.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -7,8 +7,8 @@
  * or regresses their critical contract invariants (email verification resend +
  * German address reference data + employee documents + qualification catalog +
  * employee qualifications + organizational units + employee compliance alerts +
- * passkey enrollment password step-up + canonical schema-4 bootstrap and
- * notification runtime metadata).
+ * passkey enrollment and deletion password step-up + canonical schema-4
+ * bootstrap and notification runtime metadata).
  *
  * Usage: node scripts/check-openapi-verified-endpoints.mjs <path-to-openapi.yaml>
  */
@@ -52,6 +52,7 @@ const REQUIRED_OPERATIONS = [
   ['get', '/lookups/legal-entities'],
   ['post', '/me/passkeys/challenges/registration'],
   ['post', '/me/passkeys/challenges/registration/{challengeId}/verify'],
+  ['delete', '/me/passkeys/{credentialId}'],
 ]
 
 const target = process.argv[2]
@@ -129,6 +130,7 @@ const passkeyRegistrationStart =
   paths['/me/passkeys/challenges/registration']?.post
 const passkeyRegistrationVerification =
   paths['/me/passkeys/challenges/registration/{challengeId}/verify']?.post
+const passkeyDeletion = paths['/me/passkeys/{credentialId}']?.delete
 const passkeyCurrentPasswordStepUp =
   schemas.PasskeyCurrentPasswordStepUpRequest ?? {}
 const passkeyRegistrationVerificationRequest =
@@ -139,6 +141,7 @@ const passkeyRegistrationStartRequestBody =
   passkeyRegistrationStart?.requestBody ?? {}
 const passkeyRegistrationVerificationRequestBody =
   passkeyRegistrationVerification?.requestBody ?? {}
+const passkeyDeletionRequestBody = passkeyDeletion?.requestBody ?? {}
 const passkeyRegistrationVerificationStepUp =
   passkeyRegistrationVerificationRequest.allOf?.find(
     (schema) =>
@@ -184,6 +187,22 @@ if (
 ) {
   contractErrors.push(
     'Passkey enrollment must preserve the required bodies, validation response, password step-up, credential, and optional label contracts.'
+  )
+}
+
+if (
+  passkeyDeletionRequestBody.required !== true ||
+  passkeyDeletionRequestBody.content?.['application/json']?.schema?.$ref !==
+    '#/components/schemas/PasskeyCurrentPasswordStepUpRequest' ||
+  !passkeyDeletionRequestBody.content?.['application/json']?.examples
+    ?.current_password_step_up?.value?.current_password ||
+  passkeyDeletion.responses?.['422']?.$ref !==
+    '#/components/responses/ValidationError' ||
+  passkeyDeletion.responses?.['429']?.$ref !==
+    '#/components/responses/TooManyRequests'
+) {
+  contractErrors.push(
+    'Passkey deletion must preserve its required current-password step-up body, example, validation response, and throttling response.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -336,7 +336,7 @@ test('documents the current-password step-up for passkey deletion', () => {
   )
   assert.equal(
     passkeyDeletion.responses['429'].$ref,
-    '#/components/responses/TooManyRequests'
+    '#/components/responses/SimpleTooManyRequests'
   )
 })
 
@@ -557,11 +557,11 @@ test('rejects passkey deletion contract invariant regressions', () => {
       },
     },
     {
-      invariant: 'deletion documents throttling',
+      invariant: 'deletion documents message-only throttling',
       apply(candidate) {
         candidate.paths['/me/passkeys/{credentialId}'].delete.responses[
           '429'
-        ].$ref = '#/components/responses/Conflict'
+        ].$ref = '#/components/responses/TooManyRequests'
       },
     },
   ]

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -313,6 +313,33 @@ test('documents the current-password step-up for passkey enrollment', () => {
   )
 })
 
+test('documents the current-password step-up for passkey deletion', () => {
+  const passkeyStepUp =
+    parsedContract.components.schemas.PasskeyCurrentPasswordStepUpRequest
+  const passkeyDeletion =
+    parsedContract.paths['/me/passkeys/{credentialId}'].delete
+
+  assert.match(passkeyStepUp.description, /deletion/i)
+  assert.match(
+    passkeyStepUp.properties.current_password.description,
+    /deletion/i
+  )
+  assert.equal(passkeyDeletion.requestBody.required, true)
+  assert.equal(
+    passkeyDeletion.requestBody.content['application/json'].schema.$ref,
+    '#/components/schemas/PasskeyCurrentPasswordStepUpRequest'
+  )
+  assert.ok(passkeyDeletion.requestBody.content['application/json'].examples)
+  assert.equal(
+    passkeyDeletion.responses['422'].$ref,
+    '#/components/responses/ValidationError'
+  )
+  assert.equal(
+    passkeyDeletion.responses['429'].$ref,
+    '#/components/responses/TooManyRequests'
+  )
+})
+
 test('rejects passkey enrollment contract invariant regressions', () => {
   const mutations = [
     {
@@ -490,6 +517,63 @@ test('rejects passkey enrollment contract invariant regressions', () => {
 
     assert.notEqual(result.status, 0, `${mutation.invariant}: ${result.stdout}`)
     assert.match(result.stderr, /passkey enrollment/i)
+  }
+})
+
+test('rejects passkey deletion contract invariant regressions', () => {
+  const mutations = [
+    {
+      invariant: 'deletion request body remains required',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/{credentialId}'
+        ].delete.requestBody.required = false
+      },
+    },
+    {
+      invariant: 'deletion reuses the password step-up schema',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/{credentialId}'
+        ].delete.requestBody.content['application/json'].schema = {
+          type: 'object',
+        }
+      },
+    },
+    {
+      invariant: 'deletion example includes current_password',
+      apply(candidate) {
+        delete candidate.paths['/me/passkeys/{credentialId}'].delete.requestBody
+          .content['application/json'].examples.current_password_step_up.value
+          .current_password
+      },
+    },
+    {
+      invariant: 'deletion documents validation errors',
+      apply(candidate) {
+        candidate.paths['/me/passkeys/{credentialId}'].delete.responses[
+          '422'
+        ].$ref = '#/components/responses/Conflict'
+      },
+    },
+    {
+      invariant: 'deletion documents throttling',
+      apply(candidate) {
+        candidate.paths['/me/passkeys/{credentialId}'].delete.responses[
+          '429'
+        ].$ref = '#/components/responses/Conflict'
+      },
+    },
+  ]
+
+  for (const mutation of mutations) {
+    const candidate = structuredClone(parsedContract)
+    mutation.apply(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${mutation.invariant}: ${result.stdout}`)
+    assert.match(result.stderr, /passkey deletion/i)
   }
 })
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -338,6 +338,8 @@ test('documents the current-password step-up for passkey deletion', () => {
     passkeyDeletion.responses['429'].$ref,
     '#/components/responses/SimpleTooManyRequests'
   )
+  assert.match(passkeyDeletion.description, /drop bodies on `DELETE` requests/i)
+  assert.match(passkeyDeletion.description, /Content-Type: application\/json/)
 })
 
 test('rejects passkey enrollment contract invariant regressions', () => {
@@ -546,6 +548,23 @@ test('rejects passkey deletion contract invariant regressions', () => {
         delete candidate.paths['/me/passkeys/{credentialId}'].delete.requestBody
           .content['application/json'].examples.current_password_step_up.value
           .current_password
+      },
+    },
+    {
+      invariant: 'deletion example matches the required schema',
+      apply(candidate) {
+        candidate.paths[
+          '/me/passkeys/{credentialId}'
+        ].delete.requestBody.content[
+          'application/json'
+        ].examples.current_password_step_up.value.current_password = 123
+      },
+    },
+    {
+      invariant: 'deletion warns clients to transport the required JSON body',
+      apply(candidate) {
+        candidate.paths['/me/passkeys/{credentialId}'].delete.description =
+          'Remove one enrolled passkey from the authenticated user account.'
       },
     },
     {


### PR DESCRIPTION
## Problem and evidence

`DELETE /me/passkeys/{credentialId}` omitted the current-password step-up body and its validation and throttling responses from the OpenAPI contract, although passkey deletion requires that proof at runtime. Generated clients therefore had no contract-level requirement to send `current_password`.

## Change

- Document the required JSON request body with the shared `PasskeyCurrentPasswordStepUpRequest` schema and an example.
- Add the applicable `422` validation and `429` throttling responses.
- Extend the verified-endpoint guard and its positive and negative tests so this deletion contract cannot regress.
- Record the intentional under-1.x breaking client-contract change in `CHANGELOG.md`.

## Validation

- `npm run lint`
- `npm run format:check`
- `reuse lint`

## Dependency and draft status

The API already enforces this requirement. A companion frontend change supplies `current_password` when removing a passkey; this contract PR remains draft until that coordinated rollout receives final review. No unresolved local validation failures remain.
