### PR TITLE
Document onboarding upload idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented tenant-scoped onboarding attachment upload idempotency, including
   the optional bounded multipart retry key, exact-replay `200` response, new
-  upload `201` response, and message-only `409` conflict response
+  upload `201` response, deleted-key and different-upload `409` conflicts, and
+  the `422` invalid-key validation example
   (SecPal/api#1423).
 - Completed the `Employee` response contract with every field emitted by
   `EmployeeResource`, including identity-document and work-permit copy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented tenant-scoped onboarding attachment upload idempotency, including
+  the optional bounded multipart retry key, exact-replay `200` response, new
+  upload `201` response, and message-only `409` conflict response
+  (SecPal/api#1423).
 - Completed the `Employee` response contract with every field emitted by
   `EmployeeResource`, including identity-document and work-permit copy
   metadata, retention timestamps, certification and work-authorization summaries,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6535,7 +6535,7 @@ components:
             $ref: '#/components/schemas/ValidationProblem'
 
     OnboardingUploadMissingDocumentSubtype:
-      description: Validation Error - Missing onboarding upload document subtype
+      description: Validation Error - Invalid onboarding upload request
       content:
         application/json:
           schema:
@@ -6548,9 +6548,18 @@ components:
                 errors:
                   document_subtype:
                     - 'The document subtype field is required when document type is id_document.'
+            invalidIdempotencyKey:
+              summary: '`idempotency_key` does not meet the bounded key contract'
+              value:
+                message: 'The given data was invalid.'
+                errors:
+                  idempotency_key:
+                    - 'The idempotency key field format is invalid.'
 
     OnboardingUploadIdempotencyConflict:
-      description: Conflict - The tenant-scoped idempotency key already represents a different upload
+      description: >
+        Conflict - The tenant-scoped idempotency key represents a different upload or remains reserved
+        after its attachment was deleted
       content:
         application/json:
           schema:
@@ -12327,7 +12336,7 @@ paths:
         `idempotency_key` per logical upload and reuse it only for an exact retry. The key is tenant-scoped.
         An exact retry must match the original submission, file bytes, sanitized filename,
         `document_type`, and `document_subtype`; it returns the existing, non-deleted attachment with
-        `200 OK`, even if the submission is no longer editable. After a deleted attachment, the
+        `200 OK`, even if the submission is no longer editable. After an attachment is deleted, the
         idempotency key remains reserved and a retry returns `409 Conflict`. Reusing the key for any
         different upload also returns `409 Conflict`. A new upload with an unused key, or without a key,
         returns `201 Created`.
@@ -12337,8 +12346,9 @@ paths:
         - `file=passport-front.jpg`, `document_type=id_document`, `document_subtype=identity_document_front`
         - `file=residence-permit-front.jpg`, `document_type=id_document`, `document_subtype=residence_permit_front`
 
-        Invalid request example:
+        Invalid request examples:
         - `file=passport-front.jpg`, `document_type=id_document` without `document_subtype` returns a `422` validation response
+        - `idempotency_key=invalid-key-with-an-illegal-char!` returns a `422` validation response
       operationId: uploadOnboardingSubmissionFile
       tags:
         - Onboarding

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3709,6 +3709,18 @@ components:
           type: string
           format: binary
           description: Binary attachment payload for the onboarding dossier.
+        idempotency_key:
+          type: string
+          minLength: 32
+          maxLength: 64
+          pattern: '^[A-Za-z0-9_-]+$'
+          description: |
+            Optional opaque retry key generated once per logical upload. Reuse the same key only when
+            retrying the identical submission, file bytes, sanitized filename, `document_type`, and
+            `document_subtype`. Keys are scoped to the authenticated tenant. An exact retry returns the
+            existing, non-deleted attachment. After an attachment is deleted, its key remains reserved;
+            reusing a reserved key or using a key for any different upload returns `409 Conflict`.
+          example: 7G2zJ6mJdQn4xYK8fVk2wU9cR3pL5sTa
         document_type:
           $ref: '#/components/schemas/OnboardingSubmissionUploadDocumentType'
         document_subtype:
@@ -6536,6 +6548,15 @@ components:
                 errors:
                   document_subtype:
                     - 'The document subtype field is required when document type is id_document.'
+
+    OnboardingUploadIdempotencyConflict:
+      description: Conflict - The tenant-scoped idempotency key already represents a different upload
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SimpleMessageResponse'
+          example:
+            message: The upload idempotency key was already used for a different upload.
 
     UnprocessableEntity:
       description: Unprocessable Entity - Input validation or workflow preconditions failed
@@ -12302,8 +12323,17 @@ paths:
         identity split, proof-of-residence evidence, or a front/back residence permit upload. Accepted
         formats: PDF, JPG, PNG; max 10240 KiB (10 MiB).
 
+        Clients that may retry after an interrupted response should generate one opaque, unpredictable
+        `idempotency_key` per logical upload and reuse it only for an exact retry. The key is tenant-scoped.
+        An exact retry must match the original submission, file bytes, sanitized filename,
+        `document_type`, and `document_subtype`; it returns the existing, non-deleted attachment with
+        `200 OK`, even if the submission is no longer editable. After a deleted attachment, the
+        idempotency key remains reserved and a retry returns `409 Conflict`. Reusing the key for any
+        different upload also returns `409 Conflict`. A new upload with an unused key, or without a key,
+        returns `201 Created`.
+
         Valid request examples:
-        - `file=signed-contract.pdf`, `document_type=contract`
+        - `file=signed-contract.pdf`, `document_type=contract`, `idempotency_key=7G2zJ6mJdQn4xYK8fVk2wU9cR3pL5sTa`
         - `file=passport-front.jpg`, `document_type=id_document`, `document_subtype=identity_document_front`
         - `file=residence-permit-front.jpg`, `document_type=id_document`, `document_subtype=residence_permit_front`
 
@@ -12334,8 +12364,14 @@ paths:
               file:
                 contentType: application/pdf, image/jpeg, image/png
       responses:
+        '200':
+          description: Exact idempotent retry; the originally created onboarding attachment is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnboardingSubmissionFileUploadResponse'
         '201':
-          description: Onboarding submission attachment uploaded successfully.
+          description: A new onboarding submission attachment was uploaded successfully.
           content:
             application/json:
               schema:
@@ -12346,6 +12382,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/OnboardingUploadIdempotencyConflict'
         '422':
           $ref: '#/components/responses/OnboardingUploadMissingDocumentSubtype'
         '500':

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -7,6 +7,7 @@
  * or regresses their critical contract invariants (email verification resend +
  * German address reference data + employee documents + qualification catalog +
  * employee qualifications + organizational units + employee compliance alerts +
+ * onboarding upload idempotency +
  * passkey enrollment and deletion password step-up + canonical schema-4
  * bootstrap and notification runtime metadata).
  *
@@ -50,6 +51,7 @@ const REQUIRED_OPERATIONS = [
   ['post', '/organizational-units/{organizational_unit}/parent'],
   ['delete', '/organizational-units/{organizational_unit}/parent/{parent}'],
   ['get', '/lookups/legal-entities'],
+  ['post', '/onboarding/submissions/{submission}/files'],
   ['post', '/me/passkeys/challenges/registration'],
   ['post', '/me/passkeys/challenges/registration/{challengeId}/verify'],
   ['delete', '/me/passkeys/{credentialId}'],
@@ -126,6 +128,10 @@ const parentIdParameter = paths['/organizational-units']?.get?.parameters?.find(
 const organizationalUnitListParameters =
   paths['/organizational-units']?.get?.parameters ?? []
 const employeeComplianceAlerts = paths['/employees/compliance-alerts']?.get
+const onboardingSubmissionFileUpload =
+  paths['/onboarding/submissions/{submission}/files']?.post
+const onboardingSubmissionFileUploadRequest =
+  schemas.UploadOnboardingSubmissionFileRequest ?? {}
 const passkeyRegistrationStart =
   paths['/me/passkeys/challenges/registration']?.post
 const passkeyRegistrationVerification =
@@ -136,6 +142,40 @@ const passkeyCurrentPasswordStepUp =
 const passkeyRegistrationVerificationRequest =
   schemas.PasskeyRegistrationVerificationRequest ?? {}
 const contractErrors = []
+
+const onboardingUploadIdempotencyKey =
+  onboardingSubmissionFileUploadRequest.properties?.idempotency_key ?? {}
+const onboardingUploadConflict =
+  responses.OnboardingUploadIdempotencyConflict ?? {}
+
+if (
+  onboardingSubmissionFileUpload?.requestBody?.content?.['multipart/form-data']
+    ?.schema?.$ref !==
+    '#/components/schemas/UploadOnboardingSubmissionFileRequest' ||
+  onboardingSubmissionFileUploadRequest.required?.includes('idempotency_key') ||
+  onboardingUploadIdempotencyKey.type !== 'string' ||
+  onboardingUploadIdempotencyKey.minLength !== 32 ||
+  onboardingUploadIdempotencyKey.maxLength !== 64 ||
+  onboardingUploadIdempotencyKey.pattern !== '^[A-Za-z0-9_-]+$' ||
+  onboardingSubmissionFileUpload?.responses?.['200']?.content?.[
+    'application/json'
+  ]?.schema?.$ref !==
+    '#/components/schemas/OnboardingSubmissionFileUploadResponse' ||
+  onboardingSubmissionFileUpload?.responses?.['201']?.content?.[
+    'application/json'
+  ]?.schema?.$ref !==
+    '#/components/schemas/OnboardingSubmissionFileUploadResponse' ||
+  onboardingSubmissionFileUpload?.responses?.['409']?.$ref !==
+    '#/components/responses/OnboardingUploadIdempotencyConflict' ||
+  onboardingUploadConflict.content?.['application/json']?.schema?.$ref !==
+    '#/components/schemas/SimpleMessageResponse' ||
+  onboardingUploadConflict.content?.['application/json']?.example?.message !==
+    'The upload idempotency key was already used for a different upload.'
+) {
+  contractErrors.push(
+    'Onboarding file upload must preserve its optional bounded idempotency key, 200 exact-replay, 201 creation, and message-only 409 conflict contracts.'
+  )
+}
 
 const passkeyRegistrationStartRequestBody =
   passkeyRegistrationStart?.requestBody ?? {}

--- a/scripts/check-openapi-verified-endpoints.mjs
+++ b/scripts/check-openapi-verified-endpoints.mjs
@@ -147,6 +147,8 @@ const onboardingUploadIdempotencyKey =
   onboardingSubmissionFileUploadRequest.properties?.idempotency_key ?? {}
 const onboardingUploadConflict =
   responses.OnboardingUploadIdempotencyConflict ?? {}
+const onboardingUploadValidation =
+  responses.OnboardingUploadMissingDocumentSubtype ?? {}
 
 if (
   onboardingSubmissionFileUpload?.requestBody?.content?.['multipart/form-data']
@@ -167,13 +169,26 @@ if (
     '#/components/schemas/OnboardingSubmissionFileUploadResponse' ||
   onboardingSubmissionFileUpload?.responses?.['409']?.$ref !==
     '#/components/responses/OnboardingUploadIdempotencyConflict' ||
+  onboardingSubmissionFileUpload?.responses?.['422']?.$ref !==
+    '#/components/responses/OnboardingUploadMissingDocumentSubtype' ||
+  !onboardingUploadConflict.description?.includes('different upload') ||
+  !onboardingUploadConflict.description?.includes(
+    'remains reserved after its attachment was deleted'
+  ) ||
   onboardingUploadConflict.content?.['application/json']?.schema?.$ref !==
     '#/components/schemas/SimpleMessageResponse' ||
   onboardingUploadConflict.content?.['application/json']?.example?.message !==
-    'The upload idempotency key was already used for a different upload.'
+    'The upload idempotency key was already used for a different upload.' ||
+  onboardingUploadValidation.description !==
+    'Validation Error - Invalid onboarding upload request' ||
+  onboardingUploadValidation.content?.['application/json']?.schema?.$ref !==
+    '#/components/schemas/ValidationProblem' ||
+  onboardingUploadValidation.content?.['application/json']?.examples
+    ?.invalidIdempotencyKey?.value?.errors?.idempotency_key?.[0] !==
+    'The idempotency key field format is invalid.'
 ) {
   contractErrors.push(
-    'Onboarding file upload must preserve its optional bounded idempotency key, 200 exact-replay, 201 creation, and message-only 409 conflict contracts.'
+    'Onboarding file upload must preserve its optional bounded idempotency key, 200 exact-replay, 201 creation, message-only 409 conflict, and 422 validation contracts.'
   )
 }
 

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -249,6 +249,151 @@ test('accepts the repository contract', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('documents onboarding file upload idempotency', () => {
+  const upload =
+    parsedContract.paths['/onboarding/submissions/{submission}/files'].post
+  const request =
+    parsedContract.components.schemas.UploadOnboardingSubmissionFileRequest
+  const idempotencyKey = request.properties.idempotency_key
+  const conflict =
+    parsedContract.components.responses.OnboardingUploadIdempotencyConflict
+
+  assert.equal(
+    upload.requestBody.content['multipart/form-data'].schema.$ref,
+    '#/components/schemas/UploadOnboardingSubmissionFileRequest'
+  )
+  assert.equal(request.required.includes('idempotency_key'), false)
+  assert.deepEqual(
+    {
+      type: idempotencyKey.type,
+      minLength: idempotencyKey.minLength,
+      maxLength: idempotencyKey.maxLength,
+      pattern: idempotencyKey.pattern,
+    },
+    {
+      type: 'string',
+      minLength: 32,
+      maxLength: 64,
+      pattern: '^[A-Za-z0-9_-]+$',
+    }
+  )
+  assert.match(upload.description, /exact retry/i)
+  assert.match(upload.description, /tenant-scoped/i)
+  assert.match(upload.description, /deleted attachment/i)
+  assert.match(upload.description, /idempotency key remains reserved/i)
+  assert.equal(
+    upload.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/OnboardingSubmissionFileUploadResponse'
+  )
+  assert.equal(
+    upload.responses['201'].content['application/json'].schema.$ref,
+    '#/components/schemas/OnboardingSubmissionFileUploadResponse'
+  )
+  assert.equal(
+    upload.responses['409'].$ref,
+    '#/components/responses/OnboardingUploadIdempotencyConflict'
+  )
+  assert.equal(
+    conflict.content['application/json'].schema.$ref,
+    '#/components/schemas/SimpleMessageResponse'
+  )
+  assert.deepEqual(conflict.content['application/json'].example, {
+    message:
+      'The upload idempotency key was already used for a different upload.',
+  })
+})
+
+test('rejects onboarding file upload idempotency regressions', () => {
+  const mutations = [
+    {
+      invariant: 'idempotency key remains present',
+      apply(candidate) {
+        delete candidate.components.schemas
+          .UploadOnboardingSubmissionFileRequest.properties.idempotency_key
+      },
+    },
+    {
+      invariant: 'idempotency key remains optional',
+      apply(candidate) {
+        candidate.components.schemas.UploadOnboardingSubmissionFileRequest.required.push(
+          'idempotency_key'
+        )
+      },
+    },
+    {
+      invariant: 'idempotency key retains its lower bound',
+      apply(candidate) {
+        candidate.components.schemas.UploadOnboardingSubmissionFileRequest.properties.idempotency_key.minLength = 31
+      },
+    },
+    {
+      invariant: 'idempotency key retains its upper bound',
+      apply(candidate) {
+        candidate.components.schemas.UploadOnboardingSubmissionFileRequest.properties.idempotency_key.maxLength = 65
+      },
+    },
+    {
+      invariant: 'idempotency key retains its bounded alphabet',
+      apply(candidate) {
+        candidate.components.schemas.UploadOnboardingSubmissionFileRequest.properties.idempotency_key.pattern =
+          '^.*$'
+      },
+    },
+    {
+      invariant: 'exact retries retain the upload response shape',
+      apply(candidate) {
+        candidate.paths[
+          '/onboarding/submissions/{submission}/files'
+        ].post.responses['200'].content['application/json'].schema.$ref =
+          '#/components/schemas/SimpleMessageResponse'
+      },
+    },
+    {
+      invariant: 'new uploads retain the upload response shape',
+      apply(candidate) {
+        candidate.paths[
+          '/onboarding/submissions/{submission}/files'
+        ].post.responses['201'].content['application/json'].schema.$ref =
+          '#/components/schemas/SimpleMessageResponse'
+      },
+    },
+    {
+      invariant: 'key reuse retains its dedicated conflict response',
+      apply(candidate) {
+        candidate.paths[
+          '/onboarding/submissions/{submission}/files'
+        ].post.responses['409'].$ref = '#/components/responses/Conflict'
+      },
+    },
+    {
+      invariant: 'key reuse remains a message-only response',
+      apply(candidate) {
+        candidate.components.responses.OnboardingUploadIdempotencyConflict.content[
+          'application/json'
+        ].schema.$ref = '#/components/schemas/Error'
+      },
+    },
+    {
+      invariant: 'key reuse retains the runtime message',
+      apply(candidate) {
+        candidate.components.responses.OnboardingUploadIdempotencyConflict.content[
+          'application/json'
+        ].example.message = 'Conflict.'
+      },
+    },
+  ]
+
+  for (const { invariant, apply } of mutations) {
+    const candidate = structuredClone(parsedContract)
+    apply(candidate)
+
+    const result = runGuard(yaml.dump(candidate))
+
+    assert.notEqual(result.status, 0, `${invariant}: ${result.stdout}`)
+    assert.match(result.stderr, /onboarding file upload/i, invariant)
+  }
+})
+
 test('documents the current-password step-up for passkey enrollment', () => {
   const passkeyStepUp =
     parsedContract.components.schemas.PasskeyCurrentPasswordStepUpRequest

--- a/scripts/check-openapi-verified-endpoints.test.mjs
+++ b/scripts/check-openapi-verified-endpoints.test.mjs
@@ -257,6 +257,8 @@ test('documents onboarding file upload idempotency', () => {
   const idempotencyKey = request.properties.idempotency_key
   const conflict =
     parsedContract.components.responses.OnboardingUploadIdempotencyConflict
+  const validation =
+    parsedContract.components.responses.OnboardingUploadMissingDocumentSubtype
 
   assert.equal(
     upload.requestBody.content['multipart/form-data'].schema.$ref,
@@ -279,7 +281,7 @@ test('documents onboarding file upload idempotency', () => {
   )
   assert.match(upload.description, /exact retry/i)
   assert.match(upload.description, /tenant-scoped/i)
-  assert.match(upload.description, /deleted attachment/i)
+  assert.match(upload.description, /after an attachment is deleted/i)
   assert.match(upload.description, /idempotency key remains reserved/i)
   assert.equal(
     upload.responses['200'].content['application/json'].schema.$ref,
@@ -294,6 +296,15 @@ test('documents onboarding file upload idempotency', () => {
     '#/components/responses/OnboardingUploadIdempotencyConflict'
   )
   assert.equal(
+    upload.responses['422'].$ref,
+    '#/components/responses/OnboardingUploadMissingDocumentSubtype'
+  )
+  assert.match(conflict.description, /different upload/i)
+  assert.match(
+    conflict.description,
+    /reserved after its attachment was deleted/i
+  )
+  assert.equal(
     conflict.content['application/json'].schema.$ref,
     '#/components/schemas/SimpleMessageResponse'
   )
@@ -301,6 +312,22 @@ test('documents onboarding file upload idempotency', () => {
     message:
       'The upload idempotency key was already used for a different upload.',
   })
+  assert.equal(
+    validation.description,
+    'Validation Error - Invalid onboarding upload request'
+  )
+  assert.deepEqual(
+    validation.content['application/json'].examples.invalidIdempotencyKey,
+    {
+      summary: '`idempotency_key` does not meet the bounded key contract',
+      value: {
+        message: 'The given data was invalid.',
+        errors: {
+          idempotency_key: ['The idempotency key field format is invalid.'],
+        },
+      },
+    }
+  )
 })
 
 test('rejects onboarding file upload idempotency regressions', () => {
@@ -379,6 +406,37 @@ test('rejects onboarding file upload idempotency regressions', () => {
         candidate.components.responses.OnboardingUploadIdempotencyConflict.content[
           'application/json'
         ].example.message = 'Conflict.'
+      },
+    },
+    {
+      invariant: 'deleted-key reuse remains documented as a conflict',
+      apply(candidate) {
+        candidate.components.responses.OnboardingUploadIdempotencyConflict.description =
+          'Conflict - The tenant-scoped idempotency key already represents a different upload'
+      },
+    },
+    {
+      invariant:
+        'invalid idempotency keys retain the upload validation response',
+      apply(candidate) {
+        candidate.paths[
+          '/onboarding/submissions/{submission}/files'
+        ].post.responses['422'].$ref = '#/components/responses/ValidationError'
+      },
+    },
+    {
+      invariant: 'upload validation covers all invalid upload fields',
+      apply(candidate) {
+        candidate.components.responses.OnboardingUploadMissingDocumentSubtype.description =
+          'Validation Error - Missing onboarding upload document subtype'
+      },
+    },
+    {
+      invariant: 'invalid idempotency keys retain a validation example',
+      apply(candidate) {
+        delete candidate.components.responses
+          .OnboardingUploadMissingDocumentSubtype.content['application/json']
+          .examples.invalidIdempotencyKey
       },
     },
   ]


### PR DESCRIPTION
## Problem and evidence

SecPal/api#1422 and SecPal/api#1424 make onboarding attachment retries idempotent because Android can cancel authenticated transport after the API commits an upload but before the response reaches the client. Retrying without a stable identity could create another encrypted blob and database row.

The canonical OpenAPI source did not yet expose the multipart `idempotency_key`, the `200 OK` replay response, or the message-only `409 Conflict` response. SecPal/frontend#1678 and SecPal/frontend#1679 supply the corresponding stable client key.

## Change

- document the optional 32–64 character tenant-scoped multipart idempotency key and its accepted alphabet
- distinguish new `201 Created` uploads from exact, non-deleted `200 OK` replays
- document that deleted upload keys remain reserved and that mismatched reuse returns `409 Conflict`
- add a reusable message-only conflict response while preserving the existing upload validation response component
- extend the verified-endpoint guard and positive/negative regression coverage
- update `CHANGELOG.md`

## Validation

- contract-first guard failed before the OpenAPI update and passes with the completed contract
- `npm run validate` — 188 tests passed; Redocly, verified-endpoint, domain, and formatting checks passed
- `reuse lint` — 64/64 files compliant
- `npm audit` — 0 vulnerabilities
- `git diff --check`
- local four-pass review covering correctness, security/privacy, compatibility, scope, and issue management

## Dependencies and readiness

- depends on SecPal/api#1424 for the runtime behavior and SecPal/frontend#1679 for the stable client key
- the companion API and frontend pull requests are still open, so this pull request remains draft
- the Redocly CLI 2.46.1 update notice is tracked separately in #443 and is not part of this topic
- no hosted CI status was inspected

Closes SecPal/api#1423.
Related to SecPal/api#1422, SecPal/android#412, and SecPal/android#591.
