### PR TITLE
chore(deps): update Redocly CLI to 2.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `@redocly/cli` from `2.46.0` to `2.46.1` in the local contract
+  validation toolchain and reproducible lockfile; the upstream patch refreshes
+  its AJV, OpenAPI Core, Respect Core, and client-generator dependencies
+  (closes #443).
 - Updated `@redocly/cli` from `2.43.3` to `2.46.0` in the local contract
   validation toolchain and reproducible lockfile (closes #432).
 - Updated `@redocly/cli` from `2.43.2` to `2.43.3` so local contract

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "@redocly/cli": "^2.46.0",
+        "@redocly/cli": "^2.46.1",
         "js-yaml": "^5.2.3",
         "markdownlint-cli": "0.49.1",
         "prettier": "^3.9.6"
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.46.0.tgz",
-      "integrity": "sha512-Hx4dIYwFhMkE6fZXDl0TwuVsvE8INX7dzEOgAcEhl0mhTkHC95o/rhUTlVLbNRg4mWHQ27jbdgKXPZBJJANWYA==",
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.46.1.tgz",
+      "integrity": "sha512-FSUSq2FU8VN7DmTobTmq7zb3zPnDkRKSMd3n38D62JFJUUZKnLMQtn7BUhsD2dCFH2WgF05I3fbN7QHDQyCBeA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate": "npm run lint && npm run format:check"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.46.0",
+    "@redocly/cli": "^2.46.1",
     "js-yaml": "^5.2.3",
     "markdownlint-cli": "0.49.1",
     "prettier": "^3.9.6"


### PR DESCRIPTION
## Summary

Closes #443.

Local contract validation reported that Redocly CLI 2.46.1 was available while
the validation toolchain resolved 2.46.0. This updates the declared dependency
and reproducible lockfile to 2.46.1.

The upstream patch updates Redocly's internal AJV, OpenAPI Core, Respect Core,
and client-generator dependencies. It introduces no contract shape, error,
security-scheme, or API behavior changes.

## Change

- Updated `@redocly/cli` in `package.json` and `package-lock.json`.
- Recorded the dependency update in `CHANGELOG.md`.

## Validation

- `npm run validate` (188 tests, OpenAPI lint, repository guards, and formatting)
- `npm audit` (0 vulnerabilities)
- `reuse lint`
- `npm ci --dry-run`
- Commit hooks: REUSE, Prettier, Markdown lint, YAML checks, and conflict checks

## Readiness

No in-scope dependency or unresolved local validation prevents readiness. This
pull request is intentionally opened as a draft for review.
